### PR TITLE
Import new tokens - 2026-09-04-1240

### DIFF
--- a/duckduckgo.pot
+++ b/duckduckgo.pot
@@ -2842,6 +2842,18 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -6300,6 +6312,12 @@ msgid "Dislike source"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -6407,6 +6425,12 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "Djibouti"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -8150,6 +8174,12 @@ msgid "Fast"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8460,6 +8490,12 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9357,6 +9393,12 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -10467,6 +10509,12 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15241,6 +15289,12 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -21333,6 +21387,12 @@ msgid "Too slow"
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -21764,6 +21824,12 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 # smartling.placeholder_format=C

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -449,8 +448,7 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -520,8 +518,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -886,8 +883,7 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1394,8 +1390,7 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1681,8 +1676,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
+msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1902,8 +1896,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1981,8 +1974,7 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2324,8 +2316,7 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2543,8 +2534,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
-"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
+"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2660,8 +2651,7 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2709,8 +2699,7 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2915,8 +2904,7 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2980,6 +2968,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Voordat hierdie verslag gestoor word, sal DuckDuckGo opgelaaide lêers en "
+"gegenereerde beelde verwyder, en jou kletsgesprek anonimiseer deur PII, soos "
+"name, e-posadresse en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3873,8 +3864,7 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4026,10 +4016,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
-"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
-"ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
+"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur "
+"%1$shttps://duck.ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4084,16 +4074,14 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4174,8 +4162,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"Kletsgesprekke word veilig op DuckDuckGo se bediener gestoor met end-tot-"
-"einde-enkripsie. Niemand behalwe jy kan jou data sien nie, nie eens ons nie."
+"Kletsgesprekke word veilig op DuckDuckGo se bediener gestoor met "
+"end-tot-einde-enkripsie. Niemand behalwe jy kan jou data sien nie, nie eens "
+"ons nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4184,9 +4173,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
-"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op "
+"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4736,8 +4725,7 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5610,8 +5598,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6260,8 +6247,7 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6325,8 +6311,7 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6548,7 +6533,7 @@ msgstr "Hou nie van bron nie"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Hou nie van visuele styl nie"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6625,8 +6610,7 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6665,7 +6649,7 @@ msgstr "Djiboeti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Volg nie instruksies nie"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7153,8 +7137,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
-"ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
+"%1$sduck.ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7234,9 +7218,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
-"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
-"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
+"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
+"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7405,8 +7389,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7556,8 +7539,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
-"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
+"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7663,8 +7646,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7949,8 +7931,7 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8287,8 +8268,7 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8531,7 +8511,7 @@ msgstr "Vinnig"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Vinnige prentgenerering"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8578,8 +8558,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8588,8 +8568,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
-"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
+"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8737,8 +8717,7 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8775,8 +8754,7 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8864,7 +8842,7 @@ msgstr "Opvolgboodskappe bly privaat."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Instruksies gevolg"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8970,8 +8948,7 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9084,8 +9061,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
-"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
+"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -9498,8 +9475,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
-"intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
+"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9569,8 +9546,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9607,8 +9583,8 @@ msgstr "Kry die app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te blokkeer."
-"%2$s"
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
+"blokkeer.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9667,9 +9643,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9678,9 +9654,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9690,9 +9666,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9702,9 +9678,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
-"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
-"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
+"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
+"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9812,7 +9788,7 @@ msgstr "Goeie privaatheidsbeleid"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Goeie visuele styl"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10260,8 +10236,7 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10398,8 +10373,7 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10653,8 +10627,7 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10897,8 +10870,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10961,7 +10933,7 @@ msgstr "Beeldopdragte moet aan Duck.ai se %1$s voldoen."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Beeldgehalte"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11053,8 +11025,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
-"kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
+"-kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11484,8 +11456,7 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12009,8 +11980,7 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
+msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12122,8 +12092,7 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12785,8 +12754,7 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13574,11 +13542,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
-"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
-"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
-"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
-"aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
+"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
+"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
+"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
+"nuwe aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13900,8 +13868,7 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14748,8 +14715,7 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15394,8 +15360,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
-"instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
+"%1$sDuckAssist-instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15510,8 +15476,7 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
+msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15840,7 +15805,7 @@ msgstr "Swak formatering"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Swak beeldgehalte"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16357,8 +16322,7 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16637,15 +16601,13 @@ msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
+msgstr "Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
+msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17769,8 +17731,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
-"end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
+"end-tot-end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17959,8 +17921,7 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18204,8 +18165,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
-"versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
+"POST-versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18354,8 +18315,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
-"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van "
+"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18488,8 +18449,7 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18516,8 +18476,7 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18672,8 +18631,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18921,8 +18879,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19023,8 +18980,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
-"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
+"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19303,8 +19260,7 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19614,8 +19570,7 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19630,8 +19585,7 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19703,8 +19657,7 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19856,15 +19809,13 @@ msgstr "Iets het skeefgeloop"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
+msgstr "Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19902,8 +19853,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19960,8 +19910,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
-"ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
+"Duck.ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19977,8 +19927,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20847,8 +20796,7 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20907,8 +20855,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
-"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
+"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -21343,8 +21291,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Die Duck.ai-wisselaar laat jou vinnig wissel tussen privaat soek en KI-"
-"klets, geanonimiseer deur DuckDuckGo."
+"Die Duck.ai-wisselaar laat jou vinnig wissel tussen privaat soek en "
+"KI-klets, geanonimiseer deur DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21365,8 +21313,7 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21391,8 +21338,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21483,8 +21429,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21556,8 +21501,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21677,8 +21621,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21686,8 +21629,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21816,8 +21758,7 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21848,8 +21789,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21859,10 +21801,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
-"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
-"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
-"nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
+"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
+"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
+"antwoorde by %1$s wys nie."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21947,8 +21889,7 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22061,8 +22002,7 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22094,8 +22034,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
-"blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
+"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22200,7 +22140,7 @@ msgstr "Te stadig"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Te stadig om te genereer"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22636,8 +22576,7 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22649,7 +22588,7 @@ msgstr "Probeer minder sleutelwoorde."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Probeer gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23005,8 +22944,7 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23217,14 +23155,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
-"duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23251,8 +23188,7 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23358,8 +23294,7 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23428,8 +23363,7 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr ""
-"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -23774,8 +23708,7 @@ msgstr "Gebruik jy openbare Wi-Fi? Gebruik ons VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
+msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23946,8 +23879,7 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24007,8 +23939,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24059,9 +23990,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
-"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
-"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
+"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
+"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24203,8 +24134,7 @@ msgstr "Muurpapier"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Wil jy maklike toegang tot privaat KI-klets op die nuwe oortjie-bladsy hê?"
+msgstr "Wil jy maklike toegang tot privaat KI-klets op die nuwe oortjie-bladsy hê?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24367,8 +24297,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24617,8 +24546,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24874,8 +24802,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24919,10 +24846,11 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
-"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
-"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
-"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
+"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
+"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
+"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
+"tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25007,8 +24935,7 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25159,8 +25086,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
-"boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
+"parameter-boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25269,8 +25196,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25750,8 +25676,7 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25811,8 +25736,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25888,8 +25812,7 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25990,8 +25913,7 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26073,8 +25995,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26178,8 +26099,7 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26252,8 +26172,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
+msgstr "Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26375,8 +26294,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26384,8 +26302,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26393,8 +26311,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
-"modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
+"KI-modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26486,8 +26404,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26516,8 +26433,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
-"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
+"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -26762,8 +26679,7 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: af_ZA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Knal-soeksnelsleutels"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
+msgstr ""
+"\"%1$s\" sal nie meer toegang tot jou gesinkroniseerde data kan kry nie."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -448,7 +449,8 @@ msgstr "%1$s woorde"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
+msgstr ""
+"%1$sKlik op %2$sVoeg by%3$sMerk %4$sLaat toe%5$s en klik dan op %6$sGoed%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -518,7 +520,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
+msgstr ""
+"%1$sKom meer te wete%2$s oor hoe kletse privaat op jou toestel gestoor word."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -883,7 +886,8 @@ msgstr "6-uur-gebruikslimiet is bereik."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
+msgstr ""
+"6-uur-gebruikslimiet is bereik. Jy kan hierdie kletsgesprek voortsit ná %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1390,7 +1394,8 @@ msgstr "Voeg DuckDuckGo-uitbreiding by"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
+msgstr ""
+"Voeg DuckDuckGo Privacy Essentials gratis by jou blaaier met een aflaai:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1676,7 +1681,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
+msgstr ""
+"Gevorderde modelle kan limiete 2-5x vinniger as ander modelle opgebruik. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1896,7 +1902,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
+msgstr ""
+"Alle modelverskaffers word verhoed om hul KI met jou gesprekke op te lei."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1974,7 +1981,8 @@ msgstr "Laat anonieme lêerhersiening vir hierdie kletsgesprek toe?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
+msgstr ""
+"Laat advertensies toe wat privaatheid respekteer op DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2316,7 +2324,8 @@ msgstr "Is jy nog daar?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
+msgstr ""
+"Is jy seker jy wil al jou kletse skoonmaak? Dit kan nie ontdoen word nie."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2534,8 +2543,8 @@ msgstr ""
 "verskyn: Nooit (verwyder Assist UI heeltemal uit soekresultate), Op aanvraag "
 "(wys slegs KI-gesteunde antwoorde as jy op die Assist-knoppie klik), Soms "
 "(wys slegs KI-gesteunde antwoorde wanneer dit baie relevant is) of Dikwels "
-"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is "
-"KI-gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
+"(wys meer gereeld op 'n wyer verskeidenheid soektogte). Vir nou is KI-"
+"gesteunde antwoorde slegs beskikbaar in die Amerikaanse (Engels) streek."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2651,7 +2660,8 @@ msgstr ""
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
+msgstr ""
+"Klank word nie deur ons of deur OpenAI gestoor nadat die klets eindig nie."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2699,7 +2709,8 @@ msgstr "Outo-antwoord"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
+msgstr ""
+"Outomaties gegenereer gebaseer op gelyste bronne. Mag onakkuraathede bevat."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2904,7 +2915,8 @@ msgstr "Strepieskode"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
+msgstr ""
+"Gebaseer op hierdie bladsy, is hierdie kursus die moeite werd om te volg?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2956,6 +2968,18 @@ msgstr ""
 "Voordat hierdie verslag gestoor word, sal DuckDuckGo jou kletsgesprek "
 "anonimiseer deur PII, soos name, e-posadresse en identifiserende metadata, "
 "te verwyder."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3849,7 +3873,8 @@ msgstr "Verander hoe resultaat-URL'e vertoon word"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
+msgstr ""
+"Verander hoe die opskrif vertoon word en die gedrag daarvan terwyl jy rollees"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4001,10 +4026,10 @@ msgid ""
 msgstr ""
 "Met Chat (via ons Duck.ai-diens) kan jy anonieme gesprekke voer met "
 "derdeparty-KI-kletsmodelle, wat modelle van OpenAI, Anthropic en meer "
-"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en "
-"-skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
-"Chat kry wanneer hierdie instelling afgeskakel is, deur "
-"%1$shttps://duck.ai%2$s direk te besoek."
+"ondersteun. As jy hierdie instelling afskakel, sal die Chat-knoppies en -"
+"skakels op DuckDuckGo Search verberg word. Jy kan egter steeds toegang tot "
+"Chat kry wanneer hierdie instelling afgeskakel is, deur %1$shttps://duck."
+"ai%2$s direk te besoek."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4059,14 +4084,16 @@ msgstr "Gesels privaat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met Duck.ai ingebou in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
+msgstr ""
+"Gesels privaat op enige webwerf met die Duck.ai-sybalk in ons gratis blaaier."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4147,9 +4174,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"Kletsgesprekke word veilig op DuckDuckGo se bediener gestoor met "
-"end-tot-einde-enkripsie. Niemand behalwe jy kan jou data sien nie, nie eens "
-"ons nie."
+"Kletsgesprekke word veilig op DuckDuckGo se bediener gestoor met end-tot-"
+"einde-enkripsie. Niemand behalwe jy kan jou data sien nie, nie eens ons nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4158,9 +4184,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Kletse word plaaslik op jou toestel gestoor in plaas van op "
-"DuckDuckGo-bedieners of afgeleë bedieners. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word."
+"Kletse word plaaslik op jou toestel gestoor in plaas van op DuckDuckGo-"
+"bedieners of afgeleë bedieners. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4710,7 +4736,8 @@ msgstr "Klik %1$sJa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
+msgstr ""
+"Klik %1$sinstellings/hamburgerikoon %2$s in die Chrome-taakbalk (regs bo)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -5583,7 +5610,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
+msgstr ""
+"Kon nie jou herstelkode laai nie. Maak dit asseblief toe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6232,7 +6260,8 @@ msgstr "Wil jy oudste kletsgesprekke skrap om stoorplek te maak?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
+msgstr ""
+"Wil jy oudste kletsgesprekke met aanhangsels skrap om stoorplek te maak?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6296,7 +6325,8 @@ msgstr "Beskryf veranderinge gebaseer op die beeld"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
+msgstr ""
+"Beskryf veranderinge om voort te gaan met die redigering van hierdie beeld"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6515,6 +6545,12 @@ msgid "Dislike source"
 msgstr "Hou nie van bron nie"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Wys af"
@@ -6589,7 +6625,8 @@ msgstr "Vertoon taal"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
+msgstr ""
+"Vertoon 'n regmerkie aan die linkerkant van resultate wat jy besoek het"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6623,6 +6660,12 @@ msgstr "Afdelingsrekord"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djiboeti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7110,8 +7153,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai laat jou privaat met gewilde KI-modelle gesels. As jy dit afskakel, "
-"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds "
-"%1$sduck.ai%2$s direk besoek."
+"word Duck.ai-knoppies en -skakels verberg, maar jy kan steeds %1$sduck."
+"ai%2$s direk besoek."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7191,9 +7234,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme "
-"KI-klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, "
-"oopbron KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
+"Duck.ai, DuckDuckGo KI, private KI-kletsbot, gratis KI-klets, anonieme KI-"
+"klets, KI-klets geen aanmelding, OpenAI, Anthropic, Llama, Mistral, oopbron "
+"KI-modelle, privaatheidsgefokusde KI, KI-klets geen rekening"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7362,7 +7405,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
+msgstr ""
+"DuckDuckGo AI Chat is tydelik onbeskikbaar. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7512,8 +7556,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, "
-"e-posadresse, telefoonnommers en identifiserende metadata, te verwyder."
+"DuckDuckGo anonimiseer hierdie aanmeldings deur outomaties PII, soos name, e-"
+"posadresse, telefoonnommers en identifiserende metadata, te verwyder."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7619,7 +7663,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
+msgstr ""
+"DuckDuckGo-intekeninge is nie in hierdie streek beskikbaar om te koop nie."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7904,7 +7949,8 @@ msgstr "Aktiveer diktasie in Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
+msgstr ""
+"Aktiveer liggingsinstellings op jou toestel om anonieme ligging te gebruik"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8241,7 +8287,8 @@ msgstr "Vou kaart uit"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
+msgstr ""
+"Kundig vervaardigde produkte vir mense wat 'n \"duck\" omgee vir privaatheid."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8481,6 +8528,12 @@ msgid "Fast"
 msgstr "Vinnig"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8525,8 +8578,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8535,8 +8588,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en "
-"-verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
+"Terugvoer soos joune het 'n direkte invloed op ons produkbywerkings en -"
+"verbeterings. Hopelik kan ons ook die probleem aanspreek wat jy gedeel het."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8684,7 +8737,8 @@ msgstr "Vind <b>%1$s</b> in jou aflaaivouer"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
+msgstr ""
+"Spoor DuckDuckGo op in die lys wat vertoon word en klik%1$sMaak verstek%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8721,7 +8775,8 @@ msgstr "Vind resultate nader aan jou."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
+msgstr ""
+"Vind resultate naby jou. %1$sJou ligging bly privaat, veilig en anoniem."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8804,6 +8859,12 @@ msgstr "Opvolgvraag"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Opvolgboodskappe bly privaat."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8909,7 +8970,8 @@ msgstr "Gratis en privaat geselsies, geanonimiseer deur ons"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
+msgstr ""
+"Gratis en privaat geselsies, geanonimiseer deur ons. Geen rekening nodig nie."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9022,8 +9084,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is "
-"...</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
+"Kies <strong>DuckDuckGo</strong> &gt; <strong>Kyk of daar opdaterings is ..."
+"</strong> op die app se kieslysbalk op Mac. Kies dan <strong>Installeer "
 "opdatering</strong>."
 
 # smartling.placeholder_format=C
@@ -9436,8 +9498,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n "
-"DuckDuckGo-intekening, wat ook ons VPN en ander premium "
+"Kry toegang tot gevorderde KI-modelle in Duck.ai met 'n DuckDuckGo-"
+"intekening, wat ook ons VPN en ander premium "
 "privaatheidsbeskermingsmaatreëls insluit."
 
 # smartling.placeholder_format=C
@@ -9507,7 +9569,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
+msgstr ""
+"Kry gratis probleemvrye privaatheidsbeskerming op jou blaaier met een aflaai:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9544,8 +9607,8 @@ msgstr "Kry die app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te "
-"blokkeer.%2$s"
+"Kry die gratis DuckDuckGo-blaaier %1$som advertensies op YouTube te blokkeer."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9604,9 +9667,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel › Kopieer tekskode%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel › Kopieer tekskode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9615,9 +9678,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9627,9 +9690,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s en skandeer hierdie kode:"
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s en skandeer hierdie kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9639,9 +9702,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die "
-"DuckDuckGo-app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n "
-"ander toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
+"Gaan na %1$sDuck.ai-instellings%2$s in jou ander blaaier, of die DuckDuckGo-"
+"app en gaan na %3$sKletse › Sync & Backup › Sinkroniseer met ’n ander "
+"toestel%4$s. Of skandeer die QR-kode op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9744,6 +9807,12 @@ msgstr "Goeie ontwerp"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Goeie privaatheidsbeleid"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10191,7 +10260,8 @@ msgstr "Help jou vriende en familie om by die Duck-kant aan te sluit!"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
+msgstr ""
+"Help jou vriende en familie om weer beheer oor hul privaatheid terug te neem!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10328,7 +10398,8 @@ msgstr "Versteek jou e-posadres"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
+msgstr ""
+"Dit verhoed die soekterm om in jou blaaier se oortjie/geskiedenis te vertoon"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10582,7 +10653,8 @@ msgstr "Hoe dikwels wil jy KI-gesteunde antwoorde sien?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
+msgstr ""
+"Hoeveel van jou daaglikse en weeklikse limiete jy tot dusver gebruik het."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10825,7 +10897,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
+msgstr ""
+"Indien jy ons steeds wil ondersteun, %1$shelp om DuckDuckGo te versprei%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10883,6 +10956,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Beeldopdragte moet aan Duck.ai se %1$s voldoen."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10974,8 +11053,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en "
-"-kleur"
+"Verbeter leesbaarheid van resultaat met bygewerkte URL-formaat, -plasing en -"
+"kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11405,7 +11484,8 @@ msgstr "Dit is vinnig, gratis en gee jou selfs meer aanlyn beskerming."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
+msgstr ""
+"Jy mag my (baie ongereeld) vra oor my ervaring met die gebruik van DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11929,7 +12009,8 @@ msgstr "Laat jou anoniem soek met DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
+msgstr ""
+"Laat jou wissel tussen die indiening van soeknavrae en aanwysings aan Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12041,7 +12122,8 @@ msgstr "Skakels:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
+msgstr ""
+"Gee die gereedskap, materiale of voorvereistes wat ek hiervoor benodig."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12703,7 +12785,8 @@ msgstr "Mikronesië"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
+msgstr ""
+"Mikrofoontoegang is geweier. Gee asseblief mikrofoontoegang en probeer weer."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13491,11 +13574,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n "
-"DuckDuckGo-bediener gestoor nadat dit gestuur is om te help om ’n klets te "
-"herstel as jy jou internetverbinding verloor. As jy kletsgeskiedenis "
-"deaktiveer, sal vasgespelde kletse uitgevee word en die tydelike berging van "
-"nuwe aanporrings en antwoorde deaktiveer."
+"Nuwe aanporrings en antwoorde word geënkripteer en tydelik op ’n DuckDuckGo-"
+"bediener gestoor nadat dit gestuur is om te help om ’n klets te herstel as "
+"jy jou internetverbinding verloor. As jy kletsgeskiedenis deaktiveer, sal "
+"vasgespelde kletse uitgevee word en die tydelike berging van nuwe "
+"aanporrings en antwoorde deaktiveer."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13817,7 +13900,8 @@ msgstr "Geen resultate gevind nie."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
+msgstr ""
+"Geen spraak is bespeur nie. Probeer asseblief weer en praat in jou mikrofoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14664,7 +14748,8 @@ msgstr "Maak die paneel oop oor hoe Duck.ai werk."
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
+msgstr ""
+"Maak die Safari-kieslys oop en kies %1$sInstellings vir DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15309,8 +15394,8 @@ msgid ""
 msgstr ""
 "As jy jou soektog as 'n vraag en in 'n volsin fraseer, sal DuckAssist meer "
 "geneig wees om outomaties te verskyn en dikwels beter antwoorde lewer. Om "
-"dit af te skakel en die Assist-knoppie te verberg, kan jy na "
-"%1$sDuckAssist-instellings%2$s gaan."
+"dit af te skakel en die Assist-knoppie te verberg, kan jy na %1$sDuckAssist-"
+"instellings%2$s gaan."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15425,7 +15510,8 @@ msgstr "Vasgespeld"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
+msgstr ""
+"Vasgespelde kletsgesprekke sal boaan jou onlangse kletsgesprekke verskyn."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15749,6 +15835,12 @@ msgstr "Pools"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Swak formatering"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16265,7 +16357,8 @@ msgstr "Vra my"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
+msgstr ""
+"Vra my om my geskatte ligging te gebruik om resultate in die omgewing te kry."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16544,13 +16637,15 @@ msgstr "Redenasievermoë kan beter antwoorde op ingewikkelde vrae gee."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
+msgstr ""
+"Redenasievermoë is deegliker, maar bereik gebruikslimiete 2-5x gouer. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
+msgstr ""
+"Redenasievermoë is deegliker, maar gebruik limiete 2-5x vinniger op. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17674,8 +17769,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met "
-"end-tot-end-enkripsie."
+"Stoor jou Duck.ai-kletsgesprekke op jou verskillende toestelle met end-tot-"
+"end-enkripsie."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17864,7 +17959,8 @@ msgstr "Rol af en soek %1$sjou blaaier%2$s op die lys."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
+msgstr ""
+"Rol af na %1$sDuckDuckGo%2$s en laat dit toe om jou ligging te gebruik."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18108,8 +18204,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte "
-"POST-versoeke gebruik)"
+"Soeknavrae word by bronadres ingesluit (indien af, sal soektogte POST-"
+"versoeke gebruik)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18258,8 +18354,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Stoor jou gesprekke veilig op ons bediener met behulp van "
-"punt-tot-punt-enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
+"Stoor jou gesprekke veilig op ons bediener met behulp van punt-tot-punt-"
+"enkripsie, en verkry toegang daartoe vanaf al jou toestelle."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18392,7 +18488,8 @@ msgstr "Kyk na 'n paar van ons nuutste opdaterings"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
+msgstr ""
+"Raadpleeg die %1$sURL-parameterverwysingsblad%2$s vir meer besonderhede."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18419,7 +18516,8 @@ msgstr "Kies %1$s%2$s%3$s, dan %4$sSoekenjin%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
+msgstr ""
+"Kies %1$s'Instelling vir hierdie webwerf...'%2$s op die Safari-kieslys."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18574,7 +18672,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
+msgstr ""
+"Kies %1$sjou blaaier%2$s in die lys en %3$slaat%4$s liggingstoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18822,7 +18921,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
+msgstr ""
+"Stel jou ligging handmatig in, of sorg dat liggingsdienste geaktiveer is."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18923,8 +19023,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. "
-"Duck.ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
+"Deel 'n ligging op stadsvlak met KI-modelle om relevansie te verbeter. Duck."
+"ai verklap nooit jou presiese ligging aan ons of KI-modelle nie."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19203,7 +19303,8 @@ msgstr "Wys DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
+msgstr ""
+"Wys DuckAssist meer gereeld. (Jy kan dit ook heeltemal %1$safskakel%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19513,7 +19614,8 @@ msgstr "Wys voorstelle onder die soekkassie soos jy tik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
+msgstr ""
+"Wys die privaatheidsvoordele van die gebruik van DuckDuckGo op die tuisblad"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19528,7 +19630,8 @@ msgstr "Wys verwelkomingsboodskap bo-aan die bladsy met soekresultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
+msgstr ""
+"Wys verwelkomingsboodskap vir gebruikers wat die EU Android-kieslys verkies"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19600,7 +19703,8 @@ msgstr "Webwerfname"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
+msgstr ""
+"Webwerfsoektog is tydelik onbeskikbaar. Ons is besig om 'n oplossing te vind."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19752,13 +19856,15 @@ msgstr "Iets het skeefgeloop"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr "Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
+msgstr ""
+"Iets het verkeerd geloop met die laai van hierdie gedeelde kletsgesprek."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
+msgstr ""
+"Iets het skeefgeloop toe na die bediener gestoor is; probeer asseblief weer."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19796,7 +19902,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
+msgstr ""
+"Jammer, ek kan nie help nie. Beskryf asseblief jou beeld op ’n ander manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19853,8 +19960,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om "
-"Duck.ai te vra."
+"Jammer, ons kon nie 'n ryker antwoord genereer nie. Jy kan probeer om Duck."
+"ai te vra."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19870,7 +19977,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
+msgstr ""
+"Jammer, ons kon nie jou terugvoer indien nie. Probeer asseblief weer later."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20739,7 +20847,8 @@ msgstr "Sync & Backup is geaktiveer!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
+msgstr ""
+"Sync & Backup-data kan nie herwin word ná 18 maande van onaktiwiteit nie."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20798,8 +20907,8 @@ msgid ""
 msgstr ""
 "Sinkronisasieherstelkode\n"
 "\n"
-"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en "
-"Duck.ai-kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
+"Die herstelkode stel jou in staat om jou wagwoorde, outovuldata en Duck.ai-"
+"kletsgesprekke oor verskillende toestelle te sinkroniseer, en jou "
 "gesinkroniseerde data terug te kry as jy toegang tot ’n toestel verloor.\n"
 "\n"
 "Hou hierdie inligting veilig en seker.\n"
@@ -21234,8 +21343,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Die Duck.ai-wisselaar laat jou vinnig wissel tussen privaat soek en "
-"KI-klets, geanonimiseer deur DuckDuckGo."
+"Die Duck.ai-wisselaar laat jou vinnig wissel tussen privaat soek en KI-"
+"klets, geanonimiseer deur DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21256,7 +21365,8 @@ msgstr "Die aangehegte lêers oorskry die totale groottelimiet van %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
+msgstr ""
+"Die klank kon nie verwerk word nie. Probeer asseblief om weer op te neem."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21281,7 +21391,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
+msgstr ""
+"Die modelverskaffer stoor nie hierdie kletsgesprek op die bedieners nie."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21372,7 +21483,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
+msgstr ""
+"Daar was 'n probleem met die laai van hierdie antwoord. Probeer gerus weer."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21444,7 +21556,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
+msgstr ""
+"Hierdie kitsantwoord is deur die %1$sDuckDuckHack%2$s-gemeenskap geskep."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21564,7 +21677,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie, heg asseblief 'n %1$s of %2$s aan"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21572,7 +21686,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
+msgstr ""
+"Hierdie lêertipe word nie gesteun nie; heg asseblief 'n %1$s of %2$s aan."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21701,7 +21816,8 @@ msgstr "Hierdie bladsy vereis Javascript om te funksioneer."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
+msgstr ""
+"Hierdie bladsy se inhoud sal saam met jou boodskap na Duck.ai gestuur word."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21732,9 +21848,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21744,10 +21859,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy "
-"duckduckgo.com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde "
-"antwoorde sien. Ons het egter ook 'n beginbladsy wat nooit KI-gesteunde "
-"antwoorde by %1$s wys nie."
+"Hierdie instelling word in jou blaaier gestoor, wat beteken as jy duckduckgo."
+"com-blaaierdata skoonmaak, kan jy dalk weer KI-gesteunde antwoorde sien. Ons "
+"het egter ook 'n beginbladsy wat nooit KI-gesteunde antwoorde by %1$s wys "
+"nie."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21832,7 +21947,8 @@ msgstr "Dit sal alle instellings wis. Gaan voort?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
+msgstr ""
+"Dit sal jou bewaarde instellings na die verstekwaardes terugstel. Gaan voort?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21945,7 +22061,8 @@ msgstr "Om voort te gaan, moet jy instem tot Duck.ai se %1$s en %2$s"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
+msgstr ""
+"Om voort te gaan, moet jy instem tot DuckDuckGo AI Chat se %1$s en %2$s"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21977,8 +22094,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou "
-"DuckDuckGo-blaaier by tot die nuutste weergawe en probeer weer."
+"Om jou kletsgeskiedenis na Duck.ai oor te dra, werk asseblief jou DuckDuckGo-"
+"blaaier by tot die nuutste weergawe en probeer weer."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22078,6 +22195,12 @@ msgstr "Te veel resultate vanaf hierdie bron"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Te stadig"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22513,13 +22636,20 @@ msgstr "Probeer om anonieme ligging te aktiveer vir meer akkurate resultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
+msgstr ""
+"Probeer eksperimenteer met elke model – hulle sal verskillende antwoorde gee."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Probeer minder sleutelwoorde."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22875,7 +23005,8 @@ msgstr "Skakel %1$s\"Presiese Ligging\"%2$s aan vir meer akkurate resultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
+msgstr ""
+"Skakel Duck Player aan om YouTube te kyk sonder geteikende advertensies"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23086,13 +23217,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in "
-"https://duckduckgo.com"
+"Onder %1$sAan die begin%2$s, kies %3$sTuisblad%4$s en voer in https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
+msgstr ""
+"Onder %1$sMaak oop met%2$s, kies %3$s’n spesifieke bladsy of bladsye%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23119,7 +23251,8 @@ msgstr "Onder %1$sSoek%2$s-afdeling, klik %3$sBestuur soekenjins …%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
+msgstr ""
+"Onder Aan die begin, kies %1$sMaak ’n spesifieke blad of stel blaaie oop%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23225,7 +23358,8 @@ msgstr "Ontsluit met 'n DuckDuckGo-intekening"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
+msgstr ""
+"Ontsluit gevorderde KI-modelle en hoër limiete met 'n DuckDuckGo-intekening"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23294,7 +23428,8 @@ msgstr "Onbevestigde inligting"
 #. Text explaining the limit on the number of recent chats that can be stored. Example: 'Up to 30 of your most recent chats can be saved at a time.'
 msgctxt "Information about the limit of recent chats that can be saved"
 msgid "Up to %s of your most recent chats can be saved at a time."
-msgstr "Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
+msgstr ""
+"Tot en met %1$s van jou mees onlangse kletse kan op 'n slag gestoor word."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -23639,7 +23774,8 @@ msgstr "Gebruik jy openbare Wi-Fi? Gebruik ons VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
+msgstr ""
+"Gebruik die Fire Button om ’n kletsgesprek te skrap van die geskiedenislys."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -23810,7 +23946,8 @@ msgstr "Bekyk pryse vir jou verblyf"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
+msgstr ""
+"Jou privaatheid word deur DuckDuckGo beskerm as jy na advertensies kyk."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -23870,7 +24007,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
+msgstr ""
+"Besoek %1$sDuckDuckGo.com%2$s op jou tablet of foon en volg die aanwysings."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23921,9 +24059,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak "
-"Duck.ai-instellings oop. Kies “Skakel aan” onder Sync & Backup en kies "
-"“Sinkroniseer met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
+"Besoek Duck.ai in jou ander blaaier of die DuckDuckGo-app en maak Duck.ai-"
+"instellings oop. Kies “Skakel aan” onder Sync & Backup en kies “Sinkroniseer "
+"met ’n ander toestel”. Of skandeer die QR op jou Herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24065,7 +24203,8 @@ msgstr "Muurpapier"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Wil jy maklike toegang tot privaat KI-klets op die nuwe oortjie-bladsy hê?"
+msgstr ""
+"Wil jy maklike toegang tot privaat KI-klets op die nuwe oortjie-bladsy hê?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24228,7 +24367,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
+msgstr ""
+"Ons bewaar nie jou persoonlike inligting, of spoor jou na nie. Nooit nie."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24477,7 +24617,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
+msgstr ""
+"Ons is jammer vir die ongerief. Ons werk hard om jou ervaring te verbeter."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24733,7 +24874,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
+msgstr ""
+"Wat is 'n paar faktore om te oorweeg vir die aankoop van 'n rekenaarmonitor?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -24777,11 +24919,10 @@ msgid ""
 "experience."
 msgstr ""
 "Wat is die voordele daarvan om die DuckDuckGo-blaaier af te laai vir iemand "
-"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike "
-"DuckDuckGo-bronne. Verdeel die antwoord in duidelike afdelings met titels, "
-"met ’n fokus op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, "
-"eenvoudig en maklik om te verstaan vir mense met of sonder veel KI- of "
-"tegniese ervaring."
+"wat belangstel om Duck.ai te gebruik? Verwys slegs na amptelike DuckDuckGo-"
+"bronne. Verdeel die antwoord in duidelike afdelings met titels, met ’n fokus "
+"op Duck.ai-integrasies en privaatheidsbeskerming. Hou dit kort, eenvoudig en "
+"maklik om te verstaan vir mense met of sonder veel KI- of tegniese ervaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24866,7 +25007,8 @@ msgstr "Wat is die beste geregte wat jy hier kan probeer?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
+msgstr ""
+"Wat is die openingstye, ligging en kontakbesonderhede van hierdie plek?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25017,8 +25159,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL "
-"parameter-boekmerkie?"
+"Wat is die Cloud Save-boekmerkie en hoe verskil dit van die URL parameter-"
+"boekmerkie?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25127,7 +25269,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
+msgstr ""
+"Wanneer dit geaktiveer is, sal Duck.ai kitsantwoorde in die kletsgesprek wys."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25607,7 +25750,8 @@ msgstr "Ja, nuwe gebruiker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
+msgstr ""
+"Ja, ons gooi data weg as jy daarmee klaar is en dit kan nie herwin word nie."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25667,7 +25811,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
+msgstr ""
+"Jy kan ook %1$sDuck.ai%2$s gebruik om vrae te beantwoord of teks op te som."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25743,7 +25888,8 @@ msgstr "Jy kan aanhou gesels deur jou maandelikse limiet te gebruik."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
+msgstr ""
+"Jy kan nou tot 100 kletsgesprekke op hierdie toestel stoor. Gesels gerus!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25844,7 +25990,8 @@ msgstr "Jy kan oor begin op hierdie nuwe domein (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
+msgstr ""
+"Jy kan verskillende stelle instellings stoor vir verskillende doeleindes."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25926,7 +26073,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
+msgstr ""
+"Jy sal hierdie boodskap nie weer sien nie tensy jy jou blaaierdata skoonmaak."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26030,7 +26178,8 @@ msgstr "Jy het die maksimum stemkletsduur vir een sessie bereik."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
+msgstr ""
+"Jy het die stemkletslimiet vir vandag bereik. Probeer asseblief weer môre."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26103,7 +26252,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
+msgstr ""
+"Jou Duck.ai-kletsgesprekke word met end-tot-end-enkripsie gesinchroniseer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26225,7 +26375,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
+msgstr ""
+"Jou geselsies is privaat en word nooit gebruik om KI-modelle op te lei nie"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26233,8 +26384,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26242,8 +26393,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om "
-"KI-modelle op te lei nie."
+"Jou geselsies is privaat, word deur ons geanonimiseer en nie gebruik om KI-"
+"modelle op te lei nie."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26335,7 +26486,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
+msgstr ""
+"Jou terugvoer word geanonimiseer en word nie gebruik om KI op te lei nie."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26364,8 +26516,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure "
-"Hash-algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
+"Jou kenfrase skep 'n 512-bissleutel deur middel van die Secure Hash-"
+"algoritme, ook bekend as %1$sSHA-2%2$s. Slegs die sleutel en gekoppelde "
 "instellingslêer verlaat jou blaaier. Ons stoor die instellingslêer deur die "
 "sleutel as naam te gebruik. DuckDuckGo ken nooit jou kenfrase nie."
 
@@ -26610,7 +26762,8 @@ msgstr "deur %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
+msgstr ""
+"deur DuckDuckGo – aanlyn beskerming wat elke dag deur miljoene vertrou word."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/af_ZA/LC_MESSAGES/duckduckgo.po
+++ b/locales/af_ZA/LC_MESSAGES/duckduckgo.po
@@ -5201,7 +5201,7 @@ msgstr "Kompetisie"
 #. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was complete.
 msgctxt "feedback form"
 msgid "Complete"
-msgstr "Voltooi"
+msgstr "Volledig"
 
 # smartling.placeholder_format=C
 #. An option that completely disables the Assist feature.
@@ -19196,7 +19196,7 @@ msgstr "Kortste"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Shots"
-msgstr "Doelskoppe"
+msgstr "Doelskoppogings"
 
 # smartling.placeholder_format=C
 #. Soccer match stats

--- a/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_DZ/LC_MESSAGES/duckduckgo.po
@@ -2371,6 +2371,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5212,6 +5223,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5301,6 +5317,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6764,6 +6785,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7017,6 +7043,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7764,6 +7795,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8686,6 +8722,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12626,6 +12667,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17673,6 +17719,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18031,6 +18082,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ar_EG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_EG/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5219,6 +5230,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5308,6 +5324,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6783,6 +6804,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7038,6 +7064,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7785,6 +7816,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8710,6 +8746,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12646,6 +12687,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17693,6 +17739,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18051,6 +18102,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ar_JO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_JO/LC_MESSAGES/duckduckgo.po
@@ -2373,6 +2373,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5216,6 +5227,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5305,6 +5321,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6780,6 +6801,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7033,6 +7059,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7780,6 +7811,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8700,6 +8736,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12634,6 +12675,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17677,6 +17723,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18035,6 +18086,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ar_SA/LC_MESSAGES/duckduckgo.po
+++ b/locales/ar_SA/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5221,6 +5232,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "رفض"
@@ -5310,6 +5326,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6774,6 +6795,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7028,6 +7054,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7775,6 +7806,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8697,6 +8733,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12640,6 +12681,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17691,6 +17737,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18049,6 +18100,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ast_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ast_ES/LC_MESSAGES/duckduckgo.po
@@ -2367,6 +2367,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Escartar"
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8677,6 +8713,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12615,6 +12656,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17657,6 +17703,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18016,6 +18067,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prueba delles pallabres clave."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/az_AZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/az_AZ/LC_MESSAGES/duckduckgo.po
@@ -2373,6 +2373,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5219,6 +5230,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Çıxarın"
@@ -5308,6 +5324,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6765,6 +6786,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7020,6 +7046,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7767,6 +7798,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8691,6 +8727,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12631,6 +12672,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17675,6 +17721,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18033,6 +18084,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -313,7 +314,8 @@ msgstr "Рэйтынгі %1$s яшчэ недаступныя"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
+msgstr ""
+"%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -498,8 +500,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
-"месцазнаходжання.%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -529,7 +531,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr ""
+"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1077,10 +1080,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
-"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
-"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
-"OpenAI, Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
+"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
+"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
+"Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1903,7 +1906,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr ""
+"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2033,7 +2037,8 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2342,7 +2347,8 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr ""
+"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2965,6 +2971,18 @@ msgstr ""
 "метаданыя, якія дазваляюць ідэнтыфікаваць асобу."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3100,7 +3118,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr ""
+"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3876,7 +3895,8 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr ""
+"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4009,8 +4029,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
-"%1$shttps://duck.ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4075,8 +4095,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
-"Duck.ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
+"ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4280,7 +4300,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr ""
+"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4345,7 +4366,8 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr ""
+"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4765,7 +4787,8 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr ""
+"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -6529,6 +6552,12 @@ msgid "Dislike source"
 msgstr "Не падабаецца крыніца"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Адхіліць"
@@ -6637,6 +6666,12 @@ msgstr "Вынікі дывізіёна"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Джыбуці"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7194,7 +7229,8 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr ""
+"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7204,10 +7240,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
-"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
-"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
-"уліковага запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
+"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
+"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
+"запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7373,7 +7409,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr ""
+"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8049,7 +8086,8 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8061,19 +8099,22 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr ""
+"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8091,7 +8132,8 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr ""
+"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8205,7 +8247,8 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr ""
+"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8265,7 +8308,8 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr ""
+"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8505,6 +8549,12 @@ msgid "Fast"
 msgstr "Хутка"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8652,7 +8702,8 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr ""
+"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8835,6 +8886,12 @@ msgid "Follow-ups remain private."
 msgstr "Удакладняльныя пытанні застаюцца прыватнымі."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8970,7 +9027,8 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr ""
+"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9539,7 +9597,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr ""
+"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9599,7 +9658,8 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr ""
+"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9777,6 +9837,12 @@ msgstr "Добры дызайн"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Добрая палітыка прыватнасці"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10617,7 +10683,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr ""
+"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10921,6 +10988,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Запыты на вІдарысы павінны адпавядаць патрабаванням Duck.ai %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11973,7 +12046,8 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
+msgstr ""
+"Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12382,7 +12456,8 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr ""
+"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13860,7 +13935,8 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr ""
+"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14335,7 +14411,8 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr ""
+"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -15515,7 +15592,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15523,7 +15601,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr ""
+"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15551,7 +15630,8 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr ""
+"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -15792,6 +15872,12 @@ msgstr "Польская"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Дрэннае фарматаванне"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16956,8 +17042,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
-"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
+"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17509,7 +17595,8 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr ""
+"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -18090,7 +18177,8 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr ""
+"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18165,8 +18253,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
-"POST-запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
+"запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18454,7 +18542,8 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr ""
+"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18533,7 +18622,8 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr ""
+"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18714,7 +18804,8 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr ""
+"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19679,7 +19770,8 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr ""
+"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19832,7 +19924,8 @@ msgstr "Адбылася памылка пры загрузцы гэтага с�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr ""
+"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20211,13 +20304,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr ""
+"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20350,8 +20445,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
-"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
+"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20684,7 +20779,8 @@ msgstr "Пераключыць мадэль"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr ""
+"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20821,7 +20917,8 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup захоўвае больш вашых чатаў і сінхранізуе іх на ўсіх прыладах."
+msgstr ""
+"Sync & Backup захоўвае больш вашых чатаў і сінхранізуе іх на ўсіх прыладах."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21774,7 +21871,8 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr ""
+"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21856,13 +21954,15 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr ""
+"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr ""
+"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22001,7 +22101,8 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr ""
+"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22026,8 +22127,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
-"маршрут.%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
+"%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22156,6 +22257,12 @@ msgid "Too slow"
 msgstr "Занадта павольна"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22267,8 +22374,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
-"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
+"Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22582,20 +22689,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr ""
+"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr ""
+"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Паспрабуйце меней слоў."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22682,7 +22797,8 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr ""
+"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22763,13 +22879,15 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr ""
+"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -23196,8 +23314,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
-"сістэмамі...%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23321,13 +23439,15 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr ""
+"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr ""
+"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23345,7 +23465,8 @@ msgstr "Разблакіраваць перадавыя мадэлі"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr ""
+"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23586,7 +23707,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr ""
+"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23696,7 +23818,8 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr ""
+"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23755,7 +23878,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr ""
+"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23979,8 +24103,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
-"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
+"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -24302,7 +24426,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr ""
+"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24524,8 +24649,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
-"вэб-старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
+"старонак."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24570,7 +24695,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr ""
+"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24830,7 +24956,8 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr ""
+"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24838,7 +24965,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr ""
+"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -26116,14 +26244,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr ""
+"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr ""
+"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26382,8 +26512,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
-"Duck.ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/be_BY/LC_MESSAGES/duckduckgo.po
+++ b/locales/be_BY/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: be_BY\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -314,8 +313,7 @@ msgstr "Рэйтынгі %1$s яшчэ недаступныя"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
+msgstr "%1$s дасягае лімітаў выкарыстання ў 2-5 разоў хутчэй за базавыя мадэлі. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -500,8 +498,8 @@ msgstr "%1$sДаведацца больш%2$s."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага месцазнаходжання."
-"%2$s"
+"%1$sДаведайцеся, як мы захоўваем прыватнасць даных вашага "
+"месцазнаходжання.%2$s"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -531,8 +529,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
+msgstr "%1$sДоўгае націсканне%2$s значка праграмы DuckDuckGo на галоўным экране"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1080,10 +1077,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "У цяперашні час ў адказах з дапамогай штучнага інтэлекту не падтрымліваюцца "
-"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс %1$sDuck."
-"ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш прыватны "
-"чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад OpenAI, "
-"Anthropic і іншых."
+"непасрэдна дадатковыя пытанні. Аднак мы таксама прапануем сэрвіс "
+"%1$sDuck.ai%2$s для дадатковых пытанняў і часта спасылаемся на яго. Гэта наш "
+"прыватны чат на базе штучнага інтэлекту, які падтрымлівае мадэлі чата ад "
+"OpenAI, Anthropic і іншых."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1906,8 +1903,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
+msgstr "Усім пастаўшчыкам мадэляў забаронена навучаць свой AI на вашых размовах."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2037,8 +2033,7 @@ msgstr "Ужо сінхранізавана."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
+msgstr "Таксама захоўвайце сваю прыватнасць падчас пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2347,8 +2342,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
+msgstr "Сапраўды адключыць гісторыю? Гэта выдаліць усе чаты, у тым ліку замацаваныя."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2981,6 +2975,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Перад захаваннем гэтай справаздачы DuckDuckGo выдаліць запампаваныя файлы і "
+"згенераваныя выявы, а таксама ананімізуе вашу размову, выдаляючы асабістыя "
+"даныя, напрыклад імёны, адрасы электроннай пошты і метаданыя, якія "
+"дазваляюць ідэнтыфікаваць асобу."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3118,8 +3116,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
+msgstr "Спіс блакіроўкі не з'яўляецца вычарпальным і можа ўтрымліваць недакладнасці."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3895,8 +3892,7 @@ msgstr "Змяняе колер фону на ўсім сайце"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
+msgstr "Змяняе фонавы колер вынікаў пры навядзенні курсорам, модуляў і выпадных меню"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4029,8 +4025,8 @@ msgstr ""
 "мадэлямі чата на базе штучнага інтэлекту, якімі падтрымліваюцца мадэлі "
 "OpenAI, Anthropic і іншыя. Адключэнне гэтай налады схавае кнопкі і спасылкі "
 "чата ў DuckDuckGo Search. Тым не менш, можна атрымаць доступ да чата, калі "
-"гэты параметр выключаны. Для гэтага трэба перайсці на сайт %1$shttps://duck."
-"ai%2$s ."
+"гэты параметр выключаны. Для гэтага трэба перайсці на сайт "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4095,8 +4091,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі Duck."
-"ai ў нашым бясплатным браўзеры."
+"Размаўляйце ў чаце прыватна на любым сайце з дапамогай бакавой панэлі "
+"Duck.ai ў нашым бясплатным браўзеры."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4300,8 +4296,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
+msgstr "Праверце старонку стану, каб даведацца пра абнаўленні наконт гэтага збою."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4366,8 +4361,7 @@ msgstr "Выбар мадэляў штучнага інтэлекту, у тым
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
+msgstr "Націсніце %1$sЗахаваць%2$s, каб мы і надалей абаранялі вашу прыватнасць."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4787,8 +4781,7 @@ msgstr "Націсніце на %1$sПастаўшчыкі пошуку%2$s па
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
+msgstr "Націсніце на %1$sзначок інструментаў%2$s у правым верхнім куце браўзера"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -6555,7 +6548,7 @@ msgstr "Не падабаецца крыніца"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Не падабаецца візуальны стыль"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6671,7 +6664,7 @@ msgstr "Джыбуці"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Не выконвае інструкцый"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7229,8 +7222,7 @@ msgstr "Duck.ai абноўлены!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
+msgstr "Duck.ai найлепш працуе ў нашай прыватнай і бясплатнай праграме DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7240,10 +7232,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны AI-"
-"чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI з "
-"адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без уліковага "
-"запісу"
+"Duck.ai, DuckDuckGo AI, прыватны чат-бот AI, бясплатны AI-чат, ананімны "
+"AI-чат, AI-чат без рэгістрацыі, OpenAI, Anthropic, Llama, Mistral, мадэлі AI "
+"з адкрытым зыходным кодам, арыентаваны на прыватнасць AI, AI-чат без "
+"уліковага запісу"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7409,8 +7401,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
+msgstr "DuckDuckGo AI Chat часова недаступны. Абнавіце старонку і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8086,8 +8077,7 @@ msgstr "Падабаецца Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8099,22 +8089,19 @@ msgstr "Упэўніцеся, што %1$sўключана%2$s налада \"С�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sдазволіць%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
+msgstr "Упэўніцеся, што для налады \"Месцазнаходжанне\" выбрана %1$sДазволіць%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8132,8 +8119,7 @@ msgstr "Упэўніцеся, што %1$sдазволены%2$s доступ д�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
+msgstr "Упэўніцеся, што ў браўзеры дазволены %1$sдоступ да месцазнаходжання%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8247,8 +8233,7 @@ msgstr "Экватарыяльная Гвінея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
+msgstr "Імгненна выдаляйце даныя прагляду з дапамогай кнопкі %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8308,8 +8293,7 @@ msgstr "Разгарнуць карту"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
+msgstr "Прафесійна распрацаваныя вырабы для людзей, якім неабыякавая прыватнасць."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8552,7 +8536,7 @@ msgstr "Хутка"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Хуткае стварэнне відарысаў"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8702,8 +8686,7 @@ msgstr "Фільтры неэфектыўныя"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
+msgstr "Фільтруе відарысы, створаныя штучным інтэлектам, з вынікаў пошуку відарысаў"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8889,7 +8872,7 @@ msgstr "Удакладняльныя пытанні застаюцца прыв�
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Выканаў інструкцыі"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9027,8 +9010,7 @@ msgstr "Можна абагульваць і выкарыстоўваць у к�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
+msgstr "Вызваліце месца, выдаліўшы свае чаты. Замацаваныя чаты не будуць выдалены."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9597,8 +9579,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
+msgstr "У адной спампоўцы вы бясплатна атрымліваеце комплексную абарону прыватнасці:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9658,8 +9639,7 @@ msgstr "Атрымаць гэту песню на:"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
+msgstr "Запрасіце сваіх сяброў перайсці да нас і тым самым дапамагчы нам расці!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9842,7 +9822,7 @@ msgstr "Добрая палітыка прыватнасці"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Добры візуальны стыль"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10683,8 +10663,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
+msgstr "Колькі з вашых дзённых і тыднёвых лімітаў вы выкарысталі да гэтага часу."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10993,7 +10972,7 @@ msgstr "Запыты на вІдарысы павінны адпавядаць �
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Якасць відарыса"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12046,8 +12025,7 @@ msgstr "Дазваляе вам шукаць ананімна з дапамог�
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
+msgstr "Дазваляе пераключацца паміж адпраўкай пошукавых запытаў і падказак у Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12456,8 +12434,7 @@ msgstr "Пераканайцеся, што ўсе словы напісаны п
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
+msgstr "Не забудзьцеся пазначыць %1$s\"Зрабіць стандартнай пошукавай сістэмай\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13935,8 +13912,7 @@ msgstr "Вынікі не знойдзены."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
+msgstr "Маўленне не выяўлена. Калі ласка, паспрабуйце яшчэ раз і гаварыце ў мікрафон."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14411,8 +14387,7 @@ msgstr "Аман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
+msgstr "Апускае спрэчнае змесціва (галоўным чынам, прызначанае \"для дарослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -15592,8 +15567,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што запыт выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15601,8 +15575,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
+msgstr "Выканайце наступнае заданне, каб пацвердзіць, што пошук выкананы чалавекам."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15630,8 +15603,7 @@ msgstr "Калі ласка, увядзіце кодавую фразу"
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
 msgctxt "Description for the wrong code error screen"
 msgid "Please make sure the correct code was entered or scanned."
-msgstr ""
-"Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
+msgstr "Калі ласка, пераканайцеся, што быў уведзены або адсканаваны сапраўдны код."
 
 # smartling.placeholder_format=C
 #. Disclaimer text displayed in a modal that informs the user that starting a new chat with any AI model will delete their current chat session.
@@ -15877,7 +15849,7 @@ msgstr "Дрэннае фарматаванне"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Дрэнная якасць відарыса"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17042,8 +17014,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку &quot;"
-"Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
+"Перазагрузіце DuckDuckGo, выконваючы інструкцыі або націснуўшы кнопку "
+"&quot;Абнавіць&quot; ці &quot;Перазагрузіць&quot; у браўзеры."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17595,8 +17567,7 @@ msgstr "SE"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
+msgstr "Рэклама браўзераў для камп'ютара на старонцы з вынікамі пошуку была закрыта"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -18177,8 +18148,7 @@ msgstr "Бачнасць пошуку"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
+msgstr "Шукайце і праглядайце інфармацыю ў прыватным рэжыме ў праграме DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18253,8 +18223,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць POST-"
-"запыты)"
+"Пошукавыя запыты ўключаны ў URL (калі выкл., пошук будзе выкарыстоўваць "
+"POST-запыты)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18542,8 +18512,7 @@ msgstr "Паглядзіце апошнія абнаўленні"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
+msgstr "Дадатковую інфармацыю глядзіце на старонцы %1$sПараметры URL-адраса%2$s ."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18622,8 +18591,7 @@ msgstr "Выберыце %1$sDuckDuckGo%2$s у спісе сайтаў пошу�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
+msgstr "Выберыце %1$sDuckDuckGo%2$s у раздзеле %3$sСтандартная пошукавая сістэма%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18804,8 +18772,7 @@ msgstr "Выбраны тэкст з %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
+msgstr "Вылучаны тэкст занадта доўгі. Выберыце карацейшы ўрывак і паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19770,8 +19737,7 @@ msgstr "Пошук па сайце часова недаступны. Мы пр�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
+msgstr "Сайты, якія вы заблакіруеце, будуць схаваныя ва ўсіх вашых вынікаў пошуку"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19924,8 +19890,7 @@ msgstr "Адбылася памылка пры загрузцы гэтага с�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
+msgstr "Штосьці пайшло не так з запісам на сервер. Калі ласка, паўтарыце спробу."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20304,15 +20269,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
+msgstr "Заставайцеся абароненымі і інфармаванымі праз нашу рассылку пра прыватнасць."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20445,8 +20408,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў Duck."
-"ai, або вярніцеся пазней, каб стварыць больш відарысаў."
+"Падпішыцеся на DuckDuckGo, каб разблакіраваць больш высокія ліміты ў "
+"Duck.ai, або вярніцеся пазней, каб стварыць больш відарысаў."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20779,8 +20742,7 @@ msgstr "Пераключыць мадэль"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
+msgstr "Пачніце выкарыстоўваць бясплатную мадэль у гэтым чаце або пачакайце да %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -20917,8 +20879,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup захоўвае больш вашых чатаў і сінхранізуе іх на ўсіх прыладах."
+msgstr "Sync & Backup захоўвае больш вашых чатаў і сінхранізуе іх на ўсіх прыладах."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21871,8 +21832,7 @@ msgstr "Для работы гэтай старонкі патрабуецца J
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
+msgstr "Змесціва гэтай старонкі будзе адпраўлена разам з паведамленнем у Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21954,15 +21914,13 @@ msgstr "Гэты пераклад няправільны"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
+msgstr "Відэа пакуль што нельга паглядзець тут. Вы можаце яго паглядзець на %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
+msgstr "На гэтай старонцы не выкарыстоўваецца бяспечнае шыфраванае злучэнне (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22101,8 +22059,7 @@ msgstr "Падкрэсліванне загалоўка"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
+msgstr "Каб дадаць DuckDuckGo у белы спіс у іншых пашырэннях для блакіроўкі рэкламы:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22127,8 +22084,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны маршрут."
-"%3$sНацісніце на значок друку.%4$s"
+"Як раздрукаваць маршрут:%1$sВярніцеся на карту.%2$sВыберыце патрэбны "
+"маршрут.%3$sНацісніце на значок друку.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22260,7 +22217,7 @@ msgstr "Занадта павольна"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Занадта павольна генеруецца"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22374,8 +22331,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя DuckDuckGo."
-"Спіс будзе абнаўляцца па меры вашага выкарыстання."
+"Тут паказваюцца звесткі пра спробы адсочвання, заблакіраваныя "
+"DuckDuckGo.Спіс будзе абнаўляцца па меры вашага выкарыстання."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22689,16 +22646,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
+msgstr "Для больш дакладных вынікаў паспрабуйце ўключыць ананімнае месцазнаходжанне."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
+msgstr "Паспрабуйце паэксперыментаваць з кожнай мадэллю — яны дадуць розныя адказы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22710,7 +22665,7 @@ msgstr "Паспрабуйце меней слоў."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Паспрабуйце бясплатна"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22797,8 +22752,7 @@ msgstr "Паспрабуйце наш браўзер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
+msgstr "Паспрабуйце нашу хатнюю старонку, якая ніколі не паказвае гэтыя паведамленні:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22879,15 +22833,13 @@ msgstr "Паспрабуйце новы прыватны галасавы чат
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
+msgstr "Паспрабуйце нядаўна дададзеныя мадэлі з адкрытым зыходным кодам: %1$s і %2$s"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
+msgstr "Паспрабуйце нядаўна дададзеныя Llama 3.1 і Mixtral з адкрытым зыходным кодам"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -23314,8 +23266,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі сістэмамі..."
-"%4$s"
+"Пад раздзелам %1$sПошук%2$s націсніце %3$sКіраваць пошукавымі "
+"сістэмамі...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23439,15 +23391,13 @@ msgstr ""
 msgctxt ""
 "Text that shows users they can unlock advanced AI models with a subscription."
 msgid "Unlock advanced AI models with a %s"
-msgstr ""
-"Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
+msgstr "Адкрыйце доступ да перадавых мадэляў штучнага інтэлекту з падпіскай (%1$s)"
 
 # smartling.placeholder_format=C
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
+msgstr "Разблакіруйце перадавыя мадэлі штучнага інтэлекту з падпіскай DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23465,8 +23415,7 @@ msgstr "Разблакіраваць перадавыя мадэлі"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
+msgstr "Разблакіруйце больш працяглыя галасавыя чаты, аформіўшы падпіску DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23707,8 +23656,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
+msgstr "Абнавіцеся да Pro, каб адкрыць удвая большыя ліміты выкарыстання, чым у Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23818,8 +23766,7 @@ msgstr "Выкарыстаць прыватны пошук DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
+msgstr "Скарыстайце DuckDuckGo для асабістага пошуку на iPad, iPhone ці Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23878,8 +23825,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
+msgstr "Выкарыстоўваць ваша прыблізнае месцазнаходжанне для больш дакладных вынікаў?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24103,8 +24049,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады Duck."
-"ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
+"Наведайце Duck.ai ў іншым браўзеры і перайдзіце ў раздзел %1$sНалады "
+"Duck.ai%2$s > %3$sSync & Backup%4$s > %5$sКіраванне%6$s, а затым выберыце "
 "%7$sСінхранізаваць з іншай прыладай%8$s."
 
 # smartling.placeholder_format=C
@@ -24426,8 +24372,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
+msgstr "Мы не можам прачытаць далучаныя файлы, бо прынамсі адзін з іх зашыфраваны."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24649,8 +24594,8 @@ msgstr ""
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду вэб-"
-"старонак."
+"Мы блакіруем трэкеры, якія спрабуюць збіраць вашы даныя падчас прагляду "
+"вэб-старонак."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24695,8 +24640,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
+msgstr "Прабачце за гэтыя нязручнасці. Мы старанна працуем, каб палепшыць ваш досвед."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24956,8 +24900,7 @@ msgstr "Якія фактары варта ўлічваць пры куплі м
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
+msgstr "Якія славутасці Парыжа трэба абавязкова наведаць тым, хто прыязджае ўпершыню?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24965,8 +24908,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
+msgstr "Якія варыянты слова \"лепш\" у кантэксце \"Нам сапраўды трэба зрабіць лепш\"."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -26244,16 +26186,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
+msgstr "Вы дасягнулі максімальнай працягласці галасавога чата для аднаго сеансу."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
+msgstr "Вы дасягнулі на сёння ліміту галасавога чата. Паспрабуйце яшчэ раз заўтра."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26512,8 +26452,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у Duck."
-"ai."
+"Вашы чаты былі імпартаваны. Працягвайце з таго месца, дзе спыніліся, у "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -314,7 +314,8 @@ msgstr "Класирането на %1$s все още не е налично"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
+msgstr ""
+"%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -384,7 +385,8 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
+msgstr ""
+"%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -500,7 +502,8 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr ""
+"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -1022,8 +1025,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите "
-"%1$sduckduckgo.com/aichat%2$s."
+"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1681,8 +1684,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти "
-"по-бързо от другите модели. %1$s"
+"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти по-"
+"бързо от другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -2341,7 +2344,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr ""
+"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2677,7 +2681,8 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr ""
+"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2977,6 +2982,18 @@ msgstr ""
 "Преди да съхрани този отчет, DuckDuckGo ще анонимизира разговора, като "
 "премахне личната информация, като имена, имейл адреси и идентифициращи "
 "метаданни."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3905,7 +3922,8 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr ""
+"Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -4290,7 +4308,8 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr ""
+"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4699,7 +4718,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr ""
+"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4766,7 +4786,8 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr ""
+"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4784,7 +4805,8 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr ""
+"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4859,7 +4881,8 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr ""
+"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5501,7 +5524,8 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr ""
+"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5614,7 +5638,8 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr ""
+"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6498,7 +6523,8 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr ""
+"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6546,6 +6572,12 @@ msgstr "Не харесвам дизайна"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Не харесвам източника"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6658,6 +6690,12 @@ msgid "Djibouti"
 msgstr "Джибути"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6705,7 +6743,8 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr ""
+"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7029,7 +7068,8 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr ""
+"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7075,7 +7115,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr ""
+"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7125,7 +7166,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr ""
+"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7156,8 +7198,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно "
-"%1$shttps://duck.ai%2$s ."
+"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
+"ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7397,8 +7439,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
-"по-късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8076,13 +8118,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr ""
+"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr ""
+"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8112,13 +8156,15 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr ""
+"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr ""
+"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8224,7 +8270,8 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr ""
+"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8332,7 +8379,8 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr ""
+"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8410,7 +8458,8 @@ msgstr "Разгледайте Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr ""
+"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8524,6 +8573,12 @@ msgstr "Завършил"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Бързо"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8720,7 +8775,8 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr ""
+"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8858,6 +8914,12 @@ msgid "Follow-ups remain private."
 msgstr "Следващите съобщения остават поверителни."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8961,7 +9023,8 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr ""
+"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9207,13 +9270,15 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr ""
+"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9371,7 +9436,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+msgstr ""
+"Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9713,7 +9779,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr ""
+"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9801,6 +9868,12 @@ msgstr "Добър дизайн"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Добра политика за поверителност"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10385,7 +10458,8 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr ""
+"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10653,7 +10727,8 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr ""
+"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10791,8 +10866,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
-"книги/поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
+"поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10945,6 +11020,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Подканите за изображения трябва да отговарят на %1$s на Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11418,7 +11499,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr ""
+"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11468,7 +11550,8 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr ""
+"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12054,7 +12137,8 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr ""
+"Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -12221,7 +12305,8 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr ""
+"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12250,7 +12335,8 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr "Информацията за местоположението се съхранява само на вашето устройство."
+msgstr ""
+"Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -14740,7 +14826,8 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr ""
+"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15371,9 +15458,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
-"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
-"За да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
+"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
+"да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -15502,7 +15589,8 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
+msgstr ""
+"Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15820,6 +15908,12 @@ msgstr "Полски"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Лошо форматиране"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16618,14 +16712,15 @@ msgstr "С обосновка може да получите по-подробн
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти "
-"по-бързо. %1$s"
+"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти по-"
+"бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
+msgstr ""
+"Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16994,7 +17089,8 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr ""
+"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17898,13 +17994,15 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr ""
+"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18351,7 +18449,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr ""
+"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18478,7 +18577,8 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr ""
+"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18518,7 +18618,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18539,7 +18640,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr ""
+"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -19022,8 +19124,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате "
-"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
+"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -19488,7 +19590,8 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
+msgstr ""
+"Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19586,7 +19689,8 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr ""
+"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19604,7 +19708,8 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr ""
+"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19627,12 +19732,14 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr ""
+"Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr ""
+"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19704,12 +19811,14 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr ""
+"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr ""
+"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19868,7 +19977,8 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr ""
+"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19898,7 +20008,8 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr ""
+"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19973,8 +20084,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
-"по-късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20290,7 +20401,8 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr ""
+"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21100,8 +21212,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
-"Duck.ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21481,7 +21593,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr ""
+"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21535,7 +21648,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr ""
+"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21551,7 +21665,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr ""
+"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21888,7 +22003,8 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr ""
+"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22117,7 +22233,8 @@ msgstr "Днес"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Превключете към частен чат с AI или го %1$sдеактивирайте в настройките%2$s."
+msgstr ""
+"Превключете към частен чат с AI или го %1$sдеактивирайте в настройките%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22186,6 +22303,12 @@ msgstr "Прекалено много резултати от този изто�
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Прекалено бавно"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22348,8 +22471,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22358,8 +22481,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до "
-"най-близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до най-"
+"близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22477,7 +22600,8 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr ""
+"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22634,6 +22758,12 @@ msgid "Try fewer keywords."
 msgstr "Опитайте с по-малко ключови думи."
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22718,7 +22848,8 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr ""
+"Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23215,7 +23346,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr ""
+"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23233,7 +23365,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr ""
+"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23792,7 +23925,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr ""
+"Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24296,8 +24430,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
-"по-точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
+"точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24409,7 +24543,8 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24450,7 +24585,8 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr ""
+"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24607,7 +24743,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr ""
+"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24772,7 +24909,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr ""
+"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24863,13 +25001,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr ""
+"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr ""
+"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24994,7 +25134,8 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr ""
+"Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25875,7 +26016,8 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr ""
+"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25952,7 +26094,8 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr ""
+"Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26149,14 +26292,15 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
-"по-късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
+"късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr ""
+"Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26168,7 +26312,8 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr ""
+"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26177,8 +26322,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
-"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
+"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -26206,8 +26351,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от "
-"YouTube/Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
+"Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26359,7 +26504,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr ""
+"Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26420,7 +26566,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr ""
+"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26657,7 +26804,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr ""
+"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26740,7 +26888,8 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr ""
+"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bg_BG/LC_MESSAGES/duckduckgo.po
+++ b/locales/bg_BG/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -314,8 +314,7 @@ msgstr "Класирането на %1$s все още не е налично"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
+msgstr "%1$s достига лимитите за ползване 2-5 пъти по-бързо от основните модели. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -385,8 +384,7 @@ msgstr "%1$s използвани"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
+msgstr "%1$s изразходва лимитите почти 2–5 пъти по-бързо от основните модели %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -502,8 +500,7 @@ msgstr "%1$sНаучи повече%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
+msgstr "%1$sНаучете как запазваме поверителността на вашето местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -1025,8 +1022,8 @@ msgstr ""
 "AI Chat ви позволява да провеждате анонимни разговори с модели за чат с "
 "изкуствен интелект на трети страни. Изключването на това ще скрие функцията "
 "AI Chat в DuckDuckGo Search. Все още можете да получите достъп до AI Chat, "
-"когато тази настройка е изключена, като посетите %1$sduckduckgo.com/"
-"aichat%2$s."
+"когато тази настройка е изключена, като посетите "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1684,8 +1681,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти по-"
-"бързо от другите модели. %1$s"
+"Усъвършенстваните модели могат да достигнат лимитите за ползване 2–5 пъти "
+"по-бързо от другите модели. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -2344,8 +2341,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
+msgstr "Сигурни ли сте, че искате да изчистите този разговор и да започнете нов?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2681,8 +2677,7 @@ msgstr "След приключване на чата аудиото не се �
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
+msgstr "След транскрибиране на чата аудиото не се съхранява от нас или от OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2994,6 +2989,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Преди да съхрани този отчет, DuckDuckGo ще премахне качените файлове и "
+"генерираните изображения и ще анонимизира разговора, като премахне личната "
+"информация, като имена, имейл адреси и идентифициращи метаданни."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3922,8 +3920,7 @@ msgstr "Променя фоновия цвят, когато курсорът б
 #. Description of a setting managing the color of search result snippet text.
 msgctxt "settings"
 msgid "Changes the color of descriptive content shown for results"
-msgstr ""
-"Променя цвета на описателното съдържание, което се показва с резултатите"
+msgstr "Променя цвета на описателното съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -4308,8 +4305,7 @@ msgstr "Проверете правописа"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
+msgstr "Проверка на subreddit в DuckDuckGo за актуализации относно това прекъсване."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4718,8 +4714,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
+msgstr "Щракнете върху %1$sПоверителност и услуги%2$s в лявата странична лента."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4786,8 +4781,7 @@ msgstr "Щракнете върху %1$sБраузър%2$s в странично
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
+msgstr "Щракнете върху %1$sПромяна на настройките за търсене%2$s в падащото меню"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4805,8 +4799,7 @@ msgstr "Щракнете върху %1$sТърсачки%2$s под Видове
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
+msgstr "Щракнете върху %1$sиконата Настройки%2$s в горния десен ъгъл на браузъра"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4881,8 +4874,7 @@ msgstr "Щракнете върху %1$sиконата за разрешения
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
+msgstr "Щракнете върху иконата с пате в горната част на браузъра си, за да търсите!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5524,8 +5516,7 @@ msgstr "Копиране"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
+msgstr "Копирайте и поставете %1$sabout:preferences#search%2$s в адресната лента"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5638,8 +5629,7 @@ msgstr "Коста Рика"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
+msgstr "Неуспешно зареждане на кода. Затворете този прозорец и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6523,8 +6513,7 @@ msgstr "Деактивиране и изключване"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
+msgstr "Деактивиране на историята на чата и прекъсване на връзката със Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6577,7 +6566,7 @@ msgstr "Не харесвам източника"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Не харесвам визуалния стил"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6693,7 +6682,7 @@ msgstr "Джибути"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Не следва инструкциите"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6743,8 +6732,7 @@ msgstr "Не виждате DuckDuckGo в списъка?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
+msgstr "Не го виждате? %1$s%2$s%3$sНатиснете тук, за да го изтеглите отново%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7068,8 +7056,7 @@ msgstr "Условия за ползване на Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
+msgstr "Duck.ai от DuckDuckGo. Поверителен чат с изкуствен интелект. Безплатен."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7115,8 +7102,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
+msgstr "Duck.ai е най-добър в нашия поверителен и безплатен браузър DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7166,8 +7152,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
+msgstr "Duck.ai е временно недостъпен. Моля, опреснете страницата и опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7198,8 +7183,8 @@ msgstr ""
 "интелект на трети страни, включително модели от OpenAI, Anthropic и други. "
 "Ако изключите тази настройка, бутоните и връзките на Duck.ai в DuckDuckGo "
 "Search ще се скрият. Въпреки това можете да получите достъп до Duck.ai, "
-"когато тази настройка е изключена, като посетите директно %1$shttps://duck."
-"ai%2$s ."
+"когато тази настройка е изключена, като посетите директно "
+"%1$shttps://duck.ai%2$s ."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7439,8 +7424,8 @@ msgstr ""
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
 msgstr ""
-"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново по-"
-"късно."
+"Функцията DuckDuckGo AI Chat е временно недостъпна. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8118,15 +8103,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
+msgstr "Уверете се, че функцията \"Услуги за местоположение\" е %1$sактивирана%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
+msgstr "Уверете се, че функцията „Местоположение“ е зададена на %1$s„разрешаване“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8156,15 +8139,13 @@ msgstr "Уверете се, че достъпът до местоположен
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
+msgstr "Уверете се, че на браузъра е разрешен %1$sдостъпът до местоположението%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
+msgstr "Уверете се, че браузърът има разрешен %1$sдостъп до местоположение%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8270,8 +8251,7 @@ msgstr "Екваториална Гвинея"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
+msgstr "Изтрийте светкавично данните за сърфирането с нашия %1$sбутон Fire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8379,8 +8359,7 @@ msgstr "Обясни приетия отговор с прости думи."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
+msgstr "Обясни ми основните принципи на черните дупки на ниво гимназиален етап."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8458,8 +8437,7 @@ msgstr "Разгледайте Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
+msgstr "Разгледайте най-новите актуализации на продукти и функции на DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8578,7 +8556,7 @@ msgstr "Бързо"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Бързо генериране на изображения"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8775,8 +8753,7 @@ msgstr "Финансов консултант"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
+msgstr "Намерете %1$sDuckDuckGo%2$s и щракнете върху%3$sНаправи по подразбиране%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8917,7 +8894,7 @@ msgstr "Следващите съобщения остават поверите�
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Спази инструкциите"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9023,8 +9000,7 @@ msgstr "Безплатни и поверителни чатове, аноним�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
+msgstr "Безплатни и поверителни чатове, анонимизирани от нас. Не е необходим акаунт."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9270,15 +9246,13 @@ msgstr "Общо предназначение"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с високо ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
+msgstr "Изкуствен интелект с общо предназначение с ниско ниво на вградена модерация"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9436,8 +9410,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
+msgstr "Вземете DuckDuckGo VPN, усъвършенстван Duck.ai и Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9779,8 +9752,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
+msgstr "Отидете на %1$s„Поверителност и сигурност > Услуги за местоположение“%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9873,7 +9845,7 @@ msgstr "Добра политика за поверителност"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Добър визуален стил"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10458,8 +10430,7 @@ msgstr "Скриване на Вашия имейл адрес"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
+msgstr "Скрива търсената дума, за да не се показва в раздела/историята на браузъра"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10727,8 +10698,7 @@ msgstr "Колко често искате да виждате отговори�
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
+msgstr "Колко често искаш да виждаш отговори, подпомогнати от изкуствен интелект?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -10866,8 +10836,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри книги/"
-"поредици има, които приличат най-много на нея, и защо?"
+"Харесва ми книгата „Името на вятъра“. Кажи ми какви други добри "
+"книги/поредици има, които приличат най-много на нея, и защо?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -11025,7 +10995,7 @@ msgstr "Подканите за изображения трябва да отг�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Качество на изображението"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11499,8 +11469,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
+msgstr "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11550,8 +11519,7 @@ msgstr "Той е бърз, безплатен и осигурява още по
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
+msgstr "Няма проблем (много рядко) да ме питате за мнението ми относно DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12137,8 +12105,7 @@ msgstr "Ограничено съхранение на данни за този 
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"Ограничава количеството описателно съдържание, което се показва с резултатите"
+msgstr "Ограничава количеството описателно съдържание, което се показва с резултатите"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -12305,8 +12272,7 @@ msgstr "Зареждане на още резултати с изображен�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"При превъртане зарежда повече резултати в изображения, видео и пазаруване"
+msgstr "При превъртане зарежда повече резултати в изображения, видео и пазаруване"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12335,8 +12301,7 @@ msgstr "Местоположение"
 #. Message informing users that location-based search is private.
 msgctxt "precise_user_location"
 msgid "Location information is stored only on your device."
-msgstr ""
-"Информацията за местоположението се съхранява само на вашето устройство."
+msgstr "Информацията за местоположението се съхранява само на вашето устройство."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -14826,8 +14791,7 @@ msgstr "Отваряне на панела Как работи Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
+msgstr "Отворете менюто на Safari и изберете %1$s„Настройки за DuckDuckGo“...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15458,9 +15422,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"Ако формулирате своето търсене като въпрос и в пълно изречение, е по-"
-"вероятно DuckAssist да се появи и често допринася за по-добри отговори. За "
-"да настроите как да работи тази функция или да я изключите, отидете на "
+"Ако формулирате своето търсене като въпрос и в пълно изречение, е "
+"по-вероятно DuckAssist да се появи и често допринася за по-добри отговори. "
+"За да настроите как да работи тази функция или да я изключите, отидете на "
 "%1$sНастройки на DuckAssist%2$s."
 
 # smartling.placeholder_format=C
@@ -15589,8 +15553,7 @@ msgstr "Закачени"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
+msgstr "Закачените чатове ще се показват най-отгоре в списъка с последни чатове."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15913,7 +15876,7 @@ msgstr "Лошо форматиране"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Лошо качество на изображението"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16712,15 +16675,14 @@ msgstr "С обосновка може да получите по-подробн
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти по-"
-"бързо. %1$s"
+"Обосновката е по-задълбочена, но достига лимитите за ползване 2–5 пъти "
+"по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
+msgstr "Обосновката е по-задълбочена, но изчерпва лимитите 2-5 пъти по-бързо. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17089,8 +17051,7 @@ msgstr "Запомни моя избор"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
+msgstr "Запомни моя избор (това може да бъде променено в %1$s%2$s%3$sНастройки%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17994,15 +17955,13 @@ msgstr "Шотландия"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
+msgstr "Превъртете надолу и щракнете върху %1$sПреглед на разширените настройки%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18449,8 +18408,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
+msgstr "Съхранява се сигурно на сървъра на DuckDuckGo с криптиране от край до край."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18577,8 +18535,7 @@ msgstr "Вижте някои от най-новите ни актуализац
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
+msgstr "За повече подробности вижте %1$sстраницата за справка за URL параметър%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18618,8 +18575,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
+msgstr "Изберете %1$sDuckDuckGo%2$s и натиснете %3$sДобавяне по подразбиране%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18640,8 +18596,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
+msgstr "Изберете %1$sDuckDuckGo%2$s в падащия списък като търсачка по подразбиране"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -19124,8 +19079,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Споделете местоположение на ниво град с AI моделите, за да получавате по-"
-"подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
+"Споделете местоположение на ниво град с AI моделите, за да получавате "
+"по-подходящи отговори. Duck.ai никога не разкрива точното Ви местоположение "
 "нито на нас, нито на AI моделите."
 
 # smartling.placeholder_format=C
@@ -19590,8 +19545,7 @@ msgstr "Показване на страничната лента"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
+msgstr "Показва съвети стъпка по стъпка за извличане на максимална полза от Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19689,8 +19643,7 @@ msgstr "Показва периодично напомняне за добавя
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
+msgstr "Показва периодично напомняне за добавяне на DuckDuckGo към устройствата ви"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19708,8 +19661,7 @@ msgstr "Показва номерата на страниците в края н
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
+msgstr "Показва формуляр за регистриране за бюлетините за поверителност на DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19732,14 +19684,12 @@ msgstr "Показва фона на бутона за търсене"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Показва приветствие в горната част на страницата с резултати от търсенето"
+msgstr "Показва приветствие в горната част на страницата с резултати от търсенето"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
+msgstr "Показва приветствие за потребителите с меню за предпочитания за Android в ЕС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19811,14 +19761,12 @@ msgstr "Имена на сайтове"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
+msgstr "Търсенето в сайта е временно недостъпно. Работим за разрешаване на проблема."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
+msgstr "Сайтовете, които блокирате, ще бъдат скрити от всички резултати от търсенето."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19977,8 +19925,7 @@ msgstr "Нещо се обърка при запазването на сървъ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
+msgstr "Нещо се обърка при активирането на Sync & Backup. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20008,8 +19955,7 @@ msgstr "Понякога"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
+msgstr "Съжалявам, не мога да помогна, моля, опишете изображението по друг начин."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20084,8 +20030,8 @@ msgstr ""
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново по-"
-"късно."
+"За съжаление, не успяхме да подадем вашия отзив. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20401,8 +20347,7 @@ msgstr "Спрете скритите тракери, които се спота
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
+msgstr "Спрете повечето от скритите тракери, които се спотайват в други уебсайтове."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21212,8 +21157,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим Duck."
-"ai."
+"Попълнете тази анонимна анкета, за да ни кажете как можем да подобрим "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21593,8 +21538,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
+msgstr "Възникна проблем при зареждането на този отговор. Моля, опитайте отново."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21648,8 +21592,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
+msgstr "Този AI модел вече не е наличен. Опитайте да започнете нов чат с друг модел."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21665,8 +21608,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
+msgstr "Този незабавен отговор бе създаден от общността на %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -22003,8 +21945,7 @@ msgstr "Този превод е грешен"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
+msgstr "Все още не можете да гледате това видео тук. Можете да го гледате в %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22233,8 +22174,7 @@ msgstr "Днес"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Превключете към частен чат с AI или го %1$sдеактивирайте в настройките%2$s."
+msgstr "Превключете към частен чат с AI или го %1$sдеактивирайте в настройките%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22308,7 +22248,7 @@ msgstr "Прекалено бавно"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Прекалено бавно се генерира"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22471,8 +22411,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от английски на френски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от английски на френски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22481,8 +22421,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"Преведи това изречение от български на английски: „Как да стигна до най-"
-"близкото кино?“"
+"Преведи това изречение от български на английски: „Как да стигна до "
+"най-близкото кино?“"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22600,8 +22540,7 @@ msgstr "Изпробвайте %1$s — първият ни модел с нул
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
+msgstr "Опитайте %1$sDuck.ai%2$s, нашата частна услуга за чат с изкуствен интелект:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22761,7 +22700,7 @@ msgstr "Опитайте с по-малко ключови думи."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Пробвайте безплатно"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22848,8 +22787,7 @@ msgstr "Изпробвайте нашия браузър"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Опитайте нашата начална страница, която никога не показва тези съобщения:"
+msgstr "Опитайте нашата начална страница, която никога не показва тези съобщения:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23346,8 +23284,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
+msgstr "Под %1$sСТАРТИРАНЕ > Начална страница%2$s въведете: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23365,8 +23302,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
+msgstr "В раздела %1$sТърсене%2$s щракнете върху %3$sУправляване на търсачките...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23925,8 +23861,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Да се използва приблизителното Ви местоположение за по-точни резултати?"
+msgstr "Да се използва приблизителното Ви местоположение за по-точни резултати?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24430,8 +24365,8 @@ msgstr "Ние анонимизираме"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме по-"
-"точни резултати."
+"Можем да анонимизираме%1$s вашето местоположение%2$s, за да ви показваме "
+"по-точни резултати."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24543,8 +24478,7 @@ msgstr "Ние не ви проследяваме. Никога."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24585,8 +24519,7 @@ msgstr "Не ви следим нито във, нито извън режима
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
+msgstr "Ние не Ви проследяваме. Това е нашата Политика за поверителност накратко…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24743,8 +24676,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
+msgstr "Съжаляваме за това неудобство. Работим усилено, за да подобрим изживяването."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24909,8 +24841,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
+msgstr "Добре дошли в новия Duck.ai! Вече можете да импортирате изтеглените чатове."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25001,15 +24932,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
+msgstr "Какви фактори трябва да се имам предвид, когато купувам монитор за компютър?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Кои атракции трябва да види един турист, който посещава Париж за първи път?"
+msgstr "Кои атракции трябва да види един турист, който посещава Париж за първи път?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25134,8 +25063,7 @@ msgstr "Кои са ястията, които задължително тряб
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Какво е работното време, местоположението и данните за контакт на това място?"
+msgstr "Какво е работното време, местоположението и данните за контакт на това място?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -26016,8 +25944,7 @@ msgstr "Можете да продължите този чат, като изп�
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
+msgstr "Вече можете да запазите до 100 чата на това устройство. Разговаряйте на воля!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26094,8 +26021,7 @@ msgstr "Можете да възстановите настройките си, 
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Можете да споделяте и използвате настройките си с други компютри и браузъри."
+msgstr "Можете да споделяте и използвате настройките си с други компютри и браузъри."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26292,15 +26218,14 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново по-"
-"късно."
+"Достигнахте максималния брой съобщения за момента. Моля, опитайте отново "
+"по-късно."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Достигнали сте максималната продължителност на гласовия чат за една сесия."
+msgstr "Достигнали сте максималната продължителност на гласовия чат за една сесия."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26312,8 +26237,7 @@ msgstr "Достигнали сте лимита за гласов чат за �
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
+msgstr "Достигнали сте лимита за използване на диктовка. Опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26322,8 +26246,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в Duck."
-"ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
+"Мястото за съхранение на Sync & Backup за чатове с прикачени файлове в "
+"Duck.ai е недостатъчно. Изтрийте %1$s най-стари чатове, за да възобновите "
 "синхронизирането. Закачените чатове няма да бъдат изтрити."
 
 # smartling.placeholder_format=C
@@ -26351,8 +26275,8 @@ msgid ""
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
 "YouTube (притежаван от Google) не позволява да гледате видео анонимно. "
-"Следователно гледането на YouTube видео тук ще бъде следено от YouTube/"
-"Google."
+"Следователно гледането на YouTube видео тук ще бъде следено от "
+"YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26504,8 +26428,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Чатовете са поверителни и никога не се използват за обучение на AI модели"
+msgstr "Чатовете са поверителни и никога не се използват за обучение на AI модели"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26566,8 +26489,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
+msgstr "Чатовете са импортирани. Продължете оттам, откъдето сте спрели в Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26804,8 +26726,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
+msgstr "Достигнахте лимита за гласов чат засега. Моля, опитайте отново по-късно."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26888,8 +26809,7 @@ msgstr "от %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
+msgstr "от DuckDuckGo — онлайн защита, на която милиони се доверяват всеки ден."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/bn_BD/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_BD/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5217,6 +5228,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "বন্ধ করুন"
@@ -5306,6 +5322,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6776,6 +6797,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7031,6 +7057,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7778,6 +7809,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8702,6 +8738,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12641,6 +12682,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17690,6 +17736,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18048,6 +18099,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/bn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bn_IN/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5215,6 +5226,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5304,6 +5320,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6773,6 +6794,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7026,6 +7052,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7773,6 +7804,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8693,6 +8729,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12627,6 +12668,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17670,6 +17716,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18028,6 +18079,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/bo_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/bo_CN/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/br_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/br_FR/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6770,6 +6791,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7026,6 +7052,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7773,6 +7804,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8695,6 +8731,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12636,6 +12677,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17688,6 +17734,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18046,6 +18097,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/bs_BA/LC_MESSAGES/duckduckgo.po
+++ b/locales/bs_BA/LC_MESSAGES/duckduckgo.po
@@ -2389,6 +2389,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5263,6 +5274,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Sakrij"
@@ -5352,6 +5368,11 @@ msgid "Division Record"
 msgstr "Ezultat u diviziji"
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6829,6 +6850,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7086,6 +7112,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7835,6 +7866,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8769,6 +8805,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12735,6 +12776,11 @@ msgstr "Poljski"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17825,6 +17871,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18184,6 +18235,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Probajte manje ključnih riječi."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/ca_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/ca_ES/LC_MESSAGES/duckduckgo.po
@@ -2388,6 +2388,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5264,6 +5275,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Ignora"
@@ -5354,6 +5370,11 @@ msgid "Division Record"
 msgstr "Registre de la divisió"
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6837,6 +6858,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7092,6 +7118,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7841,6 +7872,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8778,6 +8814,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12749,6 +12790,11 @@ msgstr "Polonès"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17854,6 +17900,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18214,6 +18265,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Proveu amb menys paraules clau."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -106,7 +106,8 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr ""
+"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -520,7 +521,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr ""
+"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -532,7 +534,8 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr ""
+"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -883,7 +886,8 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -954,7 +958,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr ""
+"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1674,7 +1679,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
+msgstr ""
+"Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1971,7 +1977,8 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr ""
+"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2311,7 +2318,8 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr ""
+"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2954,6 +2962,18 @@ msgstr ""
 "identifikační metadata."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3449,7 +3469,8 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr ""
+"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3528,7 +3549,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr ""
+"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4659,13 +4681,15 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr ""
+"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr ""
+"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5941,7 +5965,8 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6515,6 +6540,12 @@ msgid "Dislike source"
 msgstr "Nelíbí se mi zdroj"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Skrýt"
@@ -6625,6 +6656,12 @@ msgid "Djibouti"
 msgstr "Džibutsko"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6672,7 +6709,8 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr ""
+"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7041,7 +7079,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr ""
+"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7129,7 +7168,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr ""
+"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7178,7 +7218,8 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr ""
+"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7355,7 +7396,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr ""
+"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8178,7 +8220,8 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr ""
+"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8480,6 +8523,12 @@ msgid "Fast"
 msgstr "Rychle"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8542,7 +8591,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr ""
+"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8624,7 +8674,8 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr ""
+"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8793,7 +8844,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr ""
+"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8805,6 +8857,12 @@ msgstr "Navazující otázka"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Navazující zprávy zůstávají soukromé."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8910,7 +8968,8 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr ""
+"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9545,8 +9604,8 @@ msgstr "Stáhnout aplikaci"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
-"YouTube.%2$s"
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9747,6 +9806,12 @@ msgstr "Pěkný design"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Dobré zásady ochrany osobních údajů"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10579,7 +10644,8 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr ""
+"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10827,7 +10893,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr ""
+"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10836,7 +10903,8 @@ msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatn�
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr ""
+"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10883,6 +10951,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Pokyny k zadávání obrázků musí splňovat %1$s Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11355,7 +11429,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr ""
+"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11931,7 +12006,8 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
+msgstr ""
+"Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12340,7 +12416,8 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr ""
+"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12938,7 +13015,8 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13816,7 +13894,8 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr ""
+"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14432,7 +14511,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr ""
+"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14507,7 +14587,8 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr ""
+"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -15740,6 +15821,12 @@ msgid "Poor formatting"
 msgstr "Špatné formátování"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16254,7 +16341,8 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr ""
+"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16302,7 +16390,8 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr ""
+"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -17445,7 +17534,8 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr ""
+"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17512,7 +17602,8 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr ""
+"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -17660,7 +17751,8 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr ""
+"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17849,7 +17941,8 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr ""
+"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18413,13 +18506,14 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
-"%3$shttps://duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr ""
+"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18561,7 +18655,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr ""
+"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18808,7 +18903,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr ""
+"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18909,8 +19005,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
-"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
+"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19914,7 +20010,8 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr ""
+"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20974,7 +21071,8 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr ""
+"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21179,13 +21277,15 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr ""
+"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21255,7 +21355,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr ""
+"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21406,7 +21507,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr ""
+"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21761,13 +21863,15 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr ""
+"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr ""
+"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21983,13 +22087,15 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Přepni na soukromý chat s AI, nebo si funkci %1$svypni v nastavení%2$s."
+msgstr ""
+"Přepni na soukromý chat s AI, nebo si funkci %1$svypni v nastavení%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
+msgstr ""
+"Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22050,6 +22156,12 @@ msgstr "Moc výsledků z tohohle zdroje"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Moc pomalé"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22337,7 +22449,8 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr ""
+"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22490,6 +22603,12 @@ msgstr "Zkus s každým modelem experimentovat – poskytnou ti různé odpově
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Zkus méně klíčových slov."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23071,8 +23190,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
-"https://duckduckgo.com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23082,7 +23201,8 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr ""
+"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23474,7 +23594,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr ""
+"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23584,7 +23705,8 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr ""
+"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24236,7 +24358,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr ""
+"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24257,7 +24380,8 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr ""
+"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24298,7 +24422,8 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr ""
+"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24563,7 +24688,8 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr ""
+"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25097,7 +25223,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr ""
+"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -26253,7 +26380,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr ""
+"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26364,7 +26492,8 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr ""
+"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26479,7 +26608,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr ""
+"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26787,7 +26917,8 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr ""
+"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -106,8 +106,7 @@ msgstr "Počet pokusů: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
+msgstr "Počet pokusů zablokovaných službou DuckDuckGo za posledních 24 hodin: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -521,8 +520,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
+msgstr "%1$sPřečti si víc%2$s o tom, jak se chaty soukromě ukládají na tvé zařízení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -534,8 +532,7 @@ msgstr "%1$sPodrž%2$s ikonu aplikace DuckDuckGo na domovské obrazovce"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
+msgstr "%1$sJejda!%2$s%3$sNěco se pokazilo. %4$sObnov stránku%5$s a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -886,8 +883,7 @@ msgstr "Byl vyčerpán 6hodinový limit využití."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán 6hodinový limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -958,8 +954,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
+msgstr "Je dostupná nová verze AI Chatu! Pokud chceš pokračovat, obnov stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1679,8 +1674,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
+msgstr "Pokročilé modely můžou limity vyčerpat 2–5× rychleji než jiné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1977,8 +1971,7 @@ msgstr "Povolit anonymní kontrolu souborů pro tento chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
+msgstr "Povolit na DuckDuckGo Private Search reklamy, které respektují soukromí"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2318,8 +2311,7 @@ msgstr "Jsi tam ještě?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
+msgstr "Opravdu chceš vymazat všechny své chaty? Tenhle krok se nedá vrátit zpět."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2972,6 +2964,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Před uložením tohoto reportu DuckDuckGo odstraní nahrané soubory a "
+"vygenerované obrázky a anonymizuje tvoji konverzaci odstraněním osobních "
+"údajů, jako jsou jména, e-mailové adresy a identifikační metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3469,8 +3464,7 @@ msgstr "Kliknutím na „%1$s“ odsouhlasíš naše %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
+msgstr "Kliknutím na „%1$s“ vyjadřuješ souhlas s podmínkami Duck.ai, viz %2$s a %3$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3549,8 +3543,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
+msgstr "Můžeš vytvořit několik jednoduchých receptů z kuřete, brokolice a rýže?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4681,15 +4674,13 @@ msgstr "Klikni %1$ssem%2$s a stáhni si rozšíření DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
+msgstr "Klikni na %1$sOtevřít%2$s a stáhni si a otevři rozšíření DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
+msgstr "V levém postranním panelu klepni na tlačítko %1$sSoukromí a služby%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -5965,8 +5956,7 @@ msgstr "Byl vyčerpán denní limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán denní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6543,7 +6533,7 @@ msgstr "Nelíbí se mi zdroj"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nelíbí se mi vizuální styl"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6659,7 +6649,7 @@ msgstr "Džibutsko"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nedodržuje pokyny"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6709,8 +6699,7 @@ msgstr "Nevidíš v seznamu DuckDuckGo?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
+msgstr "Nedaří se ti soubor najít? %1$s%2$s%3$sKliknutím sem zopakuj stahování%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7079,8 +7068,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
+msgstr "Duck.ai je nejlepší v našem soukromém a bezplatném prohlížeči DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7168,8 +7156,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
+msgstr "Duck.ai může zobrazovat může zobrazovat nepřesné nebo pohoršující informace."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7218,8 +7205,7 @@ msgstr "Upgrade Duck.ai je hotový!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
+msgstr "Duck.ai funguje nejlíp v naší soukromé a bezplatné aplikaci DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7396,8 +7382,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
+msgstr "DuckDuckGo AI Chat je dočasně nedostupný. Obnov stránku a zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8220,8 +8205,7 @@ msgstr "Rovníková Guinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
+msgstr "Pomocí tlačítka %1$sFire Button%2$s můžeš bleskově vymazat data o prohlížení."
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8526,7 +8510,7 @@ msgstr "Rychle"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Rychlé generování obrázků"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8591,8 +8575,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
+msgstr "Nastavení můžeš změnit níže. Pak jednoduše zkopíruj kód do svojí stránky."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8674,8 +8657,7 @@ msgstr "Filtry nefungují"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
+msgstr "Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8844,8 +8826,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
+msgstr "Postupuj podle těchto kroků a přesuň své chaty na novou doménu Duck.ai."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8862,7 +8843,7 @@ msgstr "Navazující zprávy zůstávají soukromé."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Dodržela pokyny"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8968,8 +8949,7 @@ msgstr "Bezplatné a soukromé chaty, které anonymizujeme"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
+msgstr "Bezplatné a soukromé chaty, které anonymizujeme. Není potřeba žádný účet."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9604,8 +9584,8 @@ msgstr "Stáhnout aplikaci"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na YouTube."
-"%2$s"
+"Nainstaluj si bezplatný prohlížeč DuckDuckGo %1$sa blokuj reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9811,7 +9791,7 @@ msgstr "Dobré zásady ochrany osobních údajů"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Pěkný vizuální styl"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10644,8 +10624,7 @@ msgstr "Jak to funguje"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
+msgstr "Jak často chceš, aby se objevovaly odpovědi s podporou umělé inteligence?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10893,8 +10872,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
+msgstr "Pokud nás stále chceš podpořit, %1$spoděl se o DuckDuckGo s ostatními%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10903,8 +10881,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
+msgstr "Pokud chceš používat DuckDuckGo bez JavaScriptu, použij verzi %1$s nebo %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10956,7 +10933,7 @@ msgstr "Pokyny k zadávání obrázků musí splňovat %1$s Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Kvalita obrázku"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11429,8 +11406,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
+msgstr "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -12006,8 +11982,7 @@ msgstr "Umožní ti anonymně vyhledávat pomocí DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
+msgstr "Umožní ti přepínat mezi odesíláním vyhledávacích dotazů a promptů do Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12416,8 +12391,7 @@ msgstr "Ujisti se, že jsou všechna slova napsaná správně."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
+msgstr "Zaškrtni možnost %1$sNastavit jako výchozího poskytovatele vyhledávání%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13015,8 +12989,7 @@ msgstr "Byl vyčerpán měsíční limit"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán měsíční limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13894,8 +13867,7 @@ msgstr "Nebyly nalezeny žádné výsledky."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
+msgstr "Nebyla zaznamenána žádná řeč. Zkus to prosím znovu a mluv do mikrofonu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14511,8 +14483,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
+msgstr "Jejda! Při překládání tohoto textu došlo k neočekávané chybě. Zkus to znovu."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14587,8 +14558,7 @@ msgstr "Otevřít %1$sNastavení%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
+msgstr "Otevři možnost Poloha a ujisti se, že je přístup k poloze %1$spovolený%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -15824,7 +15794,7 @@ msgstr "Špatné formátování"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Špatná kvalita obrázku"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16341,8 +16311,7 @@ msgstr "Upozornit"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
+msgstr "Vyzvat mě, abych použil/a svou přibližnou polohu a získal/a výsledky v okolí."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16390,8 +16359,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
+msgstr "Dej mi několik návrhů, jak následující text zestručnit. [Sem vlož svůj text.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -17534,8 +17502,7 @@ msgstr "SV"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
+msgstr "Propagace na stránce s výsledky vyhledávání pro desktopový prohlížeč zavřena"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -17602,8 +17569,7 @@ msgstr "Bezpečné vyhledávání zablokovalo výsledky pro %1$s."
 # smartling.placeholder_format=C
 #. A label above search results that lets the user know the safe search filter blocked some of the results from showing. The placeholder value is the user's search term.
 msgid "Safe search blocked some results for %s."
-msgstr ""
-"Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
+msgstr "Bezpečné vyhledávání zablokovalo některé výsledky hledání pro dotaz %1$s."
 
 # smartling.placeholder_format=C
 #. Safe search lets you remove adult content from results on DuckDuckGo. This string is used to invite users to select the desired level of protection (e.g., strict, moderate, off)
@@ -17751,8 +17717,7 @@ msgstr "Ukládej až 30 svých nejnovějších chatů lokálně na své zaříze
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
+msgstr "Ulož si chaty Duck.ai mezi svými zařízeními pomocí end-to-end šifrování."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17941,8 +17906,7 @@ msgstr "Přejdi dolů a vyhledej %1$ssvůj prohlížeč%2$s v seznamu."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
+msgstr "Přejdi dolů na položku %1$sDuckDuckGo%2$s a umožni jí používat tvou polohu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18506,14 +18470,13 @@ msgstr "V Safari zvol %1$sNastavení pro tuto webovou stránku...%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej %3$shttps://"
-"duckduckgo.com%4$s"
+"Vyber možnost %1$sPřizpůsobit%2$s a do vyhledávacího pole zadej "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
+msgstr "Vyber %1$sDuckDuckGo%2$s a klikni na %3$sNastavit jako výchozí prohlížeč%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18655,8 +18618,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
+msgstr "V seznamu vyber %1$ssvůj prohlížeč%2$s a %3$spovol přístup k poloze%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18903,8 +18865,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
+msgstr "Nastav polohu ručně nebo zkontroluj, jestli jsou povolené polohové služby."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19005,8 +18966,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. Duck."
-"ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
+"Sdílej polohu na úrovni města s modely AI, aby se zlepšila relevance. "
+"Duck.ai nikdy neodhalí tvoji přesnou polohu nám ani modelům AI."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -20010,8 +19971,7 @@ msgstr "Vymazaný zdrojový text"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
+msgstr "Zdrojový text je na shrnutí příliš dlouhý. Zkus to znovu s kratším výběrem."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -21071,8 +21031,7 @@ msgstr "Měj osobní údaje ve svých rukou!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
+msgstr "Vyplň tento anonymní dotazník a dej nám vědět, jak můžeme Duck.ai vylepšit."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21277,15 +21236,13 @@ msgstr "Děkujeme za zpětnou vazbu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
+msgstr "Děkujeme ti za trpělivost. Snažíme se všechny kachny dostat zase do řady."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21355,8 +21312,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
+msgstr "Poskytovatel modelu smaže veškerá data související s tímto chatem do 30 dnů."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21507,8 +21463,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
+msgstr "Tenhle model AI už není dostupný. Zkus začít nový chat s jiným modelem."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21863,15 +21818,13 @@ msgstr "Tento překlad je špatný"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
+msgstr "Toto video zde ještě není možné sledovat. Můžete se na něho podívat na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
+msgstr "Tahle webová stránka nepoužívá zabezpečené, šifrované připojení (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22087,15 +22040,13 @@ msgstr "Dnes"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Přepni na soukromý chat s AI, nebo si funkci %1$svypni v nastavení%2$s."
+msgstr "Přepni na soukromý chat s AI, nebo si funkci %1$svypni v nastavení%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
+msgstr "Přepnutím vyzkoušej soukromý chat s AI, nebo ho %1$svypni v nabídce %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22161,7 +22112,7 @@ msgstr "Moc pomalé"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Příliš pomalé generování"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22449,8 +22400,7 @@ msgstr "Zkus přejít na %1$s a podobné zprávy už ti nebudeme ukazovat."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
+msgstr "Zkus %1$s, náš první model, ve kterém má poskytovatel nulovou viditelnost."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22608,7 +22558,7 @@ msgstr "Zkus méně klíčových slov."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Vyzkoušet zdarma"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23190,8 +23140,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: https://duckduckgo."
-"com"
+"Pod možností %1$sSpuštění > Domovská stránka%2$s zadej: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23201,8 +23151,7 @@ msgstr "V nabídce %1$sNastavení vyhledávání%2$s zvol %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
+msgstr "Pod %1$shledáním v adresním řádku pomocí %2$s vyber %3$sPřidat nový%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23594,8 +23543,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
+msgstr "Upgraduj na tarif Pro a aktivuj si dvojnásobné limity, než má tarif Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23705,8 +23653,7 @@ msgstr "Použít vyhledávač Private Search od DuckDuckGo"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
+msgstr "Používej soukromé vyhledávání DuckDuckGo na iPadu, iPhonu nebo Androidu"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24358,8 +24305,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
+msgstr "Nesledujeme tě, takže by nám pomohlo, když nám řekneš, co tě přivádí zpátky:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24380,8 +24326,7 @@ msgstr "Nesledujeme tě. Nikdy."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
+msgstr "My tě nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24422,8 +24367,7 @@ msgstr "Nesledujeme tě. Ani v anonymním režimu ani mimo něj."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
+msgstr "My vás nesledujeme. To jsou naše Zásady ochrany osobních údajů v kostce…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24688,8 +24632,7 @@ msgstr "Byl vyčerpán týdenní limit využití"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
+msgstr "Byl vyčerpán týdenní limit využití. V tomto chatu můžeš pokračovat za %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25223,8 +25166,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
+msgstr "Když je možnost zapnutá, Duck.ai bude v chatu zobrazovat okamžité odpovědi."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -26380,8 +26322,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
+msgstr "Import tvých chatů je hotový. Na Duck.ai můžeš pokračovat v rozdělané práci."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26492,8 +26433,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
+msgstr "Tady najdeš svoje nedávné chaty. Můžeš je kdykoli otevřít nebo vymazat."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26608,8 +26548,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
+msgstr "Bylo dosaženo maximálního počtu zpráv za jeden den. V chatu pokračuj zítra."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26917,8 +26856,7 @@ msgstr "oficiálních webových stránkách"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
+msgstr "nebo napište kód libovolné barvy, např. %1$s (%2$s je kód pro znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/cs_CZ/LC_MESSAGES/duckduckgo.po
@@ -22746,7 +22746,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Zkuste použít jiný vyhledávací výraz nebo frázi."
+msgstr "Zkus použít jiný vyhledávací výraz nebo frázi."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.

--- a/locales/cy_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/cy_GB/LC_MESSAGES/duckduckgo.po
@@ -2380,6 +2380,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5239,6 +5250,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Diswyddo"
@@ -5328,6 +5344,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6788,6 +6809,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7047,6 +7073,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7794,6 +7825,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8718,6 +8754,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12681,6 +12722,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17737,6 +17783,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18096,6 +18147,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Ceisiwch llai o allweddeiriau."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -314,7 +314,8 @@ msgstr "Rangeringer for %1$s er endnu ikke tilgængelige"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
+msgstr ""
+"%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -450,7 +451,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr ""
+"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -512,7 +514,8 @@ msgstr "%1$sLæs mere%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr ""
+"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -881,7 +884,8 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr ""
+"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -952,14 +956,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr ""
+"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1893,7 +1899,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr ""
+"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2206,8 +2213,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
-"f.eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
+"eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2313,7 +2320,8 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2325,7 +2333,8 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr ""
+"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2532,8 +2541,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er "
-"AI-assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
+"assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2950,6 +2959,18 @@ msgstr ""
 "PII som navne, e-mailadresser og identificerende metadata."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3077,8 +3098,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere "
-"premium-beskyttelse med vores abonnement."
+"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere premium-"
+"beskyttelse med vores abonnement."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3840,7 +3861,8 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr ""
+"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4192,8 +4214,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
-"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
+"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4326,7 +4348,8 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr ""
+"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4776,8 +4799,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
-"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
+"trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5677,7 +5700,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr "Opretter en kopi af chatten, der kan ses og gemmes af alle, der åbner linket."
+msgstr ""
+"Opretter en kopi af chatten, der kan ses og gemmes af alle, der åbner linket."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6216,7 +6240,8 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr ""
+"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6348,7 +6373,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6497,6 +6523,12 @@ msgid "Dislike source"
 msgstr "Kan ikke lide kilden"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Afvis"
@@ -6607,6 +6639,12 @@ msgid "Djibouti"
 msgstr "Djibouti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6692,8 +6730,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
-"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
+"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6702,8 +6740,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
-"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
+"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7102,12 +7140,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med "
-"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
-"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
-"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
-"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
-"direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
+"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
+"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
+"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
+"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7173,8 +7210,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
-"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
+"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -7337,7 +7374,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr ""
+"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7885,7 +7923,8 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr ""
+"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8009,7 +8048,8 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr ""
+"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8269,7 +8309,8 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr ""
+"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8463,6 +8504,12 @@ msgid "Fast"
 msgstr "Hurtig"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8507,8 +8554,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8517,8 +8564,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og "
-"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
+"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8615,7 +8662,8 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr ""
+"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8788,6 +8836,12 @@ msgid "Follow-ups remain private."
 msgstr "Opfølgninger forbliver private."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8921,7 +8975,8 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr ""
+"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9461,8 +9516,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede "
-"AI-modeller med højere chatgrænser og flere premium-beskyttelser."
+"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede AI-"
+"modeller med højere chatgrænser og flere premium-beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9525,8 +9580,8 @@ msgstr "Hent appen"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
-"YouTube.%2$s"
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9585,9 +9640,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed › Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
+"› Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9596,9 +9651,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9608,9 +9663,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9620,9 +9675,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
-"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
-"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
+"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
+"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9725,6 +9780,12 @@ msgstr "Godt design"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "God privatlivspolitik"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10563,7 +10624,8 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr ""
+"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10868,6 +10930,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Billedprompter skal overholde Duck.ai's %1$s."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Billedfliser"
@@ -11004,7 +11072,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr ""
+"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11914,7 +11983,8 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
+msgstr ""
+"Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12139,7 +12209,8 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr ""
+"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13474,11 +13545,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en "
-"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
-"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
-"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
-"og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
+"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
+"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
+"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14749,8 +14819,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
-"browsing-tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
+"tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -15727,6 +15797,12 @@ msgstr "Polsk"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Dårlig formatering"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17850,7 +17926,8 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr ""
+"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18088,8 +18165,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
-"POST-anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
+"anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18554,7 +18631,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr ""
+"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18878,7 +18956,8 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr ""
+"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19445,7 +19524,8 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr ""
+"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19466,7 +19546,8 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr ""
+"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19484,7 +19565,8 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr ""
+"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19582,7 +19664,8 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr ""
+"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19904,7 +19987,8 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr ""
+"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20073,7 +20157,8 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr ""
+"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20109,7 +20194,8 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr ""
+"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -21228,13 +21314,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr ""
+"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21272,7 +21360,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr ""
+"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21424,7 +21513,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr ""
+"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21583,14 +21673,16 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21677,7 +21769,8 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr ""
+"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21756,7 +21849,8 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22048,6 +22142,12 @@ msgstr "For mange resultater fra denne kilde"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "For langsom"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22468,7 +22568,8 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr ""
+"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22488,6 +22589,12 @@ msgstr "Prøv at eksperimentere med modellerne – de kan give forskellige svar.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prøv færre nøgleord."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23054,8 +23161,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
-"https://duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23082,14 +23189,15 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
-"...%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr ""
+"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23196,8 +23304,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et "
-"DuckDuckGo-abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23236,7 +23344,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr ""
+"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23467,7 +23576,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr ""
+"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23577,7 +23687,8 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr ""
+"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23895,10 +24006,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
-"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
-"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
-"gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
+"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
+"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23950,7 +24060,8 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr ""
+"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24181,7 +24292,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr ""
+"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24397,7 +24509,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr ""
+"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24441,7 +24554,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr ""
+"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24604,7 +24718,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr ""
+"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24695,13 +24810,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr ""
+"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr ""
+"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24738,10 +24855,9 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på "
-"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
-"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
-"erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
+"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
+"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24826,7 +24942,8 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr ""
+"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -24968,7 +25085,8 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr ""
+"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25085,7 +25203,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr ""
+"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25303,7 +25422,8 @@ msgstr ""
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr "Når chathistorik er slået til, gemmes dine seneste chats på denne enhed."
+msgstr ""
+"Når chathistorik er slået til, gemmes dine seneste chats på denne enhed."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25588,7 +25708,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr ""
+"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25884,7 +26005,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr ""
+"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25979,14 +26101,16 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr ""
+"Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr ""
+"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26173,7 +26297,8 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr ""
+"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26187,8 +26312,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26196,8 +26321,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
-"AI-modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26315,8 +26440,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
-"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
+"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/da_DK/LC_MESSAGES/duckduckgo.po
+++ b/locales/da_DK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -314,8 +314,7 @@ msgstr "Rangeringer for %1$s er endnu ikke tilgængelige"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
+msgstr "%1$s når brugsgrænserne 2-5 gange hurtigere end grundlæggende modeller. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -451,8 +450,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
+msgstr "%1$sKlik %2$sTilføj%3$sTjek %4$sTillad%5$s, og klik derefter på %6$sOkay%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -514,8 +512,7 @@ msgstr "%1$sLæs mere%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
+msgstr "%1$sLæs mere%2$s om, hvordan chats gemmes privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -884,8 +881,7 @@ msgstr "Grænsen på 6 timers brug er nået."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
+msgstr "Grænsen på 6 timers brug er nået. Du kan fortsætte denne chat efter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -956,16 +952,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af AI Chat er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
+msgstr "En ny version af Duck.ai er tilgængelig! Opdater denne side for at fortsætte."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1899,8 +1893,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
+msgstr "Alle modeludbydere er forhindret i at træne deres AI på jeres samtaler."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2213,8 +2206,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. f."
-"eks. Fortæl mig altid fakta om ænder"
+"Eventuelle yderligere instruktioner, du vil have Duck.ai til at følge. "
+"f.eks. Fortæl mig altid fakta om ænder"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2320,8 +2313,7 @@ msgstr "Er du der stadig?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette alle dine chats? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2333,8 +2325,7 @@ msgstr "Er du sikker på, at du vil rydde denne samtale og starte en ny?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
+msgstr "Er du sikker på, at du vil slette denne chat? Dette kan ikke fortrydes."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2541,8 +2532,8 @@ msgstr ""
 "skal vises: Aldrig (fjerner Assist UI fra søgeresultaterne), On-demand "
 "(viser kun AI-assisterede svar, hvis du klikker på knappen Assist), Nogle "
 "gange (viser kun AI-assisterede svar, når det er yderst relevant) eller Ofte "
-"(vises oftere på en bredere række af søgninger). Indtil videre er AI-"
-"assisterede svar kun tilgængelige i USA (engelsk)."
+"(vises oftere på en bredere række af søgninger). Indtil videre er "
+"AI-assisterede svar kun tilgængelige i USA (engelsk)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2969,6 +2960,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Før denne rapport gemmes, fjerner DuckDuckGo uploadede filer og genererede "
+"billeder og anonymiserer din samtale ved at fjerne PII som navne, "
+"e-mailadresser og identificerende metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3098,8 +3092,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere premium-"
-"beskyttelse med vores abonnement."
+"Blokér skadelige hjemmesider, skjul din IP-adresse, og få mere "
+"premium-beskyttelse med vores abonnement."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3861,8 +3855,7 @@ msgstr "Ændrer den måde, URL-resultaterne vises på"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
+msgstr "Ændrer den måde overskriften vises på, samt dens opførsel, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4214,8 +4207,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i Duck."
-"ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
+"Chats med %1$s har nul udbydersynlighed, men alle filer, der uploades i "
+"Duck.ai, gennemgås anonymt af en indholdsmodereringsudbyder for %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4348,8 +4341,7 @@ msgstr "Vælg mellem flere AI-modeller, herunder %1$s og %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
+msgstr "Vælg %1$sbehold den%2$s for at fortsætte med at beskytte dit privatliv."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4799,8 +4791,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
 "Klik eller tryk på %1$sSlet mine oplysninger%2$s. Dette fjerner "
-"oplysningerne fra skyen, men de forbliver i din browser, indtil du klikker/"
-"trykker på %3$sNulstil alle indstillinger%4$s."
+"oplysningerne fra skyen, men de forbliver i din browser, indtil du "
+"klikker/trykker på %3$sNulstil alle indstillinger%4$s."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -5700,8 +5692,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr ""
-"Opretter en kopi af chatten, der kan ses og gemmes af alle, der åbner linket."
+msgstr "Opretter en kopi af chatten, der kan ses og gemmes af alle, der åbner linket."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6240,8 +6231,7 @@ msgstr "Vil du slette de ældste chats for at frigøre lagerplads?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
+msgstr "Vil du slette de ældste chats med vedhæftede filer for at frigøre lagerplads?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6373,8 +6363,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Diktering er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6526,7 +6515,7 @@ msgstr "Kan ikke lide kilden"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Kan ikke lide den visuelle stil"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6642,7 +6631,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Følger ikke instruktionerne"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6730,8 +6719,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen AI-"
-"funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? %1$snoai.duckduckgo.com%2$s tilbyder ingen "
+"AI-funktioner, og AI-billeder filtreres fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6740,8 +6729,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden AI-"
-"funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
+"Vil du ikke have AI? Besøg %1$snoai.duckduckgo.com%2$s for at søge uden "
+"AI-funktioner og med AI-billeder filtreret fra. %3$sLæs mere%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7140,11 +7129,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai giver dig mulighed for at have anonyme samtaler med tredjeparts-AI-"
-"chatmodeller, herunder modeller fra OpenAI, Anthropic og andre. Hvis du "
-"deaktiverer denne indstilling, vil Duck.ai-knapper og -links blive skjult på "
-"DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, når denne "
-"indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s direkte."
+"Duck.ai giver dig mulighed for at have anonyme samtaler med "
+"tredjeparts-AI-chatmodeller, herunder modeller fra OpenAI, Anthropic og "
+"andre. Hvis du deaktiverer denne indstilling, vil Duck.ai-knapper og -links "
+"blive skjult på DuckDuckGo Search. Du kan dog stadig få adgang til Duck.ai, "
+"når denne indstilling er slået fra, ved at besøge %1$shttps://duck.ai%2$s "
+"direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7210,8 +7200,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privat AI-chatbot, gratis AI-chat, anonym AI-chat, "
-"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source AI-"
-"modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
+"AI-chat uden tilmelding, OpenAI, Anthropic, Llama, Mistral, open-source "
+"AI-modeller, fortrolighedsfokuseret AI, privatlivsfokuseret AI, AI-chat uden "
 "konto"
 
 # smartling.placeholder_format=C
@@ -7374,8 +7364,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
+msgstr "DuckDuckGo AI Chat er midlertidigt utilgængelig. Opdater siden og prøv igen."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7923,8 +7912,7 @@ msgstr "Aktivér diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
+msgstr "Aktivér placeringsindstillinger på din enhed for at bruge anonym placering"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8048,8 +8036,7 @@ msgstr "Kan du lide Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
+msgstr "Sørg for, at %1$s\"Tillad\"%2$s er valgt til indstillingen \"Placering\"."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8309,8 +8296,7 @@ msgstr "Forklar det accepterede svar i simple termer."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
+msgstr "Forklar de grundlæggende begreber om sorte huller for mig på gymnasieniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8507,7 +8493,7 @@ msgstr "Hurtig"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Hurtig billedgenerering"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8554,8 +8540,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8564,8 +8550,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"Feedback som din har direkte indflydelse på vores produktopdateringer og -"
-"forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
+"Feedback som din har direkte indflydelse på vores produktopdateringer og "
+"-forbedringer. Forhåbentlig kan vi også løse det problem, du delte."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8662,8 +8648,7 @@ msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
+msgstr "Filtrerer AI-genererede billeder fra billedsøgeresultater. %1$sLæs mere%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8839,7 +8824,7 @@ msgstr "Opfølgninger forbliver private."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Fulgte instruktionerne"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8887,7 +8872,7 @@ msgstr "Formateringsproblemer"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Fouls"
-msgstr "Frispark"
+msgstr "Forseelser"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: fours full name (tooltip)
@@ -8975,8 +8960,7 @@ msgstr "Gratis at dele og bruge kommercielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
+msgstr "Frigør plads ved at slette dine chats. Fastgjorte chats bliver ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9516,8 +9500,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede AI-"
-"modeller med højere chatgrænser og flere premium-beskyttelser."
+"Få vores hurtige VPN uden logfiler, valgfri adgang til avancerede "
+"AI-modeller med højere chatgrænser og flere premium-beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9580,8 +9564,8 @@ msgstr "Hent appen"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på YouTube."
-"%2$s"
+"Hent den gratis DuckDuckGo-browser %1$sfor at blokere annoncer på "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9640,9 +9624,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden enhed "
-"› Kopiér tekstkode%4$s"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed › Kopiér tekstkode%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9651,9 +9635,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s"
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9663,9 +9647,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s, og scan denne kode:"
+"Gå til %1$sDuck.ai-indstillinger%2$s i din anden browser, eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s, og scan denne kode:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9675,9 +9659,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller DuckDuckGo-"
-"appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en anden "
-"enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
+"Gå til %1$sDuck.ai-Indstillinger%2$s i din anden browser eller "
+"DuckDuckGo-appen, og gå til %3$sChats › Sync & Backup › Synkroniser med en "
+"anden enhed%4$s. Eller scan QR-koden på din gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9785,7 +9769,7 @@ msgstr "God privatlivspolitik"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "God visuel stil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10624,8 +10608,7 @@ msgstr "Hvor tit vil du have, at AI-assisterede svar skal dukke op?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
+msgstr "Hvor meget af dine daglige og ugentlige grænser du har brugt indtil videre."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10933,7 +10916,7 @@ msgstr "Billedprompter skal overholde Duck.ai's %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Billedkvalitet"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11072,8 +11055,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
+msgstr "Vælg %1$sVærktøjer%2$s i menuen i toppen af siden > %3$sIndstillinger%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11983,8 +11965,7 @@ msgstr "Lader dig søge anonymt på internettet med DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
+msgstr "Lader dig skifte mellem at indsende søgeforespørgsler og prompter til Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12209,8 +12190,7 @@ msgstr "Indlæser flere billedresultater, mens du scroller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
+msgstr "Indlæser flere resultater i billeder, videoer og shopping, når du scroller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13545,10 +13525,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nye prompter og svar krypteres og gemmes midlertidigt på en DuckDuckGo-"
-"server efter afsendelse for at hjælpe med at gendanne en chat, hvis du "
-"mister din internetforbindelse. Deaktivering af chathistorikken sletter "
-"fastgjorte chats og deaktiverer midlertidig lagring af nye prompter og svar."
+"Nye prompter og svar krypteres og gemmes midlertidigt på en "
+"DuckDuckGo-server efter afsendelse for at hjælpe med at gendanne en chat, "
+"hvis du mister din internetforbindelse. Deaktivering af chathistorikken "
+"sletter fastgjorte chats og deaktiverer midlertidig lagring af nye prompter "
+"og svar."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14819,8 +14800,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"Andre søgemaskiner sporer dine søgninger, selv når du er i privat browsing-"
-"tilstand. Vi sporer dig ikke – punktum."
+"Andre søgemaskiner sporer dine søgninger, selv når du er i privat "
+"browsing-tilstand. Vi sporer dig ikke – punktum."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -15802,7 +15783,7 @@ msgstr "Dårlig formatering"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Dårlig billedkvalitet"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17926,8 +17907,7 @@ msgstr "Rul ned til %1$sDuckDuckGo%2$s, og lad den bruge din placering."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
+msgstr "Scroll ned til sektionen %1$sTjenester%2$s, og klik på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18165,8 +18145,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge POST-"
-"anmodninger)"
+"Søgeforespørgsler indgår i URL (hvis slået fra, vil søgninger bruge "
+"POST-anmodninger)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18631,8 +18611,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
+msgstr "Vælg %1$sdin browser%2$s på listen, og %3$stillad%4$s placeringssadgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18956,8 +18935,7 @@ msgstr "Del"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
+msgstr "Del DuckDuckGo, og hjælp dine venner med at få deres privatliv tilbage!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19524,8 +19502,7 @@ msgstr "Viser vandrette linjer ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
+msgstr "Viser links til vejledning i, hvordan du føjer DuckDuckGo til din browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19546,8 +19523,7 @@ msgstr "Viser lejlighedsvise påmindelser om at føje DuckDuckGo til din browser
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
+msgstr "Viser lejlighedsvise påmindelser om at tilføje DuckDuckGo til dine enheder"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19565,8 +19541,7 @@ msgstr "Vis sidenumre ved resultat-sideskift"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
+msgstr "Vis tilmeldingsformular til DuckDuckGos nyhedsbreve om privatlivets fred"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19664,8 +19639,7 @@ msgstr "Navne på websteder"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
+msgstr "Webstedssøgning er midlertidigt utilgængelig. Vi arbejder på en løsning."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19987,8 +19961,7 @@ msgstr "Kildetekst ryddet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
+msgstr "Kildeteksten er for lang til at opsummere. Prøv igen med et kortere valg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20157,8 +20130,7 @@ msgstr "Start med et billede"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
+msgstr "Hvis du starter forfra, vil alle dine tidligere samtaler blive slettet."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20194,8 +20166,7 @@ msgstr "Bliv på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
+msgstr "Beskyt dig, og hold dig informeret med vores nyhedsbrev om privatlivets fred."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -21314,15 +21285,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
+msgstr "De vedhæftede filer overstiger grænsen for den samlede størrelse på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21360,8 +21329,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
+msgstr "Modeludbyderen gemmer ikke denne chat eller tilknyttede data på sine servere."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21513,8 +21481,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
+msgstr "Dette Øjeblikkeligt svar er leveret af fællesskabet %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21673,16 +21640,14 @@ msgstr "Dette billede kunne ikke oprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
+msgstr "Denne billedtype understøttes ikke. Vedhæft en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21769,8 +21734,7 @@ msgstr "Denne side kræver JavaScript for at kunne fungere."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
+msgstr "Indholdet af denne side vil blive sendt sammen med din besked til Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21849,8 +21813,7 @@ msgstr "Denne oversættelse er forkert"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
+msgstr "Videoen er endnu ikke tilgængelig til visning her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22147,7 +22110,7 @@ msgstr "For langsom"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "For langsom til at generere"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22568,8 +22531,7 @@ msgstr "Prøv andre nøgleord."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
+msgstr "Prøv at deaktivere din adblocker på DuckDuckGo for at se flere resultater."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22594,7 +22556,7 @@ msgstr "Prøv færre nøgleord."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23161,8 +23123,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: https://"
-"duckduckgo.com"
+"Under %1$sVed opstart%2$s, vælg %3$sStartside%4$s og indtast: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23189,15 +23151,14 @@ msgstr "Under %1$sSøg i adressefeltet med%2$s vælger du %3$sTilføj ny%4$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner ..."
-"%4$s"
+"Under %1$sSøge%2$s-sektionen klikker du på %3$sAdministrer søgemaskiner "
+"...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
+msgstr "Under \"Ved opstart\" vælger du %1$sÅbn en bestemt side eller sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23304,8 +23265,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås op for avancerede AI-modeller og højere grænser med et DuckDuckGo-"
-"abonnement"
+"Lås op for avancerede AI-modeller og højere grænser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23344,8 +23305,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
+msgstr "Få adgang til mere avancerede AI-modeller med et DuckDuckGo-abonnement. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23576,8 +23536,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
+msgstr "Opgrader til Pro for at låse op for dobbelt så høje forbrugsgrænser som Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23687,8 +23646,7 @@ msgstr "Brug DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
+msgstr "Brug DuckDuckGo Private Search på din iPad, iPhone eller Android-enhed!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24006,9 +23964,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn Duck.ai-"
-"indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg \"Synkroniser "
-"med en anden enhed\". Eller scan QR-koden på din gendannelses-PDF."
+"Besøg Duck.ai i din anden browser eller DuckDuckGo-appen, og åbn "
+"Duck.ai-indstillinger. Vælg \"Slå til\" under Sync & Backup, og vælg "
+"\"Synkroniser med en anden enhed\". Eller scan QR-koden på din "
+"gendannelses-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24060,8 +24019,7 @@ msgstr "Stemmesamtale afsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
+msgstr "Stemmechat er anonymiseret af os og bruges aldrig til at træne AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24292,8 +24250,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
+msgstr "Vi kan ikke læse de vedhæftede filer, fordi mindst én af dem er krypteret."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24509,8 +24466,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
+msgstr "Vi blokerer trackere, der forsøger at indsamle dine data, mens du browser."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24554,8 +24510,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
+msgstr "Vi beklager ulejligheden. Vi arbejder hårdt på at gøre din oplevelse bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24718,8 +24673,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
+msgstr "Velkommen til det nye Duck.ai! Du kan nu importere dine downloadede chats."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24810,15 +24764,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
+msgstr "Hvad er nogle faktorer, der skal overvejes, når man køber en computerskærm?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
+msgstr "Hvad er nogle must-see attraktioner i Paris for en førstegangsbesøgende?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24855,9 +24807,10 @@ msgid ""
 msgstr ""
 "Hvad er fordelene ved at downloade DuckDuckGo-browseren, hvis du er "
 "interesseret i at bruge Duck.ai? Referer kun officielle DuckDuckGo-kilder. "
-"Opdel svaret i klare sektioner med titler, med fokus på Duck.ai-"
-"integrationer og beskyttelse af privatlivet. Hold det kort, enkelt og "
-"letforståeligt for folk med eller uden betydelig AI- eller teknisk erfaring."
+"Opdel svaret i klare sektioner med titler, med fokus på "
+"Duck.ai-integrationer og beskyttelse af privatlivet. Hold det kort, enkelt "
+"og letforståeligt for folk med eller uden betydelig AI- eller teknisk "
+"erfaring."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24942,8 +24895,7 @@ msgstr "Hvilke retter bør man prøve her?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
+msgstr "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25085,8 +25037,7 @@ msgstr "Hvilke informationer bliver gemt?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
+msgstr "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25203,8 +25154,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
+msgstr "Når funktionen er aktiveret, vil Duck.ai vise Øjeblikkeligt svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25422,8 +25372,7 @@ msgstr ""
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
-"Når chathistorik er slået til, gemmes dine seneste chats på denne enhed."
+msgstr "Når chathistorik er slået til, gemmes dine seneste chats på denne enhed."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25708,8 +25657,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
+msgstr "Du chatter med %1$s. AI-chats kan vise unøjagtige eller stødende oplysninger."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -26005,8 +25953,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
+msgstr "Du vil ikke se denne meddelelse igen, medmindre du rydder dine browserdata."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26101,16 +26048,14 @@ msgstr "Du har nået det maksimale antal beskeder for nu. Prøv igen senere."
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Du har nået den maksimale varighed af stemmechat for en enkelt session."
+msgstr "Du har nået den maksimale varighed af stemmechat for en enkelt session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
+msgstr "Du har nået grænsen for stemmechat for i dag. Prøv venligst igen i morgen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26297,8 +26242,7 @@ msgstr "Dine chats bliver nu gemt."
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
+msgstr "Dine chats er private og hverken gemmes eller bruges til at træne AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26312,8 +26256,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26321,8 +26265,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Dine chats er private, anonymiseret af os, og bruges ikke til at træne AI-"
-"modeller."
+"Dine chats er private, anonymiseret af os, og bruges ikke til at træne "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26440,8 +26384,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure Hash-"
-"algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
+"Dit adgangsudtryk genererer en 512-bit-nøgle ved hjælp af Secure "
+"Hash-algoritmen kendt som %1$sSHA-2%2$s. Kun nøglen og den tilhørende "
 "indstillingsfil forlader din browser. Vi gemmer indstillingsfilen ved at "
 "bruge nøglen som navnet. DuckDuckGo får aldrig dit adgangsudtryk at vide."
 

--- a/locales/de_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_CH/LC_MESSAGES/duckduckgo.po
@@ -2380,6 +2380,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5245,6 +5256,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Ablehnen"
@@ -5334,6 +5350,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6792,6 +6813,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7048,6 +7074,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7797,6 +7828,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8726,6 +8762,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12675,6 +12716,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17749,6 +17795,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18108,6 +18159,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Versuche es mit weniger Suchbegriffen."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1335,8 +1335,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1991,8 +1990,7 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2341,8 +2339,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2554,13 +2551,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
-"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
-"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
-"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
-"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
-"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
-"(Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
+"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
+"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
+"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
+"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
+"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
+"Antworten nur in den USA (Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2572,8 +2569,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
-"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
+"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2741,8 +2738,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2816,8 +2812,7 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -3000,6 +2995,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Bevor dieser Bericht gespeichert wird, entfernt DuckDuckGo hochgeladene "
+"Dateien und generierte Bilder und anonymisiert deinen Chat, indem "
+"personenbezogene Daten wie Namen, E-Mail-Adressen und identifizierende "
+"Metadaten entfernt werden."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3135,8 +3134,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3152,8 +3150,7 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3411,9 +3408,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
-"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
-"wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
+"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
+"%1$sdie wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3499,8 +3496,7 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3521,11 +3517,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
-"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
-"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
-"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
-"Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen "
+"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
+"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
+"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
+"gespeichert und die Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3581,8 +3577,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3924,8 +3919,7 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4056,8 +4050,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
-"ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4215,9 +4209,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
-"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
-"angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
+"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4230,11 +4224,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
-"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
-"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
-"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
-"Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
+"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
+"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
+"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
+"Speicherung neuer Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4257,8 +4251,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
-"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
+"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4392,8 +4386,7 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -6005,8 +5998,7 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6340,8 +6332,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6363,8 +6354,7 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6433,8 +6423,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6586,7 +6576,7 @@ msgstr "Abneigung gegen Quelle"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Der visuelle Stil gefällt mir nicht"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6702,7 +6692,7 @@ msgstr "Dschibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Befolgt die Anweisungen nicht"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6802,8 +6792,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
-"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
+"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -7211,10 +7201,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
-"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
-"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
-"duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
+"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
+"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
+"%1$shttps://duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7408,8 +7398,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7418,8 +7408,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
-"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
+"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -8165,8 +8155,7 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr ""
-"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8292,8 +8281,7 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8401,8 +8389,7 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8599,7 +8586,7 @@ msgstr "Schnell"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Schnelle Bildgenerierung"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8921,8 +8908,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8939,7 +8925,7 @@ msgstr "Folgemitteilungen bleiben privat."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Anweisungen befolgt"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9045,8 +9031,7 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9159,9 +9144,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
-"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
-"<strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac "
+"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
+"und dann <strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9529,8 +9514,7 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr ""
-"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
@@ -9566,8 +9550,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9578,9 +9562,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
-"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
-"Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
+"KI-Modellen in Duck.ai, das auch unser VPN und andere "
+"Premium-Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9783,9 +9767,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
-"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
-"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
+"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
+"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -9894,7 +9878,7 @@ msgstr "Gute Datenschutzerklärung"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Guter visueller Stil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10338,15 +10322,13 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10358,8 +10340,7 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10565,8 +10546,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
-"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
+"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10892,8 +10873,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
-"Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
+"Bücher/Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10968,9 +10949,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
-"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
-"und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
+"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
+"%1$s und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -11008,8 +10989,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
-"Tabs« (öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
+"(öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -11052,7 +11033,7 @@ msgstr "Bildaufforderungen müssen mit den %1$s von Duck.ai übereinstimmen."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Bildqualität"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11544,8 +11525,7 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr ""
-"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -13587,8 +13567,7 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr ""
-"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -14001,8 +13980,7 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14696,8 +14674,7 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14854,8 +14831,7 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15477,8 +15453,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
-"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die "
+"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15502,8 +15478,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
-"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
+"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15949,7 +15925,7 @@ msgstr "Schlechte Formatierung"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Schlechte Bildqualität"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17126,8 +17102,7 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17888,8 +17863,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
-"Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
+"Ende-zu-Ende-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17931,8 +17906,7 @@ msgstr "Sag Hallo zu Duck.ai!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
+msgstr "Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18042,8 +18016,7 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18328,8 +18301,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
-"Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
+"POST-Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18439,8 +18412,7 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18449,8 +18421,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18459,8 +18431,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18469,9 +18441,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
-"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
-"darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
+"Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18480,16 +18452,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
-"Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit "
+"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18498,8 +18470,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
-"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit "
+"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
+"einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18616,8 +18589,7 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18644,8 +18616,7 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18671,15 +18642,13 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -19134,8 +19103,7 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19163,8 +19131,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
-"Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
+"KI-Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19443,8 +19411,7 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19629,8 +19596,7 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
+msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19778,8 +19744,7 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19858,8 +19823,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -20079,8 +20043,7 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20356,8 +20319,7 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20394,8 +20356,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
-"Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren "
+"Privatsphäre-Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20450,8 +20412,7 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20673,8 +20634,7 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr ""
-"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -21506,8 +21466,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Mit dem Duck.ai-Umschalter kannst du schnell zwischen privater Suche und KI-"
-"Chat wechseln, anonymisiert von DuckDuckGo."
+"Mit dem Duck.ai-Umschalter kannst du schnell zwischen privater Suche und "
+"KI-Chat wechseln, anonymisiert von DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21523,8 +21483,7 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21556,8 +21515,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21724,8 +21682,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21758,8 +21715,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
-"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
+"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -22016,8 +21973,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -22028,9 +21985,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
-"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
-"auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
+"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
+"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -22075,8 +22032,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22194,8 +22150,7 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22377,7 +22332,7 @@ msgstr "Zu langsam"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Generierung zu langsam"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22665,8 +22620,7 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22828,7 +22782,7 @@ msgstr "Versuche, weniger Stichworte zu benutzen."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Kostenlos testen"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22874,8 +22828,7 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22949,8 +22902,7 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22996,8 +22948,7 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -23021,8 +22972,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -23059,9 +23009,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
-"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
-"erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
+"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
+"%3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -23187,8 +23137,7 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23211,8 +23160,7 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23409,8 +23357,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
-"duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
+"https://duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23442,8 +23390,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23560,8 +23507,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
-"Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
+"DuckDuckGo-Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23600,8 +23547,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -24007,8 +23953,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24331,8 +24276,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
-"Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
+"KI-Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24485,8 +24430,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
-"Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die "
+"YouTube-Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24633,8 +24578,7 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24675,8 +24619,7 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24693,8 +24636,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"Wir finden und entfernen deine personenbezogenen Daten von Datenbroker-"
-"Websites. Hol dir zusätzlich ein VPN und mehr."
+"Wir finden und entfernen deine personenbezogenen Daten von "
+"Datenbroker-Websites. Hol dir zusätzlich ein VPN und mehr."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24716,8 +24659,7 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr ""
-"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -24769,8 +24711,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -25142,11 +25083,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
-"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
-"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
-"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
-"oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
+"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
+"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
+"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
+"Menschen mit oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25231,8 +25172,7 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -26078,8 +26018,7 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26390,8 +26329,7 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr ""
-"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -26484,16 +26422,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
+msgstr "Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
+msgstr "Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26727,8 +26663,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26826,8 +26761,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren."
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26837,8 +26772,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
-"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
+"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26852,8 +26787,7 @@ msgstr "Deine geteilten Links befinden sich in %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/de_DE/LC_MESSAGES/duckduckgo.po
+++ b/locales/de_DE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1335,7 +1335,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
+msgstr ""
+"Werbungsklicks werden nicht verwendet, um ein Profil von dir zu erstellen"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1990,7 +1991,8 @@ msgstr "Anonyme Dateiüberprüfung für diesen Chat erlauben?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
+msgstr ""
+"Lass datenschutzfreundliche Werbung in der Private Search von DuckDuckGo zu"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2339,7 +2341,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
+msgstr ""
+"Möchtest du diese Konversation wirklich löschen und eine neue beginnen?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2551,13 +2554,13 @@ msgid ""
 msgstr ""
 "Assist kann anonym KI-gestützte Antworten auf einige Suchanfragen "
 "generieren, die auf der Zusammenfassung relevanter Webinhalte basieren. Du "
-"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die "
-"Assist-Benutzeroberfläche wird vollständig aus den Suchergebnissen "
-"entfernt), Bei Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du "
-"auf die Assist-Schaltfläche klickst), Manchmal (KI-gestützte Antworten "
-"werden nur bei hoher Relevanz angezeigt) oder Oft (werden häufiger bei einer "
-"größeren Anzahl von Suchanfragen angezeigt). Derzeit sind KI-gestützte "
-"Antworten nur in den USA (Englisch) verfügbar."
+"kannst auswählen, wie oft Assist angezeigt werden soll: Nie (die Assist-"
+"Benutzeroberfläche wird vollständig aus den Suchergebnissen entfernt), Bei "
+"Bedarf (KI-gestützte Antworten werden nur angezeigt, wenn du auf die Assist-"
+"Schaltfläche klickst), Manchmal (KI-gestützte Antworten werden nur bei hoher "
+"Relevanz angezeigt) oder Oft (werden häufiger bei einer größeren Anzahl von "
+"Suchanfragen angezeigt). Derzeit sind KI-gestützte Antworten nur in den USA "
+"(Englisch) verfügbar."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2569,8 +2572,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym "
-"KI-gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
+"Assist ist eine optionale Funktion in unseren Suchergebnissen, die anonym KI-"
+"gestützte Antworten auf Suchanfragen generieren kann. Dazu durchsucht sie "
 "das Internet nach relevanten Inhalten und verwendet dann KI-gestützte "
 "natürliche Sprachtechnologie, um eine kurze Antwort auf der Grundlage der "
 "gefundenen relevanten Informationen zu generieren. Es ist wichtig, zu "
@@ -2738,7 +2741,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
+msgstr ""
+"Automatisch generiert basierend auf Quellen. Kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2812,7 +2816,8 @@ msgstr "Durchschn. Vol."
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
+msgstr ""
+"Vermeide das Hochladen von Dateien aus Quellen, denen du nicht vertraust."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2985,6 +2990,18 @@ msgstr ""
 "Metadaten entfernt werden."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3118,7 +3135,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
+msgstr ""
+"Die Blockliste ist nicht vollständig und kann Ungenauigkeiten enthalten."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3134,7 +3152,8 @@ msgstr "Diese Seite in allen Ergebnissen blockieren"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
+msgstr ""
+"Blockiere Tracker und übernimm die Kontrolle über deine persönlichen Daten"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3392,9 +3411,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, "
-"Tracker-Blockade, und Website-Verschlüsselung – alles in einem Download, für "
-"%1$sdie wichtigsten Browser%2$s."
+"Surfe wie immer und wir kümmern uns um den Rest: Private Suche, Tracker-"
+"Blockade, und Website-Verschlüsselung – alles in einem Download, für %1$sdie "
+"wichtigsten Browser%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3480,7 +3499,8 @@ msgstr "Indem du auf „%1$s“ klickst, akzeptierst du unsere %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
+msgstr ""
+"Indem du auf „%1$s“ klickst, akzeptierst du die %2$s und %3$s von Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3501,11 +3521,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"Normalerweise werden die Einstellungen in nicht personenbezogenen "
-"Browser-Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save "
-"lassen sich Einstellungen dauerhafter sichern (auf einem Remote-Server in "
-"der Cloud). Es werden dabei keine personenbezogenen Daten in der Cloud "
-"gespeichert und die Passphrase verlässt nie den eigenen Browser."
+"Normalerweise werden die Einstellungen in nicht personenbezogenen Browser-"
+"Cookies gespeichert (im eigenen Browser). Im anonymen Cloud Save lassen sich "
+"Einstellungen dauerhafter sichern (auf einem Remote-Server in der Cloud). Es "
+"werden dabei keine personenbezogenen Daten in der Cloud gespeichert und die "
+"Passphrase verlässt nie den eigenen Browser."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3561,7 +3581,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
+msgstr ""
+"Kannst du ein paar einfache Rezepte mit Hühnchen, Brokkoli und Reis kreieren?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3903,7 +3924,8 @@ msgstr ""
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
+msgstr ""
+"Ändert die Hintergrundfarbe, wenn du den Mauszeiger über ein Ergebnis bewegst"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4034,8 +4056,8 @@ msgstr ""
 "KI-Chatmodellen von Drittanbietern zu führen, etwa OpenAI oder Anthropic. "
 "Wenn du diese Einstellung deaktivierst, werden Chat-Schaltflächen und -Links "
 "in DuckDuckGo Search ausgeblendet. Du kannst jedoch auch dann auf den Chat "
-"zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://duck."
+"ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4193,9 +4215,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf "
-"DuckDuckGo-Servern oder Remote-Servern. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht."
+"Chats werden lokal auf deinem Gerät gespeichert, anstatt auf DuckDuckGo-"
+"Servern oder Remote-Servern. Wenn du den Chatverlauf deaktivierst, werden "
+"angeheftete Chats gelöscht."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4208,11 +4230,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "Chats werden lokal auf deinem Gerät gespeichert. Neue Prompts und Antworten "
-"werden verschlüsselt und nach dem Senden vorübergehend auf einem "
-"DuckDuckGo-Server gespeichert, damit du einen Chat wiederherstellen kannst, "
-"falls deine Internetverbindung unterbrochen wird. Wenn du den Chatverlauf "
-"deaktivierst, werden angeheftete Chats gelöscht und die vorübergehende "
-"Speicherung neuer Aufforderungen und Antworten deaktiviert."
+"werden verschlüsselt und nach dem Senden vorübergehend auf einem DuckDuckGo-"
+"Server gespeichert, damit du einen Chat wiederherstellen kannst, falls deine "
+"Internetverbindung unterbrochen wird. Wenn du den Chatverlauf deaktivierst, "
+"werden angeheftete Chats gelöscht und die vorübergehende Speicherung neuer "
+"Aufforderungen und Antworten deaktiviert."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4235,8 +4257,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in "
-"Duck.ai hochgeladenen Dateien werden anonym von einem Anbieter für "
+"Chats mit %1$s haben keine Sichtbarkeit auf Anbieterseite, aber alle in Duck."
+"ai hochgeladenen Dateien werden anonym von einem Anbieter für "
 "Inhaltsmoderation auf %2$s überprüft."
 
 # smartling.placeholder_format=C
@@ -4370,7 +4392,8 @@ msgstr "Auswahl von KI-Modellen, darunter %1$s und %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
+msgstr ""
+"Wähle %1$sBeibehalten%2$s aus, um weiterhin deine Privatsphäre zu schützen."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -5982,7 +6005,8 @@ msgstr "Tageslimit erreicht"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
+msgstr ""
+"Tägliches Nutzungslimit erreicht. Du kannst diesen Chat nach %1$s fortsetzen."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6316,7 +6340,8 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
+msgstr ""
+"Durch das Löschen der Cookies werden diese Einstellungen zurückgesetzt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6338,7 +6363,8 @@ msgstr "Beschreibe die Änderungen basierend auf dem Bild"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
+msgstr ""
+"Beschreibe die Änderungen, um mit der Bearbeitung dieses Bildes fortzufahren."
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6407,8 +6433,8 @@ msgstr "Diktierfunktion in Duck.ai"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Die Diktate werden von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6557,6 +6583,12 @@ msgid "Dislike source"
 msgstr "Abneigung gegen Quelle"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Verwerfen"
@@ -6667,6 +6699,12 @@ msgid "Djibouti"
 msgstr "Dschibuti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6764,8 +6802,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne "
-"KI-Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
+"Du möchtest keine KI? Besuche %1$snoai.duckduckgo.com%2$s um ohne KI-"
+"Funktionen und mit herausgefilterten KI-Bildern zu suchen. %3$sMehr "
 "erfahren%4$s"
 
 # smartling.placeholder_format=C
@@ -7173,10 +7211,10 @@ msgid ""
 msgstr ""
 "Mit Duck.ai kannst du anonyme Unterhaltungen mit KI-Chatmodellen von "
 "Drittanbietern führen, darunter Modelle von OpenAI, Anthropic und anderen. "
-"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und "
-"-Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf "
-"Duck.ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du "
-"%1$shttps://duck.ai%2$s direkt besuchst."
+"Wenn du diese Einstellung deaktivierst, werden Duck.ai-Schaltflächen und -"
+"Links in DuckDuckGo Search ausgeblendet. Du kannst jedoch weiterhin auf Duck."
+"ai zugreifen, wenn diese Einstellung deaktiviert ist, indem du %1$shttps://"
+"duck.ai%2$s direkt besuchst."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7370,8 +7408,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7380,8 +7418,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die "
-"Chat-Modelle %2$s von %1$s und %4$s von %3$s nutzt."
+"DuckDuckGo AI Chat ist ein privater, KI-gestützter Chat-Dienst, der die Chat-"
+"Modelle %2$s von %1$s und %4$s von %3$s nutzt."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -8127,7 +8165,8 @@ msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist"
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure location access is %sallowed%s."
-msgstr "Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Stelle sicher, dass der Zugriff auf den Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8253,7 +8292,8 @@ msgstr "Äquatorialguinea"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
+msgstr ""
+"Lösche deine Browserdaten im Handumdrehen mit unserem %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8361,7 +8401,8 @@ msgstr "Erkläre die akzeptierte Antwort in einfachen Worten."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
+msgstr ""
+"Erkläre mir die grundlegenden Konzepte von Schwarzen Löchern auf Schulniveau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8553,6 +8594,12 @@ msgstr "Spielzeit"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Schnell"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8874,7 +8921,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
+msgstr ""
+"Folge diesen Schritten, um deine Chats auf das neue Duck.ai zu übertragen."
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8886,6 +8934,12 @@ msgstr "Folgefrage"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Folgemitteilungen bleiben privat."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8991,7 +9045,8 @@ msgstr "Kostenlose und private Chats, von uns anonymisiert"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
+msgstr ""
+"Kostenlose und private Chats, von uns anonymisiert. Kein Konto erforderlich."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9104,9 +9159,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Wähle in der Menüleiste der Anwendung auf dem Mac "
-"<strong>DuckDuckGo</strong> &gt; <strong>Nach Updates suchen ...</strong> "
-"und dann <strong>Update installieren</strong>."
+"Wähle in der Menüleiste der Anwendung auf dem Mac <strong>DuckDuckGo</"
+"strong> &gt; <strong>Nach Updates suchen ...</strong> und dann "
+"<strong>Update installieren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9474,7 +9529,8 @@ msgstr ""
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections. Try it for free!"
-msgstr "Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
+msgstr ""
+"Hol dir ein VPN + zwei weitere Schutzmaßnahmen. Probiere es kostenlos aus!"
 
 # smartling.placeholder_format=C
 #. Heading of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market.
@@ -9510,8 +9566,8 @@ msgid ""
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
 "Erhalte Zugang zu den fortschrittlichen KI-Modellen in Duck.ai, indem du "
-"DuckDuckGo abonnierst, was auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"DuckDuckGo abonnierst, was auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9522,9 +9578,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen "
-"KI-Modellen in Duck.ai, das auch unser VPN und andere "
-"Premium-Datenschutzmaßnahmen beinhaltet."
+"Mit einem DuckDuckGo-Abo erhältst du Zugang zu den fortschrittlichen KI-"
+"Modellen in Duck.ai, das auch unser VPN und andere Premium-"
+"Datenschutzmaßnahmen beinhaltet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9727,9 +9783,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu "
-"%1$sDuck.ai-Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit "
-"einem anderen Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
+"Gehe in deinem anderen Browser oder in der DuckDuckGo-App zu %1$sDuck.ai-"
+"Einstellungen%2$s und dann zu %3$sChats › Sync & Backup › Mit einem anderen "
+"Gerät synchronisieren%4$s. Oder scanne den QR-Code auf deinem "
 "Wiederherstellungs-PDF."
 
 # smartling.placeholder_format=C
@@ -9833,6 +9889,12 @@ msgstr "Gutes Design"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Gute Datenschutzerklärung"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10276,13 +10338,15 @@ msgstr "Hilf uns zu verstehen, was wir falsch gemacht haben"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, sich unserer Entenfamilie anzuschließen!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
+msgstr ""
+"Hilf deinen Freunden und Verwandten, ihre Privatsphäre zurückzugewinnen!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10294,7 +10358,8 @@ msgstr "Hilfreich"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
+msgstr ""
+"Hier sind einige Dinge, die wir gemacht haben, die dir gefallen könnten."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10500,8 +10565,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"Achtung! Wenn du die Einstellung zurücksetzt, wird die "
-"DuckDuckGo-Erweiterung deaktiviert und du verlierst unseren Datenschutz."
+"Achtung! Wenn du die Einstellung zurücksetzt, wird die DuckDuckGo-"
+"Erweiterung deaktiviert und du verlierst unseren Datenschutz."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10827,8 +10892,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Ich mag das Buch „Der Name des Windes“. Welche anderen guten "
-"Bücher/Buchreihen ähneln diesem am meisten und warum?"
+"Ich mag das Buch „Der Name des Windes“. Welche anderen guten Bücher/"
+"Buchreihen ähneln diesem am meisten und warum?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10903,9 +10968,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten "
-"Chat-Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an "
-"%1$s und %2$s wenden."
+"Wenn du Bedenken bezüglich unserer Chat-Anbieter oder einer bestimmten Chat-"
+"Antwort hast, kannst du dich auch direkt über ihre Support-Seiten an %1$s "
+"und %2$s wenden."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10943,8 +11008,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue Tabs« "
-"(öffnen mit) aus."
+"Wenn du willst, wähle »Startseite« neben »Neues Fenster« und »Neue "
+"Tabs« (öffnen mit) aus."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10982,6 +11047,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Bildaufforderungen müssen mit den %1$s von Duck.ai übereinstimmen."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11473,7 +11544,8 @@ msgstr "Lohnt es sich, das anzuschauen?"
 #. Prompt sent to the AI when the user taps the "Is this worth watching?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Is this worth watching? Give me a spoiler-free take."
-msgstr "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
+msgstr ""
+"Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -13515,7 +13587,8 @@ msgstr "Niederlande"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when a network error occurs during dictation upload.
 msgid "Network error. Please check your connection and try again."
-msgstr "Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
+msgstr ""
+"Netzwerkfehler. Bitte überprüfe deine Verbindung und versuche es erneut."
 
 # smartling.placeholder_format=C
 #. The title of the 'Never' option in the assist settings modal.
@@ -13928,7 +14001,8 @@ msgstr "Keine Ergebnisse gefunden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
+msgstr ""
+"Keine Sprache erkannt. Bitte versuche es erneut und sprich in dein Mikrofon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14622,7 +14696,8 @@ msgstr "%1$sEinstellungen%2$s öffnen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
+msgstr ""
+"Öffne „Standort“ und stelle sicher, dass der Standort %1$saktiviert%2$s ist."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14779,7 +14854,8 @@ msgstr "Öffne das Bedienfeld „So funktioniert Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
+msgstr ""
+"Öffne das Safari-Menü und wähle %1$sEinstellungen für DuckDuckGo ...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15401,8 +15477,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als vollständigen Fragesatz formulierst, ist es "
 "wahrscheinlicher, dass KI-gestützte Antworten automatisch erscheinen, und du "
-"erhältst oft bessere Antworten. Um sie auszuschalten und die "
-"Assist-Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
+"erhältst oft bessere Antworten. Um sie auszuschalten und die Assist-"
+"Schaltfläche auszublenden, besuche die %1$s-Sucheinstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15426,8 +15502,8 @@ msgid ""
 msgstr ""
 "Wenn du deine Suche als Frage und in einem vollständigen Satz formulierst, "
 "ist es wahrscheinlicher, dass DuckAssist automatisch erscheint, und du "
-"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die "
-"Assist-Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
+"erhältst oft bessere Antworten. Um die Funktion auszuschalten und die Assist-"
+"Taste auszublenden, besuche die %1$sDuckAssist-Einstellungen%2$s."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15868,6 +15944,12 @@ msgstr "Polnisch"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Schlechte Formatierung"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17044,7 +17126,8 @@ msgstr "Meine Auswahl merken"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
+msgstr ""
+"Auswahl merken (kann in den %1$s%2$s%3$sEinstellungen%4$s geändert werden)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17805,8 +17888,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit "
-"Ende-zu-Ende-Verschlüsselung."
+"Speichere deine Duck.ai-Chats zwischen deinen Geräten mit Ende-zu-Ende-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17848,7 +17931,8 @@ msgstr "Sag Hallo zu Duck.ai!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
+msgstr ""
+"Sag Hallo zu Duck.ai – dem kostenlosen, privaten KI-Chat von DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17958,7 +18042,8 @@ msgstr "Scrolle herunter und wähle %1$sErweiterte Einstellungen%2$s aus"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
+msgstr ""
+"Scrolle herunter und klicke auf %1$sErweiterte Einstellungen anzeigen%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18243,8 +18328,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die "
-"POST-Methode verwendet)"
+"Suchanfragen sind Teil der Adresse (wenn ausgeschaltet, wird die POST-"
+"Methode verwendet)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18354,7 +18439,8 @@ msgstr "Zweite Meinung"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
+msgstr ""
+"Speichere und synchronisiere deine Chats sicher auf all deinen Geräten."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18363,8 +18449,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18373,8 +18459,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18383,9 +18469,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen synchronisierten "
-"Geräten darauf zu."
+"Speichere nahezu unbegrenzt viele Chats sicher auf unserem Server mit Ende-"
+"zu-Ende-Verschlüsselung und greife von all deinen synchronisierten Geräten "
+"darauf zu."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18394,16 +18480,16 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Speichere deine Chats sicher auf unserem Server mit "
-"Ende-zu-Ende-Verschlüsselung und greife von all deinen Geräten darauf zu."
+"Speichere deine Chats sicher auf unserem Server mit Ende-zu-Ende-"
+"Verschlüsselung und greife von all deinen Geräten darauf zu."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18412,9 +18498,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Sicher gespeichert auf dem Server von DuckDuckGo mit "
-"End-to-End-Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht "
-"einmal wir."
+"Sicher gespeichert auf dem Server von DuckDuckGo mit End-to-End-"
+"Verschlüsselung. Niemand außer dir kann deine Daten sehen, nicht einmal wir."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18531,7 +18616,8 @@ msgstr "Entdecke einige unserer neuesten Updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
+msgstr ""
+"Mehr Informationen findest du in der %1$sÜbersicht über URL-Parameter%2$s."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18558,7 +18644,8 @@ msgstr "%1$s%2$s%3$s auswählen, dann %4$sSuchmaschine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
+msgstr ""
+"Wähle %1$s„Einstellung für diese Website …“%2$s aus dem Safari-Menü aus."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18584,13 +18671,15 @@ msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
+msgstr ""
+"Wähle %1$sDuckDuckGo%2$s und klicke auf %3$sAls Standard festlegen%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
+msgstr ""
+"Im Dropdown-Menü für die Standardsuchmaschine %1$sDuckDuckGo%2$s auswählen"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -19045,7 +19134,8 @@ msgstr "Teilen"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
+msgstr ""
+"Teile DuckDuckGo und hilf deinen Freunden, ihre Privatsphäre zurück zu holen!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19073,8 +19163,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Teile den Standort in Form der Stadt mit KI-Modellen, um die Relevanz zu "
-"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder "
-"KI-Modelle weiter."
+"verbessern. Duck.ai gibt niemals deinen genauen Standort an uns oder KI-"
+"Modelle weiter."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19353,7 +19443,8 @@ msgstr "DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
+msgstr ""
+"DuckAssist öfter anzeigen. (Du kannst es auch %1$skomplett ausschalten%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19538,7 +19629,8 @@ msgstr "Seitenleiste anzeigen"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
+msgstr ""
+"Schritt-für-Schritt-Tipps anzeigen, um das Beste aus Duck.ai herauszuholen."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19686,7 +19778,8 @@ msgstr "Begrüßung oben auf der Suchergebnisseite anzeigen"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
+msgstr ""
+"Begrüßung für Benutzer des Android-Einstellungsmenüs in der EU wird angezeigt"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19765,7 +19858,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
+msgstr ""
+"Von dir blockierte Websites werden in all deinen Suchergebnissen ausgeblendet"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19985,7 +20079,8 @@ msgstr "Entschuldigung, ein unerwarteter Fehler ist aufgetreten."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
+msgstr ""
+"Leider wurden bei unserer Suche keine relevanten Informationen gefunden."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20261,7 +20356,8 @@ msgstr "Beginne mit einem Bild"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
+msgstr ""
+"Wenn du neu anfängst, werden alle deine bisherigen Unterhaltungen gelöscht."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20298,8 +20394,8 @@ msgstr "Bleib auf DuckDuckGo"
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
 msgstr ""
-"Bleibe gut geschützt und gut informiert – mit unseren "
-"Privatsphäre-Newslettern."
+"Bleibe gut geschützt und gut informiert – mit unseren Privatsphäre-"
+"Newslettern."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20354,7 +20450,8 @@ msgstr "Versteckte Tracker stoppen, die auf anderen Websites lauern."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
+msgstr ""
+"Stoppe die meisten versteckten Tracker, die auf anderen Websites lauern."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20576,7 +20673,8 @@ msgstr "Q&As zusammenfassen"
 #. Prompt sent to the AI when the user taps the "Summarize their background" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Summarize the background and notable work of this person."
-msgstr "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
+msgstr ""
+"Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen."
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the key details?" page-suggestion chip.
@@ -21408,8 +21506,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Mit dem Duck.ai-Umschalter kannst du schnell zwischen privater Suche und "
-"KI-Chat wechseln, anonymisiert von DuckDuckGo."
+"Mit dem Duck.ai-Umschalter kannst du schnell zwischen privater Suche und KI-"
+"Chat wechseln, anonymisiert von DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21425,7 +21523,8 @@ msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s 
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
+msgstr ""
+"Die angehängten Dateien überschreiten die Größenbegrenzung von %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21457,7 +21556,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
+msgstr ""
+"Der Anbieter des Modells speichert diesen Chat nicht auf seinen Servern."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21624,7 +21724,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
+msgstr ""
+"Diese Sofort-Antwort wurde von der %1$sDuckDuckHack%2$s-Community erstellt."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21657,8 +21758,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des "
-"%3$s-Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
+"Diese Konversation wurde mit Duck.ai (%1$s) unter Verwendung des %3$s-"
+"Modells von %2$s generiert. KI-Chats zeigen möglicherweise falsche oder "
 "anstößige Informationen an (weitere Informationen siehe %4$s)."
 
 # smartling.placeholder_format=C
@@ -21915,8 +22016,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21927,9 +22028,9 @@ msgid ""
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
 "Diese Einstellung wird in deinem Browser gespeichert. Das heißt, wenn du die "
-"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder "
-"KI-gestützte Antworten. Allerdings haben wir auch eine Startseite unter "
-"%1$s, auf der niemals KI-gestützte Antworten angezeigt werden."
+"Browserdaten von duckduckgo.com löschst, siehst du möglicherweise wieder KI-"
+"gestützte Antworten. Allerdings haben wir auch eine Startseite unter %1$s, "
+"auf der niemals KI-gestützte Antworten angezeigt werden."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21974,7 +22075,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
+msgstr ""
+"Diese Webseite verwendet keine sichere, verschlüsselte Verbindung (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22092,7 +22194,8 @@ msgstr "Tipps"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
+msgstr ""
+"Du bist es leid, online getrackt zu werden? %1$sWir schaffen Abhilfe.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22269,6 +22372,12 @@ msgstr "Zu viele Ergebnisse von dieser Quelle"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Zu langsam"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22556,7 +22665,8 @@ msgstr "Versuche, %1$s, um solche Nachrichten nicht mehr zu sehen."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
+msgstr ""
+"Probiere %1$s, unser erstes Modell ohne Sichtbarkeit auf Anbieterseite."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22715,6 +22825,12 @@ msgid "Try fewer keywords."
 msgstr "Versuche, weniger Stichworte zu benutzen."
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22758,7 +22874,8 @@ msgstr "Gratis testen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
+msgstr ""
+"Kostenlos testen! Ein sicheres VPN, fortschrittliche und private KI und mehr."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22832,7 +22949,8 @@ msgstr "Versuche deinen Standort manuell einzustellen."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
+msgstr ""
+"Probiere den %1$sDuckDuckGo-Browser aus.%2$s Schnell. Kostenlos. Privat."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22878,7 +22996,8 @@ msgstr "Probiere den neuen privaten Echtzeit-Sprachchat aus!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
+msgstr ""
+"Probier die kürzlich hinzugefügten Open-Source-Versionen %1$s und %2$s aus"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -22902,7 +23021,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
+msgstr ""
+"Versuche, einen anderen Suchbegriff oder eine andere Suchphrase zu verwenden."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -22939,9 +23059,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No "
-"AI%2$s-Sucherweiterung, damit deine Einstellungen gespeichert bleiben. "
-"%3$sMehr erfahren%4$s"
+"Möchtest du KI-Funktionen deaktivieren? Wechsle zur %1$sDuckDuckGo No AI%2$s-"
+"Sucherweiterung, damit deine Einstellungen gespeichert bleiben. %3$sMehr "
+"erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -23067,7 +23187,8 @@ msgstr "Abschalten:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
+msgstr ""
+"Aktiviere %1$sPräziser Standort%2$s, um genauere Ergebnisse zu erhalten"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23090,7 +23211,8 @@ msgstr "Aktiviere „Präziser Standort“, um genauere Ergebnisse zu erhalten."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
+msgstr ""
+"Aktiviere „Präzisen Standort verwenden“, um genauere Ergebnisse zu erhalten."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23287,8 +23409,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s "
-"https://duckduckgo.com eingeben"
+"Unter %1$sEinstellungen%2$s > Allgemein > %3$sStartseite%4$s https://"
+"duckduckgo.com eingeben"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23320,7 +23442,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
+msgstr ""
+"Im Bereich %1$sSuchen%2$s bitte %3$sSuchmaschinen verwalten …%4$s anklicken"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23437,8 +23560,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem "
-"DuckDuckGo-Abo frei"
+"Schalte fortschrittliche KI-Modelle und höhere Limits mit einem DuckDuckGo-"
+"Abo frei"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23477,7 +23600,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
+msgstr ""
+"Schalte leistungsfähigere KI-Modelle mit einem DuckDuckGo-Abo frei. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23883,7 +24007,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
+msgstr ""
+"Verwende deinen ungefähren Standort, um genauere Ergebnisse zu erhalten?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24206,8 +24331,8 @@ msgstr "Sprachchat beendet"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von "
-"KI-Modellen verwendet."
+"Der Sprachchat wird von uns anonymisiert und niemals zum Trainieren von KI-"
+"Modellen verwendet."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24360,8 +24485,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Benutze den Duck Player, um personalisierte Werbung auf YouTube zu "
-"blockieren und zu verhindern, dass deine Aktivitäten die "
-"YouTube-Empfehlungen beeinflussen."
+"blockieren und zu verhindern, dass deine Aktivitäten die YouTube-"
+"Empfehlungen beeinflussen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24508,7 +24633,8 @@ msgstr "Wir tracken dich nicht. Niemals."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24549,7 +24675,8 @@ msgstr "Wir tracken dich nicht, ob im privaten oder normalen Modus."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
+msgstr ""
+"Wir tracken dich nicht. Das ist unsere Datenschutzerklärung in Kurzform …"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24566,8 +24693,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"Wir finden und entfernen deine personenbezogenen Daten von "
-"Datenbroker-Websites. Hol dir zusätzlich ein VPN und mehr."
+"Wir finden und entfernen deine personenbezogenen Daten von Datenbroker-"
+"Websites. Hol dir zusätzlich ein VPN und mehr."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24589,7 +24716,8 @@ msgstr "Wir halten deinen Suchverlauf privat"
 #. Displayed when the voice chat connection is lost and the session ends.
 msgctxt "voice chat error"
 msgid "We lost the connection, please try again later."
-msgstr "Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
+msgstr ""
+"Die Verbindung wurde unterbrochen. Bitte versuche es später noch einmal."
 
 # smartling.placeholder_format=C
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
@@ -24641,7 +24769,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
+msgstr ""
+"Wir verhindern, dass jemand deinen Suchverlauf erhält, einschließlich uns."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -25013,11 +25142,11 @@ msgid ""
 "experience."
 msgstr ""
 "Welche Vorteile bietet das Herunterladen des DuckDuckGo-Browsers für "
-"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle "
-"DuckDuckGo-Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit "
-"Titeln auf, wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem "
-"Datenschutz liegt. Halte es sehr kurz, einfach und leicht verständlich für "
-"Menschen mit oder ohne viel KI- oder technische Erfahrung."
+"jemanden, der Duck.ai nutzen möchte? Beziehe nur offizielle DuckDuckGo-"
+"Quellen ein. Teile die Antwort in übersichtliche Abschnitte mit Titeln auf, "
+"wobei der Schwerpunkt auf den Integrationen von Duck.ai und dem Datenschutz "
+"liegt. Halte es sehr kurz, einfach und leicht verständlich für Menschen mit "
+"oder ohne viel KI- oder technische Erfahrung."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25102,7 +25231,8 @@ msgstr "Was muss man hier unbedingt probieren?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
+msgstr ""
+"Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25948,7 +26078,8 @@ msgstr "Du kannst dies jederzeit in den %1$sSucheinstellungen%2$s ändern"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
+msgstr ""
+"Du kannst diesen Chat fortsetzen, wenn dein Limit am %1$s zurückgesetzt wird."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26259,7 +26390,8 @@ msgstr "Du hast das Limit für die Erstellung von Bildern erreicht."
 #. Title shown when a user has reached their image generation edit limit.
 msgctxt "Title for image generation edit limit reached message"
 msgid "You've reached the maximum number of edits for this image"
-msgstr "Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
+msgstr ""
+"Du hast die maximale Anzahl von Bearbeitungen für dieses Bild erreicht."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum number of messages for a given moment, and should try again later when they might be able to send more messages again.
@@ -26352,14 +26484,16 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
+msgstr ""
+"Deine %1$s letzten Chats sind im lokalen Speicher dieser Browser verfügbar:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
+msgstr ""
+"Deine Duck.ai-Chats werden mit Ende-zu-Ende-Verschlüsselung synchronisiert."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26593,7 +26727,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
+msgstr ""
+"Dein Feedback wird anonymisiert und nicht zum Training der KI verwendet."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26691,8 +26826,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No "
-"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren."
+"werden sie zurückgesetzt. Aktiviere die %1$sDuckDuckGo No AI%2$s-"
+"Erweiterung, um sie dauerhaft zu aktivieren."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26702,8 +26837,8 @@ msgid ""
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
 "Deine Einstellungen sind gespeichert, aber durch das Löschen der Cookies "
-"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No "
-"AI%2$s-Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
+"werden sie zurückgesetzt. Installiere die %1$sDuckDuckGo No AI%2$s-"
+"Erweiterung, um sie dauerhaft zu aktivieren. %3$sMehr erfahren%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26717,7 +26852,8 @@ msgstr "Deine geteilten Links befinden sich in %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
+msgstr ""
+"Deine synchronisierten Chats werden auf diesem Gerät wiederhergestellt."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -110,7 +110,8 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -318,7 +319,8 @@ msgstr "Οι κατατάξεις %1$s δεν είναι ακόμη διαθέσ
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
+msgstr ""
+"Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -389,7 +391,8 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
+msgstr ""
+"Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -544,7 +547,8 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr ""
+"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -644,7 +648,8 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr ""
+"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1062,7 +1067,8 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1869,7 +1875,8 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr ""
+"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2358,7 +2365,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr ""
+"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2954,7 +2962,8 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr ""
+"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3006,6 +3015,18 @@ msgstr ""
 "Πριν από την αποθήκευση αυτής της αναφοράς, το DuckDuckGo θα ανωνυμοποιήσει "
 "τη συνομιλία σου αφαιρώντας προσωπικά δεδομένα (PII), όπως ονόματα, "
 "διευθύνσεις email και μεταδεδομένα ταυτοποίησης."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3126,7 +3147,8 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr ""
+"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3141,7 +3163,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr ""
+"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3224,7 +3247,8 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr ""
+"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3508,7 +3532,8 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr ""
+"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3908,7 +3933,8 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr ""
+"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4188,7 +4214,8 @@ msgstr "Συνομιλία με %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr "Συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης, ανωνυμοποιημένη από εμάς."
+msgstr ""
+"Συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης, ανωνυμοποιημένη από εμάς."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4657,8 +4684,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
-"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
+"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4778,7 +4805,8 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr ""
+"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4816,7 +4844,8 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr ""
+"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4896,13 +4925,15 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr ""
+"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5431,7 +5462,8 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
+msgstr ""
+"Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -6394,7 +6426,8 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr ""
+"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6564,7 +6597,8 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr ""
+"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6612,6 +6646,12 @@ msgstr "Δεν μου αρέσει το σχέδιο"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Δεν μου αρέσει η πηγή"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6688,7 +6728,8 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr ""
+"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6722,6 +6763,12 @@ msgstr "Ιστορικό κατηγορίας"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Τζιμπουτί"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6771,7 +6818,8 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr ""
+"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6820,10 +6868,9 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
-"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
-"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
-"περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
+"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
+"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7100,7 +7147,8 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr ""
+"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7178,8 +7226,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
-"https://duck.ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7220,8 +7268,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
-"%1$sduck.ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
+"ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7244,7 +7292,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr ""
+"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7260,7 +7309,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr ""
+"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7293,7 +7343,8 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr ""
+"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7487,7 +7538,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr ""
+"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7749,7 +7801,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr ""
+"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7933,7 +7986,8 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr ""
+"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7945,7 +7999,8 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr ""
+"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8168,19 +8223,22 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr ""
+"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr ""
+"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8303,7 +8361,8 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr ""
+"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -8387,7 +8446,8 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr ""
+"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8631,6 +8691,12 @@ msgid "Fast"
 msgstr "Γρήγορα"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8825,7 +8891,8 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8964,6 +9031,12 @@ msgstr "Συμπληρωματική ερώτηση"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Τα συμπληρωματικά μηνύματα παραμένουν ιδιωτικά."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9829,7 +9902,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr ""
+"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9917,6 +9991,12 @@ msgstr "Καλό σχέδιο"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Ορθή πολιτική ιδιωτικού απορρήτου"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10294,7 +10374,8 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr ""
+"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -10306,7 +10387,8 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr ""
+"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10358,7 +10440,8 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr ""
+"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10663,7 +10746,8 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr ""
+"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10776,7 +10860,8 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr ""
+"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -11011,7 +11096,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr ""
+"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11069,6 +11155,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Οι προτροπές εικόνας πρέπει να συμμορφώνονται με το Duck.ai %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11596,7 +11688,8 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr ""
+"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -14026,7 +14119,8 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr ""
+"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14050,13 +14144,15 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr ""
+"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14880,8 +14976,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
-"DuckDuckGo...%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15976,6 +16072,12 @@ msgid "Poor formatting"
 msgstr "Κακή μορφοποίηση"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16504,7 +16606,8 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr ""
+"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16767,7 +16870,8 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
+msgstr ""
+"Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17159,7 +17263,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr ""
+"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17622,7 +17727,8 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr ""
+"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17699,7 +17805,8 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr ""
+"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -18069,13 +18176,15 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr ""
+"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18295,7 +18404,8 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr ""
+"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18703,8 +18813,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
-"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
+"com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18716,13 +18826,15 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr ""
+"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18763,7 +18875,8 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr ""
+"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18837,7 +18950,8 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr ""
+"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18898,7 +19012,8 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr ""
+"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -19309,7 +19424,8 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr ""
+"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19685,7 +19801,8 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
+msgstr ""
+"Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -20083,7 +20200,8 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr ""
+"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20416,7 +20534,8 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr ""
+"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20690,7 +20809,8 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr ""
+"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21533,13 +21653,15 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr ""
+"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21715,7 +21837,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr ""
+"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21789,7 +21912,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr ""
+"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21813,7 +21937,8 @@ msgstr "Αυτή την εβδομάδα"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
+msgstr ""
+"Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21887,13 +22012,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr ""
+"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21952,14 +22079,16 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr ""
+"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -22049,7 +22178,8 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr ""
+"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -22142,7 +22272,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr ""
+"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22171,7 +22302,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr ""
+"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22259,7 +22391,8 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr ""
+"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22292,8 +22425,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
-"Duck.ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22440,6 +22573,12 @@ msgid "Too slow"
 msgstr "Πολύ αργό"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22542,7 +22681,8 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr ""
+"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22728,7 +22868,8 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr ""
+"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22854,7 +22995,8 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr ""
+"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -22873,7 +23015,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22889,6 +23032,12 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Δοκίμασε λιγότερες λέξεις-κλειδιά."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22947,7 +23096,8 @@ msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr ""
+"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -22975,7 +23125,8 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr ""
+"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23181,7 +23332,8 @@ msgstr "Απενεργοποίηση Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr "Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
+msgstr ""
+"Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -23274,7 +23426,8 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr ""
+"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23426,7 +23579,8 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr ""
+"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23480,7 +23634,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr ""
+"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23499,8 +23654,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
-"αναζήτησης…%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23601,7 +23756,8 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr ""
+"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -23631,7 +23787,8 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr ""
+"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -24006,7 +24163,8 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr ""
+"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24040,7 +24198,8 @@ msgstr "Χρησιμοποιείτε δημόσιο Wi-Fi; Χρησιμοποι�
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
+msgstr ""
+"Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24215,7 +24374,8 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr ""
+"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24693,7 +24853,8 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24736,7 +24897,8 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr ""
+"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -25075,7 +25237,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr ""
+"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25137,14 +25300,15 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
-"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
+"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr ""
+"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -26084,7 +26248,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr ""
+"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -26146,7 +26311,8 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr ""
+"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26183,7 +26349,8 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr ""
+"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -26294,7 +26461,8 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr ""
+"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26477,14 +26645,16 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr ""
+"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr ""
+"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26510,9 +26680,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
-"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
-"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
+"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
+"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.

--- a/locales/el_GR/LC_MESSAGES/duckduckgo.po
+++ b/locales/el_GR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -110,8 +110,7 @@ msgstr "%1$s απόπειρες"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκαν %1$s προσπάθειες από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -319,8 +318,7 @@ msgstr "Οι κατατάξεις %1$s δεν είναι ακόμη διαθέσ
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
+msgstr "Το %1$s φτάνει στα όρια χρήσης 2-5x νωρίτερα από τα βασικά μοντέλα. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -391,8 +389,7 @@ msgstr "%1$s χρησιμοποιήθηκε"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
+msgstr "Το %1$s χρησιμοποιεί τα όρια έως και 2-5x ταχύτερα από τα βασικά μοντέλα %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -547,8 +544,7 @@ msgstr ""
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
+msgstr "%1$sΚρίμα!%2$s%3$sΚάτι πήγε λάθος. %4$sΑνανεώστε%5$s και προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -648,8 +644,7 @@ msgstr "1 προσπάθεια"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when only one exists.
 msgid "1 attempt blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
+msgstr "Αποκλείστηκε 1 προσπάθεια από το DuckDuckGo κατά τις τελευταίες 24 ώρες"
 
 # smartling.placeholder_format=C
 #. We realise this is the incorrect way to handle plurals. Sorry, we are working on a fix.
@@ -1067,8 +1062,7 @@ msgstr ""
 #. Disclaimer text displayed at the bottom of the voice chat dialog informing the user that the AI (Artificial Intelligence) may provide inaccurate or offensive information.
 msgctxt "voice chat"
 msgid "AI may provide inaccurate or offensive information."
-msgstr ""
-"Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Η τεχνητή νοημοσύνη μπορεί να παρέχει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Label for the input field where user can specify how the AI assistant should refer to itself. Example: 'AI nickname (is): Fred'
@@ -1875,8 +1869,7 @@ msgstr "Όλες οι συνομιλίες είναι %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
+msgstr "Όλες οι συνομιλίες είναι %1$s. Η τεχνητή νοημοσύνη μπορεί να κάνει λάθη."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2365,8 +2358,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
+msgstr "Θέλετε σίγουρα να διαγράψετε τη συνομιλία αυτή και να αρχίσετε μια νέα;"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2962,8 +2954,7 @@ msgstr "Γραμμοκώδικας"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
+msgstr "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -3027,6 +3018,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Πριν από την αποθήκευση αυτής της αναφοράς, το DuckDuckGo θα αφαιρέσει τα "
+"μεταφορτωμένα αρχεία και τις εικόνες που δημιουργήθηκαν, και θα "
+"ανωνυμοποιήσει τη συνομιλία σου αφαιρώντας προσωπικά δεδομένα (PII), όπως "
+"ονόματα, διευθύνσεις email και μεταδεδομένα ταυτοποίησης."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3147,8 +3142,7 @@ msgstr "Αποκλεισμός ενοχλητικών αναδυόμενων π�
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
+msgstr "Αποκλείστε εφαρμογές παρακολούθησης email και αποκρύψτε τη διεύθυνσή σας."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3163,8 +3157,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
+msgstr "Η λίστα αποκλεισμού δεν είναι πλήρης και ενδέχεται να περιέχει ανακρίβειες."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3247,8 +3240,7 @@ msgstr "Αποκλεισμένα:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
+msgstr "Μπλοκάρει τα προγράμματα παρακολούθησης στους ιστοτόπους που επισκέπτεστε"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -3532,8 +3524,7 @@ msgstr "Κάνοντας κλικ στο «%1$s» συμφωνείτε με το
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
+msgstr "Κάνοντας κλικ στο «%1$s», αποδέχεστε την %2$s και τους %3$s του Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3933,8 +3924,7 @@ msgstr "Αλλάζει την εμφάνιση των διευθύνσεων URL
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
+msgstr "Αλλάζει την εμφάνιση της κεφαλίδας και τη συμπεριφορά της κατά την κύλιση"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4214,8 +4204,7 @@ msgstr "Συνομιλία με %1$s"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
-"Συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης, ανωνυμοποιημένη από εμάς."
+msgstr "Συνομιλία με δημοφιλή μοντέλα τεχνητής νοημοσύνης, ανωνυμοποιημένη από εμάς."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4684,8 +4673,8 @@ msgid ""
 msgstr ""
 "Η εκκαθάριση των δεδομένων του προγράμματος περιήγησης διαγράφει τις "
 "πρόσφατες συνομιλίες. Οι πρόσφατες συνομιλίες μπορεί να αποθηκευτούν επ' "
-"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του Duck."
-"ai., ανάλογα με το πρόγραμμα περιήγησής σας."
+"αόριστον ή να διαγραφούν αυτόματα μετά από 7 ημέρες χωρίς χρήση του "
+"Duck.ai., ανάλογα με το πρόγραμμα περιήγησής σας."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4805,8 +4794,7 @@ msgstr "Κάνε κλικ στις %1$sΡυθμίσεις%2$s στο αναπτ�
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
+msgstr "Κάνε κλικ στο %1$sΧρήση τρεχουσών σελίδων%2$s και έπειτα στο %3$sΟΚ%4$s"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4844,8 +4832,7 @@ msgstr "Κάνε κλικ στο %1$sΠρόγραμμα περιήγησης%2$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
+msgstr "Κάνε κλικ στο %1$sΑλλαγή ρυθμίσεων αναζήτησης%2$s στο αναπτυσσόμενο μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4925,15 +4912,13 @@ msgstr "Κάνε κλικ στην καρτέλα %1$sΓενικά%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με τα αποσιωπητικά%2$s στη γραμμή εργαλείων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
+msgstr "Κάνε κλικ στο %1$sεικονίδιο με την κλειδαριά%2$s στη γραμμή διευθύνσεων."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -5462,8 +5447,7 @@ msgstr "Συνεχίστε να μπλοκάρετε διαφημίσεις"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
+msgstr "Συνέχισε τις πρόσφατες συνομιλίες εδώ. Ή διάγραψέ τες με το Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -6426,8 +6410,7 @@ msgstr "Περιγράψτε τις αλλαγές με βάση την εικό
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
+msgstr "Περιγράψτε τις αλλαγές για να συνεχίσετε την επεξεργασία αυτής της εικόνας"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6597,8 +6580,7 @@ msgstr "Απενεργοποίηση και αποσύνδεση"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
+msgstr "Απενεργοποίηση ιστορικού συνομιλιών και αποσύνδεση από το Sync & Backup;"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6651,7 +6633,7 @@ msgstr "Δεν μου αρέσει η πηγή"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Δεν μου αρέσει το οπτικό στυλ"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6728,8 +6710,7 @@ msgstr "Γλώσσα οθόνης"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
+msgstr "Εμφανίζει ένα σημάδι στα αριστερά των αποτελεσμάτων που έχεις επισκεφθεί"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6768,7 +6749,7 @@ msgstr "Τζιμπουτί"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Δεν ακολουθεί τις οδηγίες"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6818,8 +6799,7 @@ msgstr "Δεν βλέπεις το DuckDuckGo στη λίστα;"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
+msgstr "Δεν το βλέπεις; %1$s%2$s%3$sΚάνε κλικ εδώ για να το ξανακατεβάσεις.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6868,9 +6848,10 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το %1$snoai.duckduckgo."
-"com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής νοημοσύνης και με "
-"φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε περισσότερα%4$s"
+"Δεν επιθυμείτε τεχνητή νοημοσύνη; Επισκεφθείτε το "
+"%1$snoai.duckduckgo.com%2$s για αναζήτηση χωρίς λειτουργίες τεχνητής "
+"νοημοσύνης και με φιλτραρισμένες εικόνες τεχνητής νοημοσύνης. %3$sΜάθετε "
+"περισσότερα%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7147,8 +7128,7 @@ msgstr "Όρους χρήσης υπηρεσίας του Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
+msgstr "Duck.ai από το DuckDuckGo. Ιδιωτική συνομιλία με τεχνητή νοημοσύνη. Δωρεάν."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7226,8 +7206,8 @@ msgid ""
 "remember home on the web: https://duck.ai"
 msgstr ""
 "Το Duck.ai εξακολουθεί να αποτελεί προϊόν της DuckDuckGo, ωστόσο πλέον θα "
-"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: https://duck."
-"ai"
+"έχει μια πιο εύκολη στην απομνημόνευση διεύθυνση στο διαδίκτυο: "
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7268,8 +7248,8 @@ msgid ""
 msgstr ""
 "Το Duck.ai σάς επιτρέπει να συνομιλείτε ιδιωτικά με δημοφιλή μοντέλα "
 "τεχνητής νοημοσύνης. Η απενεργοποίησή του αποκρύπτει τα κουμπιά και τους "
-"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το %1$sduck."
-"ai%2$s απευθείας."
+"συνδέσμους του Duck.ai, ωστόσο μπορείτε ακόμα να επισκεφθείτε το "
+"%1$sduck.ai%2$s απευθείας."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7292,8 +7272,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
+msgstr "Το Duck.ai ενδέχεται να εμφανίζει ανακριβείς ή προσβλητικές πληροφορίες."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7309,8 +7288,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
+msgstr "Το Duck.ai μπορεί πλέον να διαβάζει και να αναλύει αρχεία PDF. Δοκιμάστε το!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7343,8 +7321,7 @@ msgstr "Το Duck.ai αναβαθμίστηκε!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
+msgstr "Το Duck.ai λειτουργεί καλύτερα στην ιδιωτική και δωρεάν εφαρμογή DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7538,8 +7515,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
+msgstr "Το DuckDuckGo AI Chat δεν είναι διαθέσιμο προσωρινά. Ξαναδοκιμάστε αργότερα."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7801,8 +7777,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
+msgstr "Οι συνδρομές DuckDuckGo δεν είναι διαθέσιμες για αγορά στην περιοχή αυτή."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7986,8 +7961,7 @@ msgstr "Δώστε έμφαση σε σημαντικές πληροφορίες
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
+msgstr "Ενεργοποίησε την επιλογή «Οι ιστότοποι μπορούν να ζητούν την τοποθεσία μου»."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7999,8 +7973,7 @@ msgstr "Ενεργοποίηση λειτουργιών τεχνητής νοη�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
+msgstr "Ενεργοποίησε το Cloud Save, πληκτρολογώντας την υπάρχουσα φράση πρόσβασης."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8223,22 +8196,19 @@ msgstr "Βεβαιώσου ότι έχεις επιλέξει %1$sΑποδοχή
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Υπηρεσίες τοποθεσίας» είναι %1$sενεργοποιημένη%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
+msgstr "Βεβαιωθείτε ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
+msgstr "Βεβαιώσου ότι η επιλογή «Τοποθεσία» έχει οριστεί σε %1$sΝα επιτρέπεται%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8361,8 +8331,7 @@ msgstr "Καταχώρισε τη διεύθυνση email σου."
 #. A prompt asking users to enter their passphrase.
 msgctxt "cloudsave"
 msgid "Enter your passphrase to load your settings."
-msgstr ""
-"Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
+msgstr "Πληκτρολόγησε τη φράση πρόσβασής σου για να φορτωθούν οι ρυθμίσεις σου."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an entertainment guide in its responses.
@@ -8446,8 +8415,7 @@ msgstr "Ανάπτυξη χάρτη"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
+msgstr "Εξειδικευμένα προϊόντα για άτομα που ενδιαφέρονται για την ιδιωτικότητα."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8694,7 +8662,7 @@ msgstr "Γρήγορα"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Γρήγορη δημιουργία εικόνων"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8891,8 +8859,7 @@ msgstr "Οικονομικός σύμβουλος"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Βρες το %1$sDuckDuckGo%2$s και κάνε κλικ στο%3$sΟρισμός ως προεπιλογής%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -9036,7 +9003,7 @@ msgstr "Τα συμπληρωματικά μηνύματα παραμένουν 
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Ακολούθησε τις οδηγίες"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9902,8 +9869,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
+msgstr "Μεταβείτε στις επιλογές %1$sΑπόρρητο και ασφάλεια > Υπηρεσίες τοποθεσίας%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9996,7 +9962,7 @@ msgstr "Ορθή πολιτική ιδιωτικού απορρήτου"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Καλό οπτικό στυλ"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10374,8 +10340,7 @@ msgstr "Βοηθήστε με να προετοιμαστώ για τη συνέ
 #. Prompt sent to the AI when the user taps the "Tailor my resume" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Help me tailor my resume for this job."
-msgstr ""
-"Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
+msgstr "Βοηθήστε με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας."
 
 # smartling.placeholder_format=C
 #. Title of a SERP popup that invites users to take a survey (desktop only)
@@ -10387,8 +10352,7 @@ msgstr "Βοηθήστε μας να βελτιώσουμε το DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
+msgstr "Βοηθήστε μας να βελτιώσουμε τις αναζητήσεις DuckDuckGo με τα σχόλιά σας"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10440,8 +10404,7 @@ msgstr "Βοηθήστε μας να καταλάβουμε πώς δεν πετ
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
+msgstr "Βοήθησε τους φίλους και την οικογένειά σου να μάθουν τον κόσμο του Παπιού!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10746,8 +10709,7 @@ msgstr "Οι ώρες λείπουν"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
+msgstr "Χρώμα δείκτη αποτελεσμάτων, λειτουργικής μονάδας και αναπτυσσόμενου μενού"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10860,8 +10822,7 @@ msgstr "Πόσο συχνά θέλετε να βλέπετε τις απαντή
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
+msgstr "Πόσο συχνά θέλετε να βλέπετε απαντήσεις με τη βοήθεια τεχνητής νοημοσύνης;"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -11096,8 +11057,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
+msgstr "Αν θες παρ' όλα αυτά να μας υποστηρίξεις, %1$sδιάδωσε το DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11160,7 +11120,7 @@ msgstr "Οι προτροπές εικόνας πρέπει να συμμορφ�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Ποιότητα εικόνας"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11688,8 +11648,7 @@ msgstr ""
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
+msgstr "Δέχομαι να με ρωτάτε (πολύ σποραδικά) για την εμπειρία μου με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -14119,8 +14078,7 @@ msgstr "Δεν βρέθηκαν αποτελέσματα."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
+msgstr "Δεν εντοπίστηκε ομιλία. Προσπαθήστε ξανά και μιλήστε στο μικρόφωνό σας."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14144,15 +14102,13 @@ msgstr "Δεν αποκλείστηκαν εφαρμογές παρακολού�
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
+msgstr "Χωρίς παρακολούθηση, χωρίς στοχευμένες διαφημίσεις, μόνο καθαρή αναζήτηση."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14976,8 +14932,8 @@ msgstr "Άνοιγμα του πίνακα «Πώς λειτουργεί το Du
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
 msgstr ""
-"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το DuckDuckGo..."
-"%2$s"
+"Ανοίξτε το μενού του Safari και επιλέξτε %1$sΡυθμίσεις για το "
+"DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -16075,7 +16031,7 @@ msgstr "Κακή μορφοποίηση"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Κακή ποιότητα εικόνας"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16606,8 +16562,7 @@ msgstr "Προστατέψτε τα εισερχόμενά σας"
 #. DuckDuckGo's browser app has features to protect your data by keeping it private
 msgctxt "SERP footer content"
 msgid "Protect your data as you search and browse."
-msgstr ""
-"Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
+msgstr "Προστατέψτε τα δεδομένα σας καθώς πραγματοποιείτε αναζήτηση και περιήγηση."
 
 # smartling.placeholder_format=C
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
@@ -16870,8 +16825,7 @@ msgstr "Συλλογιστική τεχνητή νοημοσύνη με μέτρ
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
+msgstr "Η συλλογιστική μπορεί να δώσει καλύτερες απαντήσεις σε σύνθετες ερωτήσεις."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17263,8 +17217,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
+msgstr "Να θυμάσαι την επιλογή μου (αυτό μπορεί να αλλαχθεί στις %1$sΡυθμίσεις%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17727,8 +17680,7 @@ msgstr "Κριτικές"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
+msgstr "Ξαναγράψτε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17805,8 +17757,7 @@ msgstr "ΝΑ"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "SERP promotion for desktop browsers has been dismissed"
-msgstr ""
-"Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
+msgstr "Η προώθηση SERP για τα προγράμματα περιήγησης υπολογιστών έχει απορριφθεί"
 
 # smartling.placeholder_format=C
 #. Abbreviation indicating that a game is in shootouts, e.g. in NHL (hockey)
@@ -18176,15 +18127,13 @@ msgstr "Σκωτία"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
+msgstr "Κάνε κύλιση προς τα κάτω και κλικ στην %1$sΠροβολή σύνθετων ρυθμίσεων%2$s"
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18404,8 +18353,7 @@ msgstr "Ορατότητα αναζήτησης"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
+msgstr "Απόλαυσε ιδιωτική αναζήτηση και περιήγηση με την εφαρμογή του DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18813,8 +18761,8 @@ msgstr "Επιλέξτε %1$sΡύθμιση για αυτόν τον ιστότ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε %3$shttps://duckduckgo."
-"com%4$s στο πεδίο εισαγωγής"
+"Διάλεξε %1$sΠροσαρμοσμένη%2$s και πληκτρολόγησε "
+"%3$shttps://duckduckgo.com%4$s στο πεδίο εισαγωγής"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18826,15 +18774,13 @@ msgstr ""
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
+msgstr "Διάλεξε %1$sDuckDuckGo%2$s και κάνε κλικ στο %3$sΟρισμός ως προεπιλογής%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18875,8 +18821,7 @@ msgstr "Διάλεξε %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
+msgstr "Επιλέξτε %1$sΕπεξεργασία μηχανών αναζήτησης…%2$sστο αναπτυσσόμενη μενού"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18950,8 +18895,7 @@ msgstr "Διάλεξε %1$sΡυθμίσεις%2$s και έπειτα %3$sΣύν
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
+msgstr "Επιλέξτε %1$sΡυθμίσεις%2$s και έπειτα %3$sΠροεπιλεγμένη μηχανή αναζήτησης%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -19012,8 +18956,7 @@ msgstr "Διάλεξε όλα τα τετράγωνα που περιέχουν 
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
+msgstr "Ορίστε μια επιλογή για να %1$sεπιτρέπεται%2$s η πρόσβαση στην τοποθεσία"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -19424,8 +19367,7 @@ msgstr "Κοινοποίησε αυτή τη συνομιλία στο DuckDuckG
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
+msgstr "Μοιραστείτε την απάντηση στην προτροπή και στη συνομιλία σας με το DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19801,8 +19743,7 @@ msgstr "Εμφάνιση πλαϊνής γραμμής"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
+msgstr "Εμφάνιση συμβουλών βήμα προς βήμα για να αξιοποιήσεις στο έπακρο το Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -20200,8 +20141,7 @@ msgstr "Κάτι πήγε στραβά κατά την αποθήκευση στ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
+msgstr "Κάτι πήγε λάθος κατά την ενεργοποίηση του Sync & Backup. Προσπαθήστε ξανά."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20534,8 +20474,7 @@ msgstr "Αρχίστε με μια εικόνα"
 #. Warning that starting fresh deletes conversations.
 msgctxt "duckai_migration"
 msgid "Starting fresh will delete all your past conversations."
-msgstr ""
-"Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
+msgstr "Ξεκινώντας από την αρχή θα διαγραφούν όλες οι προηγούμενες συνομιλίες σας."
 
 # smartling.placeholder_format=C
 #. Footnote warning that starting fresh deletes conversations.
@@ -20809,8 +20748,7 @@ msgstr "Πρότεινε έναν τίτλο για μια ανάρτηση σε
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
+msgstr "Προτείνετε σχετικά άρθρα ή θέματα που αξίζει να εξερευνήσετε στη συνέχεια."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21653,15 +21591,13 @@ msgstr "Ευχαριστούμε για τα σχόλιά σας!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
+msgstr "Ευχαριστούμε για την υπομονή σας ενώ θα βάλουμε τα παπάκια μας στη σειρά."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21837,8 +21773,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
+msgstr "Παρουσιάστηκε πρόβλημα κατά τη φόρτωση αυτής της απάντησης. Δοκιμάστε ξανά."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21912,8 +21847,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
+msgstr "Αυτή η άμεση απάντηση δημιουργήθηκε από την κοινότητα %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21937,8 +21871,7 @@ msgstr "Αυτή την εβδομάδα"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
+msgstr "Αυτή η συνομιλία παραμένει στο Duck.ai και παραμένει ιδιωτική για σένα."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -22012,15 +21945,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
+msgstr "Αυτό το αρχείο είναι πολύ μεγάλο. Το μέγιστο μέγεθος αρχείου είναι %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -22079,16 +22010,14 @@ msgstr "Δεν ήταν δυνατή η δημιουργία αυτής της �
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται. Επισύναψε JPG, PNG, WebP ή GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
+msgstr "Αυτός ο τύπος εικόνας δεν υποστηρίζεται, επισύναψε JPG, PNG, WebP ή GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -22178,8 +22107,7 @@ msgstr "Αυτή η σελίδα απαιτεί Javascript για να λειτ�
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
+msgstr "Το περιεχόμενο της σελίδας αυτής θα σταλεί μαζί με το μήνυμά σας στο Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -22272,8 +22200,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
+msgstr "Η ιστοσελίδα αυτή δεν χρησιμοποιεί ασφαλή, κρυπτογραφημένη σύνδεση (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22302,8 +22229,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
+msgstr "Αυτό θα διαγράψει την επιλεγμένη εικόνα σας. Αυτό δεν μπορεί να αναιρεθεί."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22391,8 +22317,7 @@ msgstr "Συμβουλές"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
+msgstr "Έχεις βαρεθεί να σε παρακολουθούν στο διαδίκτυο; %1$sΆσ' το πάνω μας.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22425,8 +22350,8 @@ msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
 msgstr ""
-"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του Duck."
-"ai"
+"Για να συνεχίσετε, πρέπει να συμφωνήσετε με την %1$s και τους %2$s του "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22576,7 +22501,7 @@ msgstr "Πολύ αργό"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Πολύ αργό στη δημιουργία"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22681,8 +22606,7 @@ msgstr "Εφαρμογές παρακολούθησης που αποκλείσ�
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
+msgstr "Οι εφαρμογές παρακολούθησης που αποκλείει το DuckDuckGo θα εμφανίζονται εδώ"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22868,8 +22792,7 @@ msgstr "Δοκιμάστε το %1$s για να σταματήσετε να β�
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
+msgstr "Δοκίμασε το %1$s, το πρώτο μας μοντέλο με μηδενική ορατότητα από τον πάροχο."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22995,8 +22918,7 @@ msgstr ""
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
 msgctxt "noresults"
 msgid "Try clearing your filters and searching again."
-msgstr ""
-"Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
+msgstr "Δοκιμάστε να καθαρίσετε τα φίλτρα σας και να πραγματοποιήσετε αναζήτηση ξανά."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with different words.
@@ -23015,8 +22937,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
+msgstr "Δοκίμασε να ενεργοποιήσεις την ανώνυμη τοποθεσία για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -23037,7 +22958,7 @@ msgstr "Δοκίμασε λιγότερες λέξεις-κλειδιά."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Δοκίμασέ το δωρεάν"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23096,8 +23017,7 @@ msgstr "Δοκίμασε δωρεάν για 7 ημέρες"
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask Assist (an instant answer based on generative AI) for an answer
 msgid "Try generating an AI-assisted answer"
-msgstr ""
-"Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
+msgstr "Δοκιμάστε να δημιουργήσετε μια απάντηση με τη βοήθεια τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Copy to invite the user to ask duckassist (an instant answer based on generative AI) for an answer
@@ -23125,8 +23045,7 @@ msgstr "Δοκιμάστε το πρόγραμμα περιήγησής μας"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
+msgstr "Δοκίμασε την αρχική μας σελίδα που ποτέ δεν εμφανίζει αυτά τα μηνύματα:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23332,8 +23251,7 @@ msgstr "Απενεργοποίηση Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
-"Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
+msgstr "Απενεργοποίηση του Sync & Backup και διαγραφή των δεδομένων διακομιστή;"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -23426,8 +23344,7 @@ msgstr "Ενεργοποιήστε την «Ακριβή τοποθεσία» γ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
+msgstr "Ενεργοποιήστε τη «Χρήση ακριβούς τοποθεσίας» για πιο ακριβή αποτελέσματα."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23579,8 +23496,7 @@ msgstr "Δεν είναι δυνατή η αποστολή σχολίων"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
+msgstr "Δεν είναι δυνατή η σύνδεση στη φωνητική συνομιλία. Προσπαθήστε πάλι αργότερα."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23634,8 +23550,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
+msgstr "Στο %1$sΕΚΚΙΝΗΣΗ > Αρχική σελίδα%2$s, πληκτρολόγησε: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23654,8 +23569,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών αναζήτησης…"
-"%4$s"
+"Στην ενότητα %1$sΑναζήτηση%2$s, διάλεξε %3$sΔιαχείριση μηχανών "
+"αναζήτησης…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23756,8 +23671,7 @@ msgstr ""
 #. Title for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Unlock VPN + Advanced AI"
-msgstr ""
-"Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
+msgstr "Αποκτήστε πρόσβαση σε δίκτυο VPN + προηγμένες δυνατότητες τεχνητής νοημοσύνης"
 
 # smartling.placeholder_format=C
 #. Text for the button that allows the user to unlock an AI model with a DuckDuckGo subscription when clicked.
@@ -23787,8 +23701,7 @@ msgstr "Ξεκλειδώστε προηγμένα μοντέλα τεχνητή�
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
+msgstr "Ξεκλείδωσε προηγμένα μοντέλα τεχνητής νοημοσύνης με συνδρομή στο DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -24163,8 +24076,7 @@ msgstr "Χρήση της ιδιωτικής αναζήτησης του DuckDuc
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
+msgstr "Χρησιμοποίησε την ιδιωτική αναζήτηση DuckDuckGo σε iPad, iPhone ή Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24198,8 +24110,7 @@ msgstr "Χρησιμοποιείτε δημόσιο Wi-Fi; Χρησιμοποι�
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
+msgstr "Χρησιμοποίησε το Fire Button για να διαγράψεις μια συνομιλία από το ιστορικό."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24374,8 +24285,7 @@ msgstr "Δείτε τιμές για τη διαμονή σας"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
+msgstr "Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24853,8 +24763,7 @@ msgstr "Δεν σε παρακολουθούμε, ποτέ μα ποτέ."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24897,8 +24806,7 @@ msgstr ""
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
+msgstr "Δεν σας παρακολουθούμε. Αυτή είναι η Πολιτική απορρήτου μας με λίγα λόγια…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -25237,8 +25145,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
+msgstr "Καλώς ορίσατε στο νέο Duck.ai, ήρθε η ώρα να εισαγάγετε τις συνομιλίες σας"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25300,15 +25207,14 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του Duck."
-"ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
+"Λυπούμαστε πολύ, αλλά φαίνεται ότι υπήρξε πρόβλημα κατά τη φόρτωση του "
+"Duck.ai. Προσπαθήστε να επαναλάβετε τη φόρτωση της σελίδας."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What AI model would you like us to add? (optional)"
-msgstr ""
-"Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
+msgstr "Ποιο μοντέλο τεχνητής νοημοσύνης θα θέλατε να προσθέσουμε; (προαιρετικό)"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for providing arguments, counter-arguments, and rebuttals to the concept of a plant-based diet.
@@ -26248,8 +26154,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
+msgstr "Μπορείτε να αποκτήσετε πρόσβαση στο DuckDuckGo AI Chat απευθείας από το %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -26311,8 +26216,7 @@ msgstr ""
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
+msgstr "Μπορείς να συνεχίσεις αυτή τη συνομιλία όταν ανανεωθεί το όριό σου: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26349,8 +26253,7 @@ msgstr ""
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can keep chatting by using your monthly limit."
-msgstr ""
-"Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
+msgstr "Μπορείς να συνεχίσεις να συνομιλείς χρησιμοποιώντας το μηνιαίο όριό σου."
 
 # smartling.placeholder_format=C
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
@@ -26461,8 +26364,7 @@ msgstr "Μπορείς να ξεκινήσεις από την αρχή σε α�
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
+msgstr "Μπορείς να αποθηκεύσεις διάφορα σύνολα ρυθμίσεων για διαφορετικούς σκοπούς."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26645,16 +26547,14 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
+msgstr "Έχετε φτάσει τη μέγιστη διάρκεια φωνητικής συνομιλίας για μία συνεδρία."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
+msgstr "Έχετε φτάσει το όριο φωνητικής συνομιλίας για σήμερα. Δοκιμάστε ξανά αύριο."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26680,9 +26580,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες Duck."
-"ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να συνεχίσετε "
-"τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
+"Έχει εξαντληθεί ο χώρος αποθήκευσης του Sync & Backup για συνομιλίες "
+"Duck.ai. Διαγράψτε τις %1$s παλαιότερες συνομιλίες με συνημμένα για να "
+"συνεχίσετε τον συγχρονισμό. Οι καρφιτσωμένες συνομιλίες δεν θα διαγραφούν."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.

--- a/locales/en_AU/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_AU/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Dismiss"
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6770,6 +6791,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7025,6 +7051,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7772,6 +7803,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8697,6 +8733,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12640,6 +12681,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17692,6 +17738,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18051,6 +18102,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Try fewer keywords."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/en_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_CA/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Dismiss"
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6770,6 +6791,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7025,6 +7051,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7772,6 +7803,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8697,6 +8733,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12640,6 +12681,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17692,6 +17738,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18051,6 +18102,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Try fewer keywords."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/en_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_GB/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Dismiss"
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6770,6 +6791,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7025,6 +7051,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7772,6 +7803,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8697,6 +8733,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12640,6 +12681,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17692,6 +17738,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18051,6 +18102,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Try fewer keywords."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/en_US/LC_MESSAGES/duckduckgo.po
+++ b/locales/en_US/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/eo_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/eo_XX/LC_MESSAGES/duckduckgo.po
@@ -2381,6 +2381,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5232,6 +5243,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Rezignu"
@@ -5321,6 +5337,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6779,6 +6800,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7034,6 +7060,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7781,6 +7812,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8706,6 +8742,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12649,6 +12690,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17709,6 +17755,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18068,6 +18119,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Provu per malpli da vortoj."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/es_AR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_AR/LC_MESSAGES/duckduckgo.po
@@ -2377,6 +2377,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5240,6 +5251,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Descartar"
@@ -5329,6 +5345,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6788,6 +6809,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7045,6 +7071,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7792,6 +7823,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8721,6 +8757,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12671,6 +12712,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17738,6 +17784,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18098,6 +18149,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Probá con menos palabras claves."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/es_CL/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CL/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5227,6 +5238,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Cancelar"
@@ -5316,6 +5332,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6775,6 +6796,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7031,6 +7057,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7778,6 +7809,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8700,6 +8736,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12646,6 +12687,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17709,6 +17755,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18068,6 +18119,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_CO/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CO/LC_MESSAGES/duckduckgo.po
@@ -2376,6 +2376,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5235,6 +5246,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Descartar"
@@ -5324,6 +5340,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6783,6 +6804,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7040,6 +7066,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7787,6 +7818,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8709,6 +8745,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12656,6 +12697,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17718,6 +17764,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18077,6 +18128,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_CR/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_CR/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5214,6 +5225,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5303,6 +5319,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6760,6 +6781,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7015,6 +7041,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7762,6 +7793,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8684,6 +8720,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12618,6 +12659,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17663,6 +17709,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18022,6 +18073,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_EC/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_EC/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5218,6 +5229,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5307,6 +5323,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6765,6 +6786,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7022,6 +7048,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7769,6 +7800,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8691,6 +8727,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12627,6 +12668,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17679,6 +17725,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18038,6 +18089,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -452,7 +452,8 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr ""
+"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -2334,19 +2335,22 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr ""
+"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr ""
+"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2977,6 +2981,18 @@ msgstr ""
 "Antes de almacenar este informe, DuckDuckGo anonimizará tu conversación "
 "eliminando información personal como nombres, direcciones de correo "
 "electrónico y metadatos identificativos."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4701,7 +4717,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr ""
+"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4728,7 +4745,8 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr ""
+"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4861,7 +4879,8 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr ""
+"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5503,7 +5522,8 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr ""
+"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6266,7 +6286,8 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr ""
+"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6398,7 +6419,8 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr ""
+"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6547,6 +6569,12 @@ msgid "Dislike source"
 msgstr "No me gusta la fuente"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Descartar"
@@ -6655,6 +6683,12 @@ msgstr "Registro de la división"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Yibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7078,7 +7112,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr ""
+"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7137,7 +7172,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr ""
+"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8144,7 +8180,8 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr ""
+"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8238,7 +8275,8 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr ""
+"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8426,7 +8464,8 @@ msgstr "Explora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr ""
+"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8540,6 +8579,12 @@ msgstr "Final"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Rápido"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8736,7 +8781,8 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr ""
+"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8875,6 +8921,12 @@ msgid "Follow-ups remain private."
 msgstr "Los mensajes de seguimiento siguen siendo privados."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8978,7 +9030,8 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr ""
+"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9008,7 +9061,8 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr ""
+"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9089,9 +9143,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona "
-"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
-"y, a continuación, selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
+"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
+"selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9613,8 +9667,8 @@ msgstr "Obtén la app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
-"YouTube.%2$s"
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9813,6 +9867,12 @@ msgstr "Buen diseño"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Buena política de privacidad"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10556,7 +10616,8 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr ""
+"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10647,13 +10708,15 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr ""
+"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr ""
+"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10908,7 +10971,8 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr ""
+"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10955,8 +11019,14 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de "
-"Duck.ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
+"ai %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11887,7 +11957,8 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr ""
+"Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -12010,8 +12081,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
-"Duck.ai"
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -15519,7 +15590,8 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
+msgstr ""
+"Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15578,13 +15650,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr ""
+"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15837,6 +15911,12 @@ msgstr "Polaco"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Formato deficiente"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16353,7 +16433,8 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr ""
+"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16626,7 +16707,8 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
+msgstr ""
+"El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17475,7 +17557,8 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr ""
+"Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17760,7 +17843,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr ""
+"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -18318,7 +18402,8 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr ""
+"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18541,7 +18626,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr ""
+"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18640,7 +18726,8 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr ""
+"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18665,7 +18752,8 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18680,7 +18768,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr ""
+"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -19450,7 +19539,8 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr ""
+"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19614,7 +19704,8 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr ""
+"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19627,7 +19718,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr "Muestra los números de página en los saltos de página de los resultados"
+msgstr ""
+"Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19640,7 +19732,8 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr ""
+"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19745,7 +19838,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr ""
+"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19959,7 +20053,8 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr ""
+"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20326,7 +20421,8 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr ""
+"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20889,7 +20985,8 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup guarda más chats y los sincroniza en todos tus dispositivos."
+msgstr ""
+"Sync & Backup guarda más chats y los sincroniza en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20974,7 +21071,8 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr ""
+"La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
@@ -21129,7 +21227,8 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr ""
+"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21510,7 +21609,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr ""
+"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21679,13 +21779,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr ""
+"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21705,7 +21807,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21713,7 +21816,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr ""
+"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21957,7 +22061,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr ""
+"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22155,8 +22260,8 @@ msgstr "Cambia al chat privado de IA o %1$sdesactívalo en los ajustes%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
-"%2$s.%3$s"
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22217,6 +22322,12 @@ msgstr "Demasiados resultados de esta fuente"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Demasiado lento"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22378,7 +22489,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22386,7 +22498,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr ""
+"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22641,20 +22754,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr ""
+"Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr ""
+"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prueba con menos palabras."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22826,13 +22947,15 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr ""
+"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr ""
+"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -23226,7 +23349,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr ""
+"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23406,7 +23530,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr ""
+"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -24014,7 +24139,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr ""
+"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24210,7 +24336,8 @@ msgstr "Fondo de pantalla"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "¿Quieres un acceso fácil al chat privado de IA en la página de nueva pestaña?"
+msgstr ""
+"¿Quieres un acceso fácil al chat privado de IA en la página de nueva pestaña?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24367,7 +24494,8 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "No almacenamos nombres de usuario ni información personal identificable."
+msgstr ""
+"No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24547,12 +24675,14 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr ""
+"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr ""
+"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24797,7 +24927,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr ""
+"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24838,7 +24969,8 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr ""
+"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -25246,7 +25378,8 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr ""
+"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25278,7 +25411,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr ""
+"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25296,7 +25430,8 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr ""
+"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -26002,7 +26137,8 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr ""
+"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26082,7 +26218,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr ""
+"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26187,12 +26324,14 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr ""
+"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr ""
+"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.

--- a/locales/es_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_ES/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -452,8 +452,7 @@ msgstr "%1$s palabras"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
+msgstr "%1$sPulsa %2$sAñadir%3$sMarcar %4$sPermitir%5$s y luego %6$sAceptar%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -2335,22 +2334,19 @@ msgstr "¿Sigues ahí?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar todos tus chats? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
+msgstr "¿Estás seguro de que quieres eliminar esta conversación y empezar una nueva?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
+msgstr "¿Seguro que quieres borrar este chat? Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2993,6 +2989,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Antes de almacenar este informe, DuckDuckGo eliminará los archivos subidos y "
+"las imágenes generadas, y anonimizará tu conversación eliminando información "
+"personal como nombres, direcciones de correo electrónico y metadatos "
+"identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4717,8 +4717,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
+msgstr "Pulsa %1$sPrivacidad y servicios%2$s en la barra lateral de la izquierda."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4745,8 +4744,7 @@ msgstr "Haz clic en %1$sAjustes%2$s en el menú desplegable."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
+msgstr "Pulsa %1$sUse las actuales páginas%2$s y, a continuación, %3$sAceptar%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4879,8 +4877,7 @@ msgstr "Haz clic en el %1$sicono de permisos%2$s en la barra de direcciones"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
+msgstr "¡Pulsa el icono del pato en la parte superior del navegador para buscar!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5522,8 +5519,7 @@ msgstr "Copiar"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
+msgstr "Copia y pega %1$sabout:preferences#search%2$s en la barra de direcciones"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6286,8 +6282,7 @@ msgstr "¿Borrar los chats más antiguos para liberar espacio de almacenamiento?
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
+msgstr "¿Eliminar los chats más antiguos con archivos adjuntos para liberar espacio?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6419,8 +6414,7 @@ msgstr "Dictado en Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
+msgstr "Anonimizamos el dictado y nunca lo utilizamos para entrenar modelos de IA."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6572,7 +6566,7 @@ msgstr "No me gusta la fuente"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "No me gusta el estilo visual"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6688,7 +6682,7 @@ msgstr "Yibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "No sigue las instrucciones"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7112,8 +7106,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
+msgstr "¡Duck.ai es mejor en nuestro navegador privado y gratuito de DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7172,8 +7165,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
+msgstr "Duck.ai no está disponible temporalmente. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8180,8 +8172,7 @@ msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
+msgstr "Asegúrate de que tu navegador tenga permitido el acceso a la ubicación."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8275,8 +8266,7 @@ msgstr "Guinea Ecuatorial"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
+msgstr "Borra tus datos de navegación en un instante con nuestro %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8464,8 +8454,7 @@ msgstr "Explora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
+msgstr "Explora las últimas actualizaciones de productos y funciones de DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8584,7 +8573,7 @@ msgstr "Rápido"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Generación rápida de imágenes"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8781,8 +8770,7 @@ msgstr "Asesor financiero"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
+msgstr "Busca %1$sDuckDuckGo%2$s y haz clic en %3$sEstablecer como predeterminado%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8924,7 +8912,7 @@ msgstr "Los mensajes de seguimiento siguen siendo privados."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Siguió las instrucciones"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9030,8 +9018,7 @@ msgstr "Chats gratuitos y privados, anonimizados por nosotros"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
+msgstr "Chats gratuitos y privados, anonimizados por nosotros. No se requiere cuenta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9061,8 +9048,7 @@ msgstr "Libre de compartir y usar comercialmente"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
+msgstr "Libera espacio eliminando tus chats. Los chats anclados no se eliminarán."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9143,9 +9129,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"En la barra de menú de la aplicación en Mac, selecciona <strong>DuckDuckGo</"
-"strong> &gt; <strong>Buscar actualizaciones...</strong> y, a continuación, "
-"selecciona <strong>Instalar actualización</strong>."
+"En la barra de menú de la aplicación en Mac, selecciona "
+"<strong>DuckDuckGo</strong> &gt; <strong>Buscar actualizaciones...</strong> "
+"y, a continuación, selecciona <strong>Instalar actualización</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9667,8 +9653,8 @@ msgstr "Obtén la app"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en YouTube."
-"%2$s"
+"Obtén el navegador gratuito DuckDuckGo %1$spara bloquear anuncios en "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9872,7 +9858,7 @@ msgstr "Buena política de privacidad"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Buen estilo visual"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10616,8 +10602,7 @@ msgstr "Falta el horario"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Color de fondo al pasar el cursor, de los módulos y de los desplegables"
+msgstr "Color de fondo al pasar el cursor, de los módulos y de los desplegables"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10708,15 +10693,13 @@ msgstr "Cómo funciona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
+msgstr "¿Con qué frecuencia quieres que aparezcan las respuestas asistidas por IA?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
+msgstr "Qué parte de tus límites diarios y semanales has utilizado hasta ahora."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10971,8 +10954,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
+msgstr "Si quieres usar DuckDuckGo sin JavaScript, usa nuestra versión %1$s o %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11019,14 +11001,14 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
-"Las indicaciones para las imágenes deben cumplir con las directrices de Duck."
-"ai %1$s."
+"Las indicaciones para las imágenes deben cumplir con las directrices de "
+"Duck.ai %1$s."
 
 # smartling.placeholder_format=C
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Calidad de la imagen"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11957,8 +11939,7 @@ msgstr "Obtén más información sobre la protección de privacidad activa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Más información sobre la privacidad en Internet en tu bandeja de entrada."
+msgstr "Más información sobre la privacidad en Internet en tu bandeja de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -12081,8 +12062,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Te permite alternar entre enviar consultas de búsqueda y sugerencias a Duck."
-"ai"
+"Te permite alternar entre enviar consultas de búsqueda y sugerencias a "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -15590,8 +15571,7 @@ msgstr "Anclados"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Los chats anclados aparecerán en la parte superior de tus chats recientes."
+msgstr "Los chats anclados aparecerán en la parte superior de tus chats recientes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15650,15 +15630,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
+msgstr "Describe por qué la respuesta del chat es perjudicial o ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
+msgstr "Describe por qué la respuesta del chat es ilegal o perjudicial. (Opcional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15916,7 +15894,7 @@ msgstr "Formato deficiente"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Mala calidad de imagen"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16433,8 +16411,7 @@ msgstr "Pedir confirmación"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
+msgstr "Pedirme utilizar mi ubicación aproximada para obtener mejores resultados."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16707,8 +16684,7 @@ msgstr "IA de razonamiento con moderación media integrada"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
+msgstr "El razonamiento puede ofrecer mejores respuestas a preguntas complejas."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17557,8 +17533,7 @@ msgstr "Reseñas"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Reescribe esta receta ajustándola para un número diferente de raciones."
+msgstr "Reescribe esta receta ajustándola para un número diferente de raciones."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17843,8 +17818,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
+msgstr "Guarda hasta 30 de tus chats más recientes localmente en tu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -18402,8 +18376,7 @@ msgstr "Segunda opinión"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
+msgstr "Guarda y sincroniza tus chats de forma segura en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18626,8 +18599,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
+msgstr "Selecciona %1$sDuckDuckGo%2$s y pulsa %3$sAgregar como predeterminado%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18726,8 +18698,7 @@ msgstr "Selecciona %1$sMotor de búsqueda%2$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
+msgstr "Selecciona %1$sMotor de búsqueda%2$s y, a continuación, %3$sOtros...%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18752,8 +18723,7 @@ msgstr "Selecciona %1$sAjustes%2$s en el menú desplegable."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sAjustes avanzados%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18768,8 +18738,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sSearch Engine%s"
-msgstr ""
-"Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
+msgstr "Selecciona %1$sAjustes%2$s y, a continuación, %3$sMotor de búsqueda%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -19539,8 +19508,7 @@ msgstr "Mostrar todos los resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
+msgstr "Mostrar respuestas con más frecuencia. (También puedes %1$sapagarlas%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19704,8 +19672,7 @@ msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo al navegador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
+msgstr "Muestra recordatorios ocasionales para añadir DuckDuckGo a tus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19718,8 +19685,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows page numbers at result page breaks"
-msgstr ""
-"Muestra los números de página en los saltos de página de los resultados"
+msgstr "Muestra los números de página en los saltos de página de los resultados"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19732,8 +19698,7 @@ msgstr ""
 #. http://i.imgur.com/94erFcS.png
 msgctxt "settings"
 msgid "Shows suggestions under the search box as you type"
-msgstr ""
-"Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
+msgstr "Muestra sugerencias debajo del cuadro de búsqueda a medida que escribes"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19838,8 +19803,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
+msgstr "Los sitios que bloquees se ocultarán de todos tus resultados de búsqueda"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -20053,8 +20017,7 @@ msgstr "Lo sentimos, se ha producido un error inesperado."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
+msgstr "Lo sentimos, no se ha encontrado información relevante en nuestra búsqueda."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20421,8 +20384,7 @@ msgstr "Detén a los rastreadores ocultos que acechan en otros sitios web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
+msgstr "Detén a la mayoría de rastreadores ocultos que acechan en otros sitios web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20985,8 +20947,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup guarda más chats y los sincroniza en todos tus dispositivos."
+msgstr "Sync & Backup guarda más chats y los sincroniza en todos tus dispositivos."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21071,8 +21032,7 @@ msgstr "Sincronizar con otro dispositivo"
 #. Title shown when sync service is temporarily unavailable.
 msgctxt "Sync unavailable modal title"
 msgid "Sync and Backup is temporarily unavailable"
-msgstr ""
-"La sincronización y la copia de seguridad no están disponibles temporalmente"
+msgstr "La sincronización y la copia de seguridad no están disponibles temporalmente"
 
 # smartling.placeholder_format=C
 #. Onboarding checklist item: opens the Sync setup so the user can access chat history across devices. Leads with the Sync mechanism and explains its cross-device benefit.
@@ -21227,8 +21187,7 @@ msgstr "Toma el control de tus datos personales"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
+msgstr "Responde a esta encuesta anónima para decirnos cómo podemos mejorar Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21609,8 +21568,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
+msgstr "Se ha producido un problema al cargar esta respuesta. Inténtalo de nuevo."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21779,15 +21737,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
+msgstr "Este archivo es demasiado grande. El tamaño máximo del archivo es de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21807,8 +21763,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21816,8 +21771,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
+msgstr "Este tipo de archivo no es compatible, por favor adjunta un %1$s o %2$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -22061,8 +22015,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
+msgstr "Esto eliminará tu imagen seleccionada. Esta acción no se puede deshacer."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22260,8 +22213,8 @@ msgstr "Cambia al chat privado de IA o %1$sdesactívalo en los ajustes%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú %2$s."
-"%3$s"
+"Cambia para probar el chat privado de IA o %1$sdesactívalo en el menú "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22327,7 +22280,7 @@ msgstr "Demasiado lento"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Tarda demasiado en generarse"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22489,8 +22442,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al francés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22498,8 +22450,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
+msgstr "Traduce esta frase del español al inglés: «¿Cómo ir al cine más cercano?»"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22754,16 +22705,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Prueba a activar la ubicación anónima para obtener resultados más precisos."
+msgstr "Prueba a activar la ubicación anónima para obtener resultados más precisos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
+msgstr "Intenta experimentar con cada modelo, ya que ofrecerán diferentes respuestas."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22775,7 +22724,7 @@ msgstr "Prueba con menos palabras."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Probar gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22947,15 +22896,13 @@ msgstr "Prueba %1$s y %2$s de código abierto recientemente añadidos"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
+msgstr "Prueba los recientemente añadidos de código abierto Llama 3.1 y Mixtral"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
+msgstr "Prueba uno de estos mensajes o introduce tu propio mensaje a continuación"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -23349,8 +23296,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
+msgstr "En %1$sAbrir con%2$s, selecciona %3$sUna o varias páginas específicas%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23530,8 +23476,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
+msgstr "Desbloquea modelos de IA más capaces con una suscripción a DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -24139,8 +24084,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
+msgstr "Visita %1$sDuckDuckGo.com%2$s en tu móvil o tablet y sigue las instrucciones."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24336,8 +24280,7 @@ msgstr "Fondo de pantalla"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"¿Quieres un acceso fácil al chat privado de IA en la página de nueva pestaña?"
+msgstr "¿Quieres un acceso fácil al chat privado de IA en la página de nueva pestaña?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24494,8 +24437,7 @@ msgstr "No te perseguimos con anuncios."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"No almacenamos nombres de usuario ni información personal identificable."
+msgstr "No almacenamos nombres de usuario ni información personal identificable."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24675,14 +24617,12 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
+msgstr "Confiamos en tus comentarios anónimos para mejorar DuckDuckGo para todos."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
+msgstr "Impedimos que nadie acceda a tu historial de búsquedas, ni siquiera nosotros."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24927,8 +24867,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
+msgstr "¡Te damos la bienvenida al nuevo Duck.ai! Es hora de importar tus chats."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24969,8 +24908,7 @@ msgstr "Conferencia Oeste"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "We’re currently experiencing an issue with DuckDuckGo Search."
-msgstr ""
-"En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
+msgstr "En estos momentos, estamos experimentando un problema con DuckDuckGo Search."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong even though we were able to show some organic results.
@@ -25378,8 +25316,7 @@ msgstr "¿Sobre qué te gustaría dar tu opinión?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
+msgstr "Lo que veas en DuckDuckGo no influirá en tus recomendaciones en YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25411,8 +25348,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
+msgstr "Cuando esté activado, Duck.ai mostrará respuestas instantáneas en el chat."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25430,8 +25366,7 @@ msgstr "Dónde ver <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
+msgstr "Donde pone Página de inicio pulsa en %1$sEstablecer como página actual%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -26137,8 +26072,7 @@ msgstr "Puedes empezar de cero en este nuevo dominio (duck.ai)."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
+msgstr "Puedes almacenar varios conjuntos de ajustes para diferentes propósitos."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26218,8 +26152,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"No volverás a ver este mensaje a menos que borres los datos de tu navegador."
+msgstr "No volverás a ver este mensaje a menos que borres los datos de tu navegador."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26324,14 +26257,12 @@ msgstr "Has alcanzado la duración máxima del chat de voz para una sola sesión
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
+msgstr "Has alcanzado el límite de chat de voz para hoy. Inténtalo de nuevo mañana."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
+msgstr "Has alcanzado tu límite de uso de dictado. Inténtalo de nuevo más tarde."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.

--- a/locales/es_MX/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_MX/LC_MESSAGES/duckduckgo.po
@@ -2379,6 +2379,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5244,6 +5255,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Descartar"
@@ -5333,6 +5349,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6792,6 +6813,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7049,6 +7075,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7798,6 +7829,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8726,6 +8762,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12680,6 +12721,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17753,6 +17799,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18113,6 +18164,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prueba menos palabras."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/es_PE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_PE/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6769,6 +6790,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7024,6 +7050,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7771,6 +7802,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8693,6 +8729,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12630,6 +12671,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17686,6 +17732,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18045,6 +18096,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_UY/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_UY/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6759,6 +6780,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7014,6 +7040,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7761,6 +7792,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8681,6 +8717,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12615,6 +12656,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17658,6 +17704,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18017,6 +18068,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/es_VE/LC_MESSAGES/duckduckgo.po
+++ b/locales/es_VE/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5220,6 +5231,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5309,6 +5325,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6766,6 +6787,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7023,6 +7049,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7770,6 +7801,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8692,6 +8728,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12628,6 +12669,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17677,6 +17723,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18036,6 +18087,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -448,7 +448,8 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr ""
+"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -2243,7 +2244,8 @@ msgstr "Mistahes ajal"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr "Igaüks, kellel on link, saab vestlust vaadata ja sellest koopia salvestada."
+msgstr ""
+"Igaüks, kellel on link, saab vestlust vaadata ja sellest koopia salvestada."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2541,8 +2543,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
-"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
+"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2663,7 +2665,8 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr ""
+"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2963,6 +2966,18 @@ msgstr ""
 "Enne selle aruande salvestamist muudab DuckDuckGo sinu vestluse anonüümseks, "
 "eemaldades automaatselt isikuandmeid nagu nimed, e-posti aadressid ja "
 "tuvastavad metaandmed."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4129,7 +4144,8 @@ msgstr "Vestle %1$s-ga"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr "Vestle populaarsete tehisintellekti mudelitega, meie poolt anonüümistatud."
+msgstr ""
+"Vestle populaarsete tehisintellekti mudelitega, meie poolt anonüümistatud."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4609,9 +4625,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
-"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
+"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4670,7 +4686,8 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr ""
+"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5944,7 +5961,8 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6370,8 +6388,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
-"AI-mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
+"mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6520,6 +6538,12 @@ msgid "Dislike source"
 msgstr "Ei meeldi allikas"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Tühista"
@@ -6628,6 +6652,12 @@ msgstr "Divisioni rekord"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djibouti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7243,9 +7273,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
-"vestlusmudeleid OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
+"OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7254,8 +7284,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
-"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
+"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7361,7 +7391,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr ""
+"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8242,7 +8273,8 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr ""
+"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8480,6 +8512,12 @@ msgstr "Lõppenud"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Kiire"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8807,6 +8845,12 @@ msgid "Follow-ups remain private."
 msgstr "Järgnevad sõnumid jäävad privaatseks."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8910,7 +8954,8 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr ""
+"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8940,7 +8985,8 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr ""
+"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9495,8 +9541,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud "
-"Duck.ai, Personal Information Removal ja Identity Theft Restoration teenus."
+"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud Duck."
+"ai, Personal Information Removal ja Identity Theft Restoration teenus."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9548,7 +9594,8 @@ msgstr "Hangi rakendus"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
+msgstr ""
+"Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9746,6 +9793,12 @@ msgstr "Hea disain"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Hea privaatsuspoliitika"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10584,7 +10637,8 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr ""
+"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10882,6 +10936,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Pildiviibad peavad vastama Duck.ai tingimustele %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11404,7 +11464,8 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr ""
+"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11928,7 +11989,8 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
+msgstr ""
+"Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12040,7 +12102,8 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr ""
+"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12337,7 +12400,8 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr ""
+"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14430,7 +14494,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr ""
+"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14777,8 +14842,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "Meie kiire ja kasutajate andmeid salvestamatu VPN sisaldab nutikamaid "
-"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid "
-"premium-kaitseid. Kõik ühes tellimuses."
+"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid premium-"
+"kaitseid. Kõik ühes tellimuses."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -15372,7 +15437,8 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr ""
+"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15468,19 +15534,22 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr ""
+"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr ""
+"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr ""
+"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15733,6 +15802,12 @@ msgstr "poola keel"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Kehv vormindus"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16530,13 +16605,15 @@ msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
+msgstr ""
+"Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
+msgstr ""
+"Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17298,7 +17375,8 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr ""
+"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17369,7 +17447,8 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr ""
+"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17661,7 +17740,8 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr ""
+"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17850,7 +17930,8 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr ""
+"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18252,7 +18333,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr ""
+"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18412,7 +18494,8 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr ""
+"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18806,7 +18889,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr ""
+"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18880,7 +18964,8 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr ""
+"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18907,8 +18992,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
-"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
+"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19060,8 +19145,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire "
-"VPN-iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
+"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire VPN-"
+"iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19907,7 +19992,8 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr ""
+"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -21256,7 +21342,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr ""
+"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21406,7 +21493,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr ""
+"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21755,7 +21843,8 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr ""
+"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21875,7 +21964,8 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr ""
+"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21933,8 +22023,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
-"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
+"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22044,6 +22134,12 @@ msgstr "Sellest allikast on liiga palju tulemusi"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Liiga aeglane"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22331,7 +22427,8 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr ""
+"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22464,7 +22561,8 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr ""
+"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22484,6 +22582,12 @@ msgstr "Proovi katsetada iga mudeliga — need annavad erinevaid vastuseid."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Proovi kasutada vähem märksõnu."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22857,7 +22961,8 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr ""
+"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23049,8 +23154,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
-"https://duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23572,7 +23677,8 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr ""
+"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24034,7 +24140,8 @@ msgstr "Taustapilt"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Kas soovid uuel vahelehel hõlpsat juurdepääsu privaatsele AI-vestlusele?"
+msgstr ""
+"Kas soovid uuel vahelehel hõlpsat juurdepääsu privaatsele AI-vestlusele?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24187,7 +24294,8 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr ""
+"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24367,7 +24475,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr ""
+"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24546,7 +24655,8 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr ""
+"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25318,8 +25428,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie "
-"e-posti aadress, nimi, aadress ja muu."
+"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie e-"
+"posti aadress, nimi, aadress ja muu."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25588,7 +25698,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr ""
+"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25628,8 +25739,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
-"%1$sDuck.ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
+"ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25703,7 +25814,8 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr ""
+"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25884,7 +25996,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr ""
+"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -25974,7 +26087,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr ""
+"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25987,7 +26101,8 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr ""
+"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26134,7 +26249,8 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr ""
+"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26176,8 +26292,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
-"AI-mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
+"mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/et_EE/LC_MESSAGES/duckduckgo.po
+++ b/locales/et_EE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: et_EE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -448,8 +448,7 @@ msgstr "%1$s sõna"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
+msgstr "%1$sKlõpsa %2$sLisa%3$sKontrolli %4$sLuba%5$s, seejärel klõpsa %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -2244,8 +2243,7 @@ msgstr "Mistahes ajal"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr ""
-"Igaüks, kellel on link, saab vestlust vaadata ja sellest koopia salvestada."
+msgstr "Igaüks, kellel on link, saab vestlust vaadata ja sellest koopia salvestada."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2543,8 +2541,8 @@ msgstr ""
 "mõnedele otsingutele, tuginedes asjakohase veebisisu kokkuvõttele. Saate "
 "valida, kui tihti soovite Assisti kuvada: mitte kunagi (eemaldab "
 "otsingutulemustest täielikult Assisti kasutajaliidese), nõudmisel (AI-toega "
-"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord (AI-"
-"toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
+"vastuseid kuvatakse ainult siis, kui klõpsate nuppu Assist), mõnikord "
+"(AI-toega vastuseid kuvatakse ainult siis, kui need on väga asjakohased) või "
 "sageli (kuvatakse sagedamini laiema otsingute valiku puhul). Praegu on AI "
 "abil genereeritud vastused saadaval ainult USA (ingliskeelses) piirkonnas."
 
@@ -2665,8 +2663,7 @@ msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse lõppu."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
+msgstr "Heli ei salvestata meie ega OpenAI poolt pärast vestluse transkribeerimist."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2978,6 +2975,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Enne selle aruande salvestamist eemaldab DuckDuckGo üleslaaditud failid ja "
+"genereeritud pildid ning muudab sinu vestluse anonüümseks, eemaldades "
+"isikuandmed nagu nimed, e-posti aadressid ja tuvastavad metaandmed."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4144,8 +4144,7 @@ msgstr "Vestle %1$s-ga"
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Chat with popular AI models, anonymized by us."
-msgstr ""
-"Vestle populaarsete tehisintellekti mudelitega, meie poolt anonüümistatud."
+msgstr "Vestle populaarsete tehisintellekti mudelitega, meie poolt anonüümistatud."
 
 # smartling.placeholder_format=C
 #. Text for a button button that allows users to access their recent chat conversations. The translation should convey the meaning of 'recent activity' or 'recently generated conversations', not historical events or periods.
@@ -4625,9 +4624,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi %1$sDuck."
-"ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teised."
+"Teema süvenemiseks klõpsake nuppu \"Veel\" ja esitage lisaküsimusi "
+"%1$sDuck.ai%2$skaudu, meie privaatne AI-vestlusteenus, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teised."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4686,8 +4685,7 @@ msgstr "Klõpsa %1$sSiia%2$s, et laadida alla DuckDuckGo laiend"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
+msgstr "Klõpsa %1$sAva%2$s, et laadida alla ja avada DuckDuckGo Safari laiendus"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -5961,8 +5959,7 @@ msgstr "Päevane piirang on saavutatud"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Päevane kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6388,8 +6385,8 @@ msgstr "Dikteerimine Duck.ai-s"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi AI-"
-"mudelite koolitamiseks."
+"Dikteerimine on meie poolt anonümiseeritud ja seda ei kasutata kunagi "
+"AI-mudelite koolitamiseks."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6541,7 +6538,7 @@ msgstr "Ei meeldi allikas"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Ei meeldi visuaalne stiil"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6657,7 +6654,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Ei järgi juhiseid"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7273,9 +7270,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab vestlusmudeleid "
-"OpenAI, Anthropic ja teisi."
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust %1$sDuckDuckGo AI Chat%2$s, mis toetab "
+"vestlusmudeleid OpenAI, Anthropic ja teisi."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7284,8 +7281,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset AI-"
-"põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
+"DuckAssist ei saa järelküsimustele vastata, kuid pakume ka privaatset "
+"AI-põhist vestlusteenust DuckDuckGo %1$sAI Chat%2$s, mis toetab OpenAI ja "
 "Anthropicu vestlusmudeleid."
 
 # smartling.placeholder_format=C
@@ -7391,8 +7388,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
+msgstr "DuckDuckGo AI Chat pole ajutiselt saadaval. Värskenda lehte ja proovi uuesti."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -8273,8 +8269,7 @@ msgstr "Laienda kaarti"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
+msgstr "Asjatundlikult loodud tooted inimestele, kes tõesti hoolivad privaatsusest."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8517,7 +8512,7 @@ msgstr "Kiire"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Kiire pildi genereerimine"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8848,7 +8843,7 @@ msgstr "Järgnevad sõnumid jäävad privaatseks."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Järgis juhiseid"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8954,8 +8949,7 @@ msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
+msgstr "Meie poolt anonüümistatud tasuta ja privaatsed vestlused. Konto pole vajalik."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8985,8 +8979,7 @@ msgstr "Tasuta jagatavad ja kaubanduslikult kasutatavad"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
+msgstr "Vabasta ruumi oma vestluste kustutamisega. Kinnitatud vestlusi ei kustutata."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9541,8 +9534,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud Duck."
-"ai, Personal Information Removal ja Identity Theft Restoration teenus."
+"Hangi meie turvaline, kasutajate andmeid salvestamatu VPN, täiustatud "
+"Duck.ai, Personal Information Removal ja Identity Theft Restoration teenus."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9594,8 +9587,7 @@ msgstr "Hangi rakendus"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
+msgstr "Hangi tasuta DuckDuckGo brauser %1$sreklaamide blokeerimiseks YouTube'is.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9798,7 +9790,7 @@ msgstr "Hea privaatsuspoliitika"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Hea visuaalne stiil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10637,8 +10629,7 @@ msgstr "Kui tihti soovid, et ilmuksid AI-toega vastused?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
+msgstr "Kui suurt osa oma päevastest ja nädalapiirangutest sa seni kasutanud oled."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10941,7 +10932,7 @@ msgstr "Pildiviibad peavad vastama Duck.ai tingimustele %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Pildikvaliteet"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11464,8 +11455,7 @@ msgstr "See on kiire, tasuta ja pakub sulle veelgi suuremat võrgukaitset."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
+msgstr "Mulle sobib, kui küsite (väga harva) minu DuckDuckGo kasutuskogemuse kohta"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11989,8 +11979,7 @@ msgstr "Võimaldab sul DuckDuckGo abil anonüümselt otsida"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
+msgstr "Võimaldab vahetada Duck.ai-le otsingupäringute ja käskluste saatmise vahel"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12102,8 +12091,7 @@ msgstr "Lingid:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
+msgstr "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12400,8 +12388,7 @@ msgstr "Veendu, et kõik sõnad on korrektselt kirjutatud."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
+msgstr "Veendu, et märkisid %1$s„Muuda see minu vaikimisi otsingupakkujaks“%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14494,8 +14481,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
+msgstr "Oih! Selle teksti tõlkimisel tekkis ootamatu viga. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14842,8 +14828,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "Meie kiire ja kasutajate andmeid salvestamatu VPN sisaldab nutikamaid "
-"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid premium-"
-"kaitseid. Kõik ühes tellimuses."
+"tehisintellekti vestlusi kõrgemate piirangutega ning lisaks muid "
+"premium-kaitseid. Kõik ühes tellimuses."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -15437,8 +15423,7 @@ msgstr "Vali konkreetne probleem"
 #. Header instructing the user to follow the instructions for their ad blocker
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
-msgstr ""
-"Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
+msgstr "Vali oma reklaamiblokeerija ja järgi juhiseid, et lubada DuckDuckGo reklaame."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15534,22 +15519,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
+msgstr "Soorita järgmine ülesanne, et kinnitada, et selle otsingu tegi inimene."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
+msgstr "Kirjelda, miks vestluse vastus on kahjulik või ebaseaduslik. (valikuline)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
+msgstr "Kirjeldage, miks vestluse vastus on ebaseaduslik või kahjulik. (Valikuline)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15807,7 +15789,7 @@ msgstr "Kehv vormindus"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Kehv pildikvaliteet"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16605,15 +16587,13 @@ msgstr "Arutlus võib anda paremaid vastuseid keerulistele küsimustele."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
+msgstr "Arutlus on põhjalikum, kuid jõuab kasutuspiiranguteni 2–5 korda varem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
+msgstr "Arutlus on põhjalikum, kuid ammendab piiranguid 2–5 korda kiiremini. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17375,8 +17355,7 @@ msgstr "Tulemused ei sisalda blokeeritud saitide teavet."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
+msgstr "Tulemused välistavad sinu blokeeritud saidid, mida saad hallata oma %1$s-s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17447,8 +17426,7 @@ msgstr "Arvustused"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
+msgstr "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -17740,8 +17718,7 @@ msgstr "Salvesta oma seadmesse kuni 30 viimast vestlust."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
+msgstr "Salvesta oma Duck.ai vestlused seadmete vahel otsast lõpuni krüptimisega."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17930,8 +17907,7 @@ msgstr "Keri alla ja leia loendist %1$soma brauser%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
+msgstr "Keri alla suvandini %1$sDuckDuckGo%2$s ja luba sellel oma asukohta kasutada."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18333,8 +18309,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
+msgstr "Turvaliselt salvestatud DuckDuckGo serverisse otspunktide krüptimisega."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18494,8 +18469,7 @@ msgstr "Vali Safari menüüst %1$sSelle veebisaidi seadistamine...%2$s."
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
+msgstr "Vali %1$sKohanda%2$s ja sisesta %3$shttps://duckduckgo.com%4$s sisendväljale"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18889,8 +18863,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
+msgstr "Määra oma asukoht käsitsi või veendu, et asukohateenused oleksid lubatud."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18964,8 +18937,7 @@ msgstr "Jaga"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
+msgstr "Jaga rakendust DuckDuckGo ja aita sõpradel oma privaatsus tagasi saada!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18992,8 +18964,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. Duck."
-"ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
+"Jaga linna tasemel asukohta TI-mudelitega, et parandada asjakohasust. "
+"Duck.ai ei avalda meile ega TI-mudelitele kunagi teie täpset asukohta."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19145,8 +19117,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire VPN-"
-"iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
+"Kaitse oma veebitegevust meie kasutajate andmeid salvestamatu ja kiire "
+"VPN-iga. Lihtne seadistada ning igal ajal hõlpsasti sisse ja välja lülitada."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19992,8 +19964,7 @@ msgstr "Algtekst kustutatud"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
+msgstr "Algtekst on liiga pikk, et seda kokku võtta. Proovi uuesti lühema valikuga."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -21342,8 +21313,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
+msgstr "Mudelipakkuja kustutab kõik selle vestlusega seotud andmed 30 päeva jooksul."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21493,8 +21463,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
+msgstr "See AI mudel pole enam saadaval. Proovi alustada uut vestlust teise mudeliga."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21843,8 +21812,7 @@ msgstr "See tõlge on vale"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
+msgstr "Seda videot ei saa veel siin vaadata. Sa saad seda vaadata saidil %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21964,8 +21932,7 @@ msgstr "Soovitused"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
+msgstr "Oled väsinud sellest, et sind võrgus jälitatakse? %1$sMeie saame aidata.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22023,8 +21990,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "Sünkroonitud andmete taastamiseks vajad taastamiskoodi, mille salvestasid "
-"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud PDF-"
-"vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
+"sünkroonimise esmakordsel seadistamisel. See kood võis olla salvestatud "
+"PDF-vormingus seadmesse, milles sa sünkroonimise algselt seadistasid."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22139,7 +22106,7 @@ msgstr "Liiga aeglane"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Liiga aeglane genereerimiseks"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22427,8 +22394,7 @@ msgstr "Proovi %1$s, et selliseid sõnumeid enam ei näeks."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
+msgstr "Proovi mudelit %1$s, meie esimest mudelit null teenusepakkuja nähtavusega."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22561,8 +22527,7 @@ msgstr "Proovi teisi märksõnu."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
+msgstr "Rohkemate tulemuste nägemiseks proovi DuckDuckGo reklaamiblokeerija keelata."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22587,7 +22552,7 @@ msgstr "Proovi kasutada vähem märksõnu."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Proovi tasuta"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22961,8 +22926,7 @@ msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Täpne asukoht“
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
+msgstr "Täpsemate tulemuste saamiseks lülita sisse suvand „Kasuta täpset asukohta“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23154,8 +23118,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: https://"
-"duckduckgo.com"
+"Jaotisest %1$sKäivitamisel%2$s vali %3$sAvaleht%4$s ja sisesta: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23677,8 +23641,7 @@ msgstr "Kasuta DuckDuckGo privaatset otsingut"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
+msgstr "Kasuta DuckDuckGo privaatsest otsingut oma iPadis, iPhone'is või Androidis!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24140,8 +24103,7 @@ msgstr "Taustapilt"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Kas soovid uuel vahelehel hõlpsat juurdepääsu privaatsele AI-vestlusele?"
+msgstr "Kas soovid uuel vahelehel hõlpsat juurdepääsu privaatsele AI-vestlusele?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24294,8 +24256,7 @@ msgstr "Me ei jälita sind reklaamidega."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
+msgstr "Me ei salvesta kasutajanimesid ega isikut tuvastada võimaldavat teavet."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24475,8 +24436,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
+msgstr "Me ei lase kellelgi, sealhulgas meil endil, sinu otsinguajalugu vaadata."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24655,8 +24615,7 @@ msgstr "Nädala kasutuspiirang on saavutatud"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
+msgstr "Nädala kasutuspiirang on saavutatud. Saad seda vestlust jätkata pärast %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25428,8 +25387,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie e-"
-"posti aadress, nimi, aadress ja muu."
+"Töötab otse teie seadmest, et eemaldada andmevahendajate saitidelt teie "
+"e-posti aadress, nimi, aadress ja muu."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25698,8 +25657,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
+msgstr "Vestled %1$s-ga. AI-vestlused võivad kuvada ebatäpset või solvavat teavet."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25739,8 +25697,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka %1$sDuck."
-"ai%2$s."
+"Küsimustele vastamiseks või teksti kokkuvõtmiseks võite kasutada ka "
+"%1$sDuck.ai%2$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25814,8 +25772,7 @@ msgstr "Saad vestlust jätkata, kasutades oma igakuist piirangut."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
+msgstr "Nüüd saad sellesse seadmesse salvestada kuni 100 vestlust. Vestle edasi!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25996,8 +25953,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
+msgstr "Sa ei näe seda sõnumit enam, kui sa ei kustuta oma veebilehitseja andmeid."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26087,8 +26043,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
+msgstr "Oled hetkel saavutanud maksimaalse sõnumite arvu. Proovi hiljem uuesti."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26101,8 +26056,7 @@ msgstr "Oled saavutanud ühe seansi maksimaalse häälvestluse kestuse."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
+msgstr "Oled jõudnud tänase päeva häälvestluse limiidini. Palun proovi homme uuesti."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26249,8 +26203,7 @@ msgstr "Sinu brauser näitab, kui oled seda linki külastanud"
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
+msgstr "Sinu brauser esitab sinu kõige sagedamini külastatavate saitide loetelu."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26292,8 +26245,8 @@ msgstr "Sinu vestlused salvestatakse nüüd."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi AI-"
-"mudelite treenimiseks"
+"Sinu vestlused on privaatsed ja neid ei salvestata ega kasutata kunagi "
+"AI-mudelite treenimiseks"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.

--- a/locales/eu_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/eu_ES/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6759,6 +6780,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7014,6 +7040,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7761,6 +7792,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8681,6 +8717,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12615,6 +12656,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17658,6 +17704,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18016,6 +18067,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fa_IR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fa_IR/LC_MESSAGES/duckduckgo.po
@@ -2387,6 +2387,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5241,6 +5252,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "لغو"
@@ -5330,6 +5346,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6805,6 +6826,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7064,6 +7090,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7811,6 +7842,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8747,6 +8783,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12702,6 +12743,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17779,6 +17825,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18137,6 +18188,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fi_FI/LC_MESSAGES/duckduckgo.po
+++ b/locales/fi_FI/LC_MESSAGES/duckduckgo.po
@@ -2948,6 +2948,18 @@ msgid ""
 msgstr ""
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -6495,6 +6507,12 @@ msgid "Dislike source"
 msgstr "En pidä lähteestä"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Ohita"
@@ -6603,6 +6621,12 @@ msgstr "Voitot ja tappiot divisioonassa"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djibouti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -8455,6 +8479,12 @@ msgid "Fast"
 msgstr "Nopea"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8773,6 +8803,12 @@ msgstr "Jatkokysymys"
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -9691,6 +9727,12 @@ msgstr "Hyvä ulkoasu"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Hyvä tietosuojakäytäntö"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10831,6 +10873,12 @@ msgstr "Kuvakehotteiden on oltava ehtojen \"%1$s\" mukaisia"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 # smartling.placeholder_format=C
@@ -15674,6 +15722,12 @@ msgstr "Puola"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Huono muotoilu"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -22002,6 +22056,12 @@ msgid "Too slow"
 msgstr "Liian hidas"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22443,6 +22503,12 @@ msgstr "Kokeile kutakin mallia - ne antavat erilaisia vastauksia."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Kokeile vähemmän hakusanoja."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fr_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_BE/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5229,6 +5240,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Fermer"
@@ -5318,6 +5334,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6779,6 +6800,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7034,6 +7060,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7781,6 +7812,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8707,6 +8743,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12655,6 +12696,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17722,6 +17768,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18080,6 +18131,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fr_CA/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CA/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5233,6 +5244,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Ignorer"
@@ -5322,6 +5338,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6780,6 +6801,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7035,6 +7061,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7782,6 +7813,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8709,6 +8745,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12658,6 +12699,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17722,6 +17768,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18081,6 +18132,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fr_CH/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_CH/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5229,6 +5240,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Rejeter"
@@ -5318,6 +5334,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6776,6 +6797,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7032,6 +7058,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7779,6 +7810,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8702,6 +8738,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12649,6 +12690,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17714,6 +17760,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18073,6 +18124,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1024,8 +1024,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
-"aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1511,8 +1511,7 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -2351,8 +2350,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2680,21 +2678,18 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2996,8 +2991,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses e-"
-"mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses "
+"e-mail et les métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -3010,6 +3005,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Avant de stocker ce rapport, DuckDuckGo supprimera les fichiers importés et "
+"les images générées, et anonymisera votre conversation en supprimant les "
+"données à caractère personnel comme les noms, les adresses e-mail et les "
+"métadonnées d'identification."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3145,8 +3144,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3162,8 +3160,7 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3511,8 +3508,7 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3911,8 +3907,7 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4409,8 +4404,7 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4778,8 +4772,7 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -6375,8 +6368,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6398,8 +6390,7 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr ""
-"Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6568,8 +6559,7 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6622,7 +6612,7 @@ msgstr "Je n'aime pas la source"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Je n'aime pas le style visuel"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6738,7 +6728,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Ne suit pas les instructions"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7161,8 +7151,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7253,8 +7242,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7270,8 +7258,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7954,8 +7941,7 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8230,15 +8216,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8640,7 +8624,7 @@ msgstr "Rapide"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Génération rapide d'images"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8707,8 +8691,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
-"collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
+"copiez-collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8790,8 +8774,7 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8848,8 +8831,7 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8960,8 +8942,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8978,7 +8959,7 @@ msgstr "Les messages complémentaires restent privés."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Instructions respectées"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9200,8 +9181,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
-"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
+"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9678,8 +9659,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé Duck."
-"ai, de Personal Information Removal et d'Identity Theft Restoration."
+"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé "
+"Duck.ai, de Personal Information Removal et d'Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9846,8 +9827,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9940,7 +9920,7 @@ msgstr "Bonne politique de confidentialité"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Bon style visuel"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10130,8 +10110,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10331,8 +10310,7 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10390,8 +10368,7 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10799,8 +10776,7 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr ""
-"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -11089,14 +11065,13 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr ""
-"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Qualité de l’image"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11616,8 +11591,7 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12266,8 +12240,7 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -14525,8 +14498,7 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14745,8 +14717,7 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14903,8 +14874,7 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15670,8 +15640,7 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Les discussions épinglées apparaîtront en haut de vos discussions récentes."
+msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -16000,7 +15969,7 @@ msgstr "Mauvais formatage"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Mauvaise qualité d’image"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16794,8 +16763,7 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Le raisonnement peut donner de meilleures réponses aux questions complexes."
+msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17180,8 +17148,7 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17649,8 +17616,7 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr ""
-"Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -18137,8 +18103,7 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr ""
-"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -18721,35 +18686,31 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
-"com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez "
+"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18790,8 +18751,7 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18865,8 +18825,7 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18927,8 +18886,7 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr ""
-"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18963,8 +18921,7 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19712,8 +19669,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
-"Découvrez des conseils étape par étape pour tirer le meilleur parti de Duck."
-"ai."
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19860,8 +19817,7 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20068,8 +20024,7 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr ""
-"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -20097,8 +20052,7 @@ msgstr "Une erreur s'est produite"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Une erreur s'est produite lors du chargement de cette discussion partagée."
+msgstr "Une erreur s'est produite lors du chargement de cette discussion partagée."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20142,8 +20096,7 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20482,8 +20435,7 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20538,8 +20490,7 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20629,8 +20580,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
-"ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
+"Duck.ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20965,8 +20916,7 @@ msgstr "Changer de modèle"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -21168,8 +21118,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
-"ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
+"Duck.ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -21557,15 +21507,13 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr ""
-"Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21620,8 +21568,7 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21646,8 +21593,7 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr ""
-"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21707,8 +21653,7 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr ""
-"Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -21912,15 +21857,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21958,8 +21901,7 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr ""
-"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -22057,8 +21999,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
-"conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
+"non-conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -22178,8 +22120,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22320,8 +22261,7 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22335,8 +22275,7 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22409,8 +22348,8 @@ msgstr "Passez au chat IA privé ou %1$sdésactivez dans les paramètres%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Activez cette option pour essayer le chat privé avec l’IA ou %1$sdésactivez-"
-"la dans le menu %2$s.%3$s"
+"Activez cette option pour essayer le chat privé avec l’IA ou "
+"%1$sdésactivez-la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22476,7 +22415,7 @@ msgstr "Trop lent"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Se génère trop lentement"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22764,8 +22703,7 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22906,16 +22844,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22927,7 +22863,7 @@ msgstr "Essayer de nouveau avec moins de mots clés."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Essayer gratuitement"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23101,15 +23037,13 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr ""
-"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -23117,8 +23051,7 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr ""
-"Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -23306,8 +23239,7 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23500,20 +23432,18 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
-"saisissez : https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
+": https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -24074,8 +24004,7 @@ msgstr "Vous utilisez le Wi-Fi public ? Utilisez notre VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr ""
-"Utilisez le Fire Button pour supprimer une conversation de l’historique."
+msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24249,8 +24178,7 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24341,9 +24269,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
-"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
-"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
+"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
+"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -24511,8 +24439,7 @@ msgstr "Fond d'écran"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Tu veux accéder facilement au chat IA privé sur la page Nouvel onglet ?"
+msgstr "Tu veux accéder facilement au chat IA privé sur la page Nouvel onglet ?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24815,8 +24742,7 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -25107,8 +25033,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25460,8 +25385,7 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr ""
-"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -25473,8 +25397,7 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25483,8 +25406,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
-"il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
+"est-il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25829,8 +25752,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Fonctionne directement depuis votre appareil pour supprimer votre adresse e-"
-"mail, votre nom, votre adresse et plus encore des sites de courtiers en "
+"Fonctionne directement depuis votre appareil pour supprimer votre adresse "
+"e-mail, votre nom, votre adresse et plus encore des sites de courtiers en "
 "données."
 
 # smartling.placeholder_format=C
@@ -26173,8 +26096,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26204,8 +26126,7 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr ""
-"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -26510,8 +26431,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26525,8 +26445,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26681,8 +26600,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le plus."
-"DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le "
+"plus.DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26956,8 +26875,7 @@ msgstr "Tes liens partagés se trouvent dans %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -27025,8 +26943,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/fr_FR/LC_MESSAGES/duckduckgo.po
+++ b/locales/fr_FR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1024,8 +1024,8 @@ msgstr ""
 "AI Chat vous permet d'avoir des conversations anonymes avec des modèles de "
 "chat IA tiers. La désactivation de cette option masquera la fonctionnalité "
 "AI Chat sur DuckDuckGo Search. Vous pouvez toujours accéder à l'AI Chat "
-"lorsque ce paramètre est désactivé en consultant "
-"%1$sduckduckgo.com/aichat%2$s."
+"lorsque ce paramètre est désactivé en consultant %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1511,7 +1511,8 @@ msgstr "Ajouter un champ de recherche %1$s à votre site !"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
+msgstr ""
+"Ajoutez un lieu de départ et une destination pour trouver un itinéraire."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -2350,7 +2351,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
+msgstr ""
+"Voulez-vous vraiment effacer cette conversation et en commencer une autre ?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2678,18 +2680,21 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat terminé, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
+msgstr ""
+"Une fois le chat transcrit, le son n'est conservé ni par nous ni par OpenAI."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2991,8 +2996,20 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Avant de stocker ce rapport, DuckDuckGo anonymisera votre conversation en "
-"supprimant les données à caractère personnel comme les noms, les adresses "
-"e-mail et les métadonnées d'identification."
+"supprimant les données à caractère personnel comme les noms, les adresses e-"
+"mail et les métadonnées d'identification."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3128,7 +3145,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
+msgstr ""
+"La liste de blocage n'est pas exhaustive et peut contenir des inexactitudes."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3144,7 +3162,8 @@ msgstr "Bloquer ce site dans tous les résultats"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
+msgstr ""
+"Bloquez les traqueurs et prenez le contrôle de vos données personnelles"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3492,7 +3511,8 @@ msgstr "En cliquant sur « %1$s », vous acceptez nos %2$s."
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
+msgstr ""
+"En cliquant sur « %1$s », vous acceptez la %2$s et les %3$s de Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3891,7 +3911,8 @@ msgstr "Change l'affichage de l'URL des résultats"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
+msgstr ""
+"Change l'affichage de l'en-tête ainsi que son comportement lors du défilement"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4388,7 +4409,8 @@ msgstr "Choix de modèles d'IA, y compris %1$s et %2$s"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
+msgstr ""
+"Choisissez %1$sConserver%2$s pour continuer à protéger votre confidentialité."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4756,7 +4778,8 @@ msgstr "Cliquez sur %1$sParamètres%2$s dans le menu déroulant."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
+msgstr ""
+"Cliquez sur %1$sUtiliser les pages Web actuelles%2$s puis sur %3$sOK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -6352,7 +6375,8 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "La suppression des cookies aura pour effet de réinitialiser ces paramètres."
+msgstr ""
+"La suppression des cookies aura pour effet de réinitialiser ces paramètres."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6374,7 +6398,8 @@ msgstr "Décrivez les modifications en fonction de l'image"
 #. Placeholder text displayed in the input field when the user can make follow-up edits to a generated image.
 msgctxt "Placeholder text for the image generation input field for follow-ups"
 msgid "Describe changes to continue editing this image"
-msgstr "Décrivez les modifications souhaitées pour continuer à modifier cette image"
+msgstr ""
+"Décrivez les modifications souhaitées pour continuer à modifier cette image"
 
 # smartling.placeholder_format=C
 #. Title shown when the user first enters Image Generation mode, prompting them to describe the image they want to create.
@@ -6543,7 +6568,8 @@ msgstr "Désactiver et déconnecter"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
+msgstr ""
+"Désactiver l'historique des discussions et se déconnecter de Sync & Backup ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6591,6 +6617,12 @@ msgstr "Je n'aime pas le design"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Je n'aime pas la source"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6701,6 +6733,12 @@ msgstr "Classement par division"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djibouti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7123,7 +7161,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
+msgstr ""
+"Duck.ai fonctionne mieux dans notre navigateur DuckDuckGo privé et gratuit !"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7214,7 +7253,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
+msgstr ""
+"Duck.ai est susceptible d'afficher des informations inexactes ou offensantes."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7230,7 +7270,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
+msgstr ""
+"Duck.ai peut désormais lire et analyser des PDF. Essayez par vous-même !"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7913,7 +7954,8 @@ msgstr "Activer les fonctionnalités d'IA"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
+msgstr ""
+"Activez la sauvegarde dans le cloud en saisissant votre phrase de passe."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8188,13 +8230,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
+msgstr ""
+"Assurez-vous que votre navigateur est autorisé à accéder à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Vérifiez que votre navigateur est autorisé à accéder à la localisation."
+msgstr ""
+"Vérifiez que votre navigateur est autorisé à accéder à la localisation."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8593,6 +8637,12 @@ msgid "Fast"
 msgstr "Rapide"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8657,8 +8707,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, "
-"copiez-collez le code dans votre site."
+"Ajustez les paramètres ci-dessous comme bon vous semble. Ensuite, copiez-"
+"collez le code dans votre site."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8740,7 +8790,8 @@ msgstr "Filtres inefficaces"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtre les images générées par l'IA des résultats de recherche d'images"
+msgstr ""
+"Filtre les images générées par l'IA des résultats de recherche d'images"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8797,7 +8848,8 @@ msgstr "Vous trouverez <b>%1$s</b> dans votre dossier de téléchargements"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
+msgstr ""
+"Cherchez DuckDuckGo dans la liste et cliquez sur %1$sDéfinir par défaut%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8908,7 +8960,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
+msgstr ""
+"Suivez ces étapes pour déplacer vos discussions vers le nouveau Duck.ai"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8920,6 +8973,12 @@ msgstr "Question de suivi"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Les messages complémentaires restent privés."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9141,8 +9200,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dans la barre de menu de l'application sur Mac, sélectionnez "
-"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à "
-"jour…</strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
+"<strong>DuckDuckGo</strong> &gt; <strong>Rechercher des mises à jour…</"
+"strong>, puis sélectionnez <strong>Installer la mise à jour</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9619,8 +9678,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé "
-"Duck.ai, de Personal Information Removal et d'Identity Theft Restoration."
+"Bénéficiez de notre VPN sécurisé sans journalisation, du chat avancé Duck."
+"ai, de Personal Information Removal et d'Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9787,7 +9846,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
+msgstr ""
+"Accédez à %1$sConfidentialité et sécurité > Services de localisation%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9875,6 +9935,12 @@ msgstr "Design réussi"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Bonne politique de confidentialité"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10064,7 +10130,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
+msgstr ""
+"Explique-moi les principales étapes à suivre pour remplacer un essuie-glace."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10264,7 +10331,8 @@ msgstr "Aide-nous à améliorer DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
+msgstr ""
+"Aidez-nous à améliorer les recherches DuckDuckGo grâce à vos commentaires"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10322,7 +10390,8 @@ msgstr "Aidez votre famille et vos ami(e)s à rejoindre le côté Duck !"
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
+msgstr ""
+"Aidez vos amis et votre famille à reprendre le contrôle de leur vie privée !"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10730,7 +10799,8 @@ msgstr "À quelle fréquence souhaitez-vous voir des réponses %1$s ?"
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How often do you want to see AI-assisted answers?"
-msgstr "À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
+msgstr ""
+"À quelle fréquence souhaitez-vous voir des réponses assistées par l’IA ?"
 
 # smartling.placeholder_format=C
 #. Section title above the frequency radio options in the Search Assist settings modal.
@@ -11019,7 +11089,14 @@ msgstr "Les prompts d’image doivent respecter les %1$s"
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
-msgstr "Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+msgstr ""
+"Les prompts relatifs aux images doivent être conformes aux %1$s de Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11539,7 +11616,8 @@ msgstr "Cela peut prendre quelques minutes."
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Il est rapide, gratuit et vous offre encore plus de protection en ligne."
+msgstr ""
+"Il est rapide, gratuit et vous offre encore plus de protection en ligne."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12188,7 +12266,8 @@ msgstr "Liens :"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
+msgstr ""
+"Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -14446,7 +14525,8 @@ msgstr "Oman"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
+msgstr ""
+"Omet le contenu à caractère sensible (principalement du contenu pour adulte)"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14665,7 +14745,8 @@ msgstr "Ouvrir %1$sParamètres%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
+msgstr ""
+"Ouvrez « Localisation » et vérifiez que la localisation est %1$sactivée%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14822,7 +14903,8 @@ msgstr "Ouvrir le volet « Comment fonctionne Duck.ai »"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
+msgstr ""
+"Ouvrez le menu Safari et sélectionnez %1$sRéglages pour DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15588,7 +15670,8 @@ msgstr "Épinglé"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Les discussions épinglées apparaîtront en haut de vos discussions récentes."
+msgstr ""
+"Les discussions épinglées apparaîtront en haut de vos discussions récentes."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15912,6 +15995,12 @@ msgstr "Polonais"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Mauvais formatage"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16705,7 +16794,8 @@ msgstr "IA de raisonnement avec modération intégrée moyenne"
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Le raisonnement peut donner de meilleures réponses aux questions complexes."
+msgstr ""
+"Le raisonnement peut donner de meilleures réponses aux questions complexes."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17090,7 +17180,8 @@ msgstr "Mémoriser mon choix"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
+msgstr ""
+"Se souvenir de mon choix (peut être changé dans %1$s%2$s%3$sParamètres%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17558,7 +17649,8 @@ msgstr "Avis"
 #. Prompt sent to the AI when the user taps the "Adjust the servings" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Rewrite this recipe scaled for a different number of servings."
-msgstr "Réécris cette recette pour l'adapter à un nombre de portions différent."
+msgstr ""
+"Réécris cette recette pour l'adapter à un nombre de portions différent."
 
 # smartling.placeholder_format=C
 msgid "Romania"
@@ -18045,7 +18137,8 @@ msgstr ""
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down and locate %syour browser%s in the list."
-msgstr "Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
+msgstr ""
+"Faites défiler la liste vers le bas et localisez %1$svotre navigateur%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service.
@@ -18628,31 +18721,35 @@ msgstr "Sélectionner %1$s%2$s%3$s, puis %4$sMoteur de recherche%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
+msgstr ""
+"Sélectionnez %1$s« Réglages pour ce site Web... »%2$s dans le menu Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Selectionnez %1$sPersonnaliser%2$s et saisissez "
-"%3$shttps://duckduckgo.com%4$s dans le champ de saisie"
+"Selectionnez %1$sPersonnaliser%2$s et saisissez %3$shttps://duckduckgo."
+"com%4$s dans le champ de saisie"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s, puis cliquez sur %3$sAjouter par défaut%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
+msgstr ""
+"Sélectionnez %1$sDuckDuckGo%2$s et cliquez sur %3$sDéfinir par défaut%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18693,7 +18790,8 @@ msgstr "Sélectionnez %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
+msgstr ""
+"Sélectionnez %1$sModifier les moteurs de recherche…%2$sdans le menu déroulant"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18767,7 +18865,8 @@ msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sRéglages avancés%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
+msgstr ""
+"Sélectionnez %1$sRéglages%2$s, puis %3$sMoteur de recherche par défaut%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18828,7 +18927,8 @@ msgstr "Sélectionnez tous les carrés contenant un canard :"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select an option to %sallow%s location access"
-msgstr "Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
+msgstr ""
+"Sélectionnez une option pour %1$sautoriser%2$s l'accès à la localisation"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -18863,7 +18963,8 @@ msgstr "Texte sélectionné de %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
+msgstr ""
+"Le texte sélectionné est trop long. Réessayez avec une sélection plus courte."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19611,8 +19712,8 @@ msgstr "Afficher la barre latérale"
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
 msgstr ""
-"Découvrez des conseils étape par étape pour tirer le meilleur parti de "
-"Duck.ai."
+"Découvrez des conseils étape par étape pour tirer le meilleur parti de Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19759,7 +19860,8 @@ msgstr "Montre l'arrière-plan du bouton de recherche"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Affiche un message de bienvenue en haut de la page des résultats de recherche"
+msgstr ""
+"Affiche un message de bienvenue en haut de la page des résultats de recherche"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19966,7 +20068,8 @@ msgstr "Résolvez des problèmes complexes grâce au mode de raisonnement !"
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
 msgctxt "Promotional text for reasoning mode"
 msgid "Solve complex problems with the new reasoning mode!"
-msgstr "Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
+msgstr ""
+"Résolvez des problèmes complexes grâce au nouveau mode de raisonnement !"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the reasoning mode on complex problems which thinks longer to hopefully provide a more accurate answer.
@@ -19994,7 +20097,8 @@ msgstr "Une erreur s'est produite"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr "Une erreur s'est produite lors du chargement de cette discussion partagée."
+msgstr ""
+"Une erreur s'est produite lors du chargement de cette discussion partagée."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20038,7 +20142,8 @@ msgstr "Parfois"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
+msgstr ""
+"Désolé, je ne peux pas vous aider, veuillez décrire votre image différemment."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20377,7 +20482,8 @@ msgstr "Reste sur DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
+msgstr ""
+"Restez protégé(e) et informé(e) avec notre newsletter sur la confidentialité."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20432,7 +20538,8 @@ msgstr "Arrêtez les traqueurs qui se cachent sur d'autres sites Web."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
+msgstr ""
+"Arrêtez la plupart des traqueurs qui se cachent sur d'autres sites Web."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20522,8 +20629,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans "
-"Duck.ai, ou revenez plus tard pour créer plus d'images."
+"Abonnez-vous à DuckDuckGo pour débloquer des limites plus élevées dans Duck."
+"ai, ou revenez plus tard pour créer plus d'images."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20858,7 +20965,8 @@ msgstr "Changer de modèle"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
+msgstr ""
+"Passez cette conversation à un modèle gratuit ou attendez jusqu’au %1$s."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -21060,8 +21168,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Comment fonctionne ce code ?\n"
-"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de "
-"Duck.ai.\n"
+"1. Accédez à Duck.ai dans votre navigateur et ouvrez les paramètres de Duck."
+"ai.\n"
 "2. Sélectionnez « Activer Sync & Backup », puis « Récupérer les données "
 "synchronisées »\n"
 "3. Copiez le code de récupération ci-dessus et collez-le là où il est écrit "
@@ -21449,13 +21557,15 @@ msgstr "Merci pour vos commentaires !"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre !"
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre !"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row."
-msgstr "Merci pour votre patience pendant que nous mettons les choses en ordre."
+msgstr ""
+"Merci pour votre patience pendant que nous mettons les choses en ordre."
 
 # smartling.placeholder_format=C
 #. Message indicating that the open lock icon in the address bar means that a website is not secure.
@@ -21510,7 +21620,8 @@ msgstr "Les fichiers joints dépassent la limite totale de taille de %1$s Mo."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
+msgstr ""
+"L'audio n'a pas pu être traité. Veuillez essayer d'enregistrer à nouveau."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21535,7 +21646,8 @@ msgstr ""
 #. Description explaining that the AI model provider does not store any chat data on their servers.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid "The model provider does not save this chat on their servers."
-msgstr "Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
+msgstr ""
+"Le fournisseur de modèles n'enregistre pas cette discussion sur ses serveurs."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21595,7 +21707,8 @@ msgstr "Thèmes"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "There was an error displaying the search results."
-msgstr "Une erreur s'est produite lors de l'affichage des résultats de recherche."
+msgstr ""
+"Une erreur s'est produite lors de l'affichage des résultats de recherche."
 
 # smartling.placeholder_format=C
 #. Error message displayed when there was an issue in saving the chat locally to the browser's storage
@@ -21799,13 +21912,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
+msgstr ""
+"Ce fichier est trop volumineux. La taille maximale du fichier est de %1$s Mo."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21843,7 +21958,8 @@ msgstr ""
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
 msgctxt "Error message when an uploaded file type is not supported"
 msgid "This file type is not supported, please attach a %s."
-msgstr "Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
+msgstr ""
+"Ce type de fichier n’est pas pris en charge ; veuillez joindre un %1$s."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21941,8 +22057,8 @@ msgid ""
 "Other model providers follow a zero data retention model."
 msgstr ""
 "Ce fournisseur de modèles supprime les données associées à cette discussion "
-"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de "
-"non-conservation des données."
+"dans les 30 jours. D'autres fournisseurs de modèles suivent un modèle de non-"
+"conservation des données."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -22062,7 +22178,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
+msgstr ""
+"Cette page web n'utilise pas de connexion sécurisée et cryptée (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22203,7 +22320,8 @@ msgstr "Souligner le titre"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
+msgstr ""
+"Pour autoriser DuckDuckGo dans d'autres extensions de blocage de publicités :"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22217,7 +22335,8 @@ msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
+msgstr ""
+"Pour continuer, vous devez accepter la %1$s et les %2$s de DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22290,8 +22409,8 @@ msgstr "Passez au chat IA privé ou %1$sdésactivez dans les paramètres%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Activez cette option pour essayer le chat privé avec l’IA ou "
-"%1$sdésactivez-la dans le menu %2$s.%3$s"
+"Activez cette option pour essayer le chat privé avec l’IA ou %1$sdésactivez-"
+"la dans le menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22352,6 +22471,12 @@ msgstr "Trop de résultats provenant de cette source"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Trop lent"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22639,7 +22764,8 @@ msgstr "Essayez %1$s pour ne plus voir de messages comme celui-ci."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
+msgstr ""
+"Essayez %1$s, notre premier modèle sans aucune visibilité du fournisseur."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22780,20 +22906,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
+msgstr ""
+"Essayez d'activer la géolocalisation anonyme pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
+msgstr ""
+"N’hésitez pas à essayer chaque modèle pour obtenir des réponses différentes."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Essayer de nouveau avec moins de mots clés."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22967,13 +23101,15 @@ msgstr "Essayez les logiciels open source %1$s et %2$s récemment ajoutés"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
-msgstr "Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
+msgstr ""
+"Essayez les logiciels open source Llama 3.1 et Mixtral récemment ajoutés"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
+msgstr ""
+"Essayez ces prompts pour commencer ou saisissez les vôtres ci-dessous :"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22981,7 +23117,8 @@ msgctxt ""
 "Description shown when a chat search in Duck.ai returns no matching chats, "
 "suggesting the user rephrase their query"
 msgid "Try using a different search term or phrase."
-msgstr "Essayez d'utiliser un autre terme ou une autre expression de recherche."
+msgstr ""
+"Essayez d'utiliser un autre terme ou une autre expression de recherche."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, text prompting the user to try their prompt with a different AI model.
@@ -23169,7 +23306,8 @@ msgstr "Activez la « position exacte » pour des résultats plus précis."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Activez « Utiliser la position exacte » pour des résultats plus précis."
+msgstr ""
+"Activez « Utiliser la position exacte » pour des résultats plus précis."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23362,18 +23500,20 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et saisissez "
-": https://duckduckgo.com"
+"Sous %1$sAu démarrage%2$s, séléctionnez %3$sPage d'accueil%4$s et "
+"saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
+msgstr ""
+"Sous %1$sOuvrir avec%2$s, sélectionnez %3$sUne ou des pages spécifiques%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
+msgstr ""
+"Sous %1$sDÉMARRAGE > Page d'accueil%2$s saisissez : https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23934,7 +24074,8 @@ msgstr "Vous utilisez le Wi-Fi public ? Utilisez notre VPN."
 #. Second, dimmer line of the highlight tooltip shown under the 'Delete a chat' item title when the user activates that onboarding step. 'Fire Button' is DuckDuckGo's one-tap data-clearing feature; user testing showed people don't realize it deletes.
 msgctxt "Product-tour tooltip description"
 msgid "Use the Fire Button to delete a chat from history."
-msgstr "Utilisez le Fire Button pour supprimer une conversation de l’historique."
+msgstr ""
+"Utilisez le Fire Button pour supprimer une conversation de l’historique."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing, above the recovery code the user should save.
@@ -24108,7 +24249,8 @@ msgstr "Voir les prix de votre séjour"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "DuckDuckGo protège la confidentialité lors de la consultation des publicités."
+msgstr ""
+"DuckDuckGo protège la confidentialité lors de la consultation des publicités."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24199,9 +24341,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de "
-"Duck.ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser "
-"avec un autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
+"Visitez Duck.ai dans votre autre navigateur et ouvrez les paramètres de Duck."
+"ai. Sélectionnez « Activer » sous Sync & Backup, puis « Synchroniser avec un "
+"autre appareil ». Ou scannez le code QR figurant sur votre PDF de "
 "récupération."
 
 # smartling.placeholder_format=C
@@ -24369,7 +24511,8 @@ msgstr "Fond d'écran"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Tu veux accéder facilement au chat IA privé sur la page Nouvel onglet ?"
+msgstr ""
+"Tu veux accéder facilement au chat IA privé sur la page Nouvel onglet ?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24672,7 +24815,8 @@ msgstr "Nous avons perdu la connexion ; veuillez réessayer plus tard."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
+msgstr ""
+"Nous avons perdu la connexion. Veuillez réessayer d'envoyer votre message."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24963,7 +25107,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
+msgstr ""
+"Bienvenue sur le nouveau Duck.ai ; il est temps d'importer vos discussions."
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25315,7 +25460,8 @@ msgstr "À quoi cela répond-il ?"
 #. A placeholder text for a text area field prompting the user to suggest a feature to be added to the product, and this field is optional.
 msgctxt "Feedback prompt"
 msgid "What feature would you like us to add? (optional)"
-msgstr "Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
+msgstr ""
+"Quelle fonctionnalité souhaiteriez-vous que nous ajoutions ? (facultatif)"
 
 # smartling.placeholder_format=C
 #. Header above a list of types of information that gets saved by the cloud save feature.
@@ -25327,7 +25473,8 @@ msgstr "Quelles informations sont sauvegardées ?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
+msgstr ""
+"Quelles questions pourraient être posées lors de l'entretien pour ce poste ?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25336,8 +25483,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi "
-"est-il différent du bookmarklet avec URL de paramétrage ?"
+"À quoi sert le bookmarklet de sauvegarde dans le Cloud Save et en quoi est-"
+"il différent du bookmarklet avec URL de paramétrage ?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25682,8 +25829,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Fonctionne directement depuis votre appareil pour supprimer votre adresse "
-"e-mail, votre nom, votre adresse et plus encore des sites de courtiers en "
+"Fonctionne directement depuis votre appareil pour supprimer votre adresse e-"
+"mail, votre nom, votre adresse et plus encore des sites de courtiers en "
 "données."
 
 # smartling.placeholder_format=C
@@ -26026,7 +26173,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
+msgstr ""
+"Vous pouvez modifier cela à tout moment dans %1$sParamètres de recherche%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26056,7 +26204,8 @@ msgstr "Vous pouvez trouver le"
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
 msgctxt "duckai_migration"
 msgid "You can find the <b>%s</b> file in your downloads folder."
-msgstr "Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
+msgstr ""
+"Vous trouverez le fichier <b>%1$s</b> dans votre dossier de téléchargements."
 
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
@@ -26361,7 +26510,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
+msgstr ""
+"Vous avez atteint la durée maximale de chat vocal lors d'une seule session."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26375,7 +26525,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
+msgstr ""
+"Vous avez atteint votre limite d'utilisation de dictée. Réessayez plus tard."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26530,8 +26681,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Votre navigateur fournit une liste des sites que vous visitez le "
-"plus.DuckDuckGo n'a jamais accès à ces données."
+"Votre navigateur fournit une liste des sites que vous visitez le plus."
+"DuckDuckGo n'a jamais accès à ces données."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26805,7 +26956,8 @@ msgstr "Tes liens partagés se trouvent dans %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "Vos discussions synchronisées sont en cours de restauration sur cet appareil."
+msgstr ""
+"Vos discussions synchronisées sont en cours de restauration sur cet appareil."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26873,7 +27025,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
+msgstr ""
+"Vous avez atteint la limite de chat vocal. Veuillez réessayer plus tard."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ga_IE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ga_IE/LC_MESSAGES/duckduckgo.po
@@ -2385,6 +2385,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5249,6 +5260,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Ruaig é seo"
@@ -5338,6 +5354,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6800,6 +6821,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7057,6 +7083,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7804,6 +7835,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8732,6 +8768,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12688,6 +12729,11 @@ msgstr "Polainnis"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17784,6 +17830,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18143,6 +18194,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Féach líon níos lú focail."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/gd_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/gd_GB/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5235,6 +5246,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Leig seachad"
@@ -5324,6 +5340,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6785,6 +6806,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7043,6 +7069,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7790,6 +7821,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8715,6 +8751,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12661,6 +12702,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17723,6 +17769,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18081,6 +18132,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/gl_ES/LC_MESSAGES/duckduckgo.po
+++ b/locales/gl_ES/LC_MESSAGES/duckduckgo.po
@@ -2384,6 +2384,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5244,6 +5255,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Rexeitar"
@@ -5333,6 +5349,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6791,6 +6812,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7048,6 +7074,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7797,6 +7828,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8724,6 +8760,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12672,6 +12713,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17739,6 +17785,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18098,6 +18149,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Probe con menos palabras chave."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/gu_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/gu_IN/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6767,6 +6788,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7020,6 +7046,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7767,6 +7798,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8685,6 +8721,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12619,6 +12660,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17662,6 +17708,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18020,6 +18071,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/he_IL/LC_MESSAGES/duckduckgo.po
+++ b/locales/he_IL/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "שחרר"
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6769,6 +6790,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7023,6 +7049,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7770,6 +7801,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8692,6 +8728,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12632,6 +12673,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17678,6 +17724,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18037,6 +18088,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "נסה יותר מילות מפתח."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
-"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
+"स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
+"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
-"करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -311,7 +314,9 @@ msgstr "%1$s रैंकिंग अभी तक उपलब्ध नही
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। %2$s"
+msgstr ""
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -332,9 +337,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
-"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
-"कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
+"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
+"चैट को अपने सर्वर पर सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -382,7 +387,8 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता है %2$s"
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
+"है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -421,8 +427,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
-"के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
+"रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -433,8 +439,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
-"लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
+"जारी रखने के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -447,8 +453,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
-"हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
+"फिर %6$sठीक हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -456,8 +462,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
-"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -467,8 +473,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
+"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -509,14 +515,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
+"जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -528,7 +536,9 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
+msgstr ""
+"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -879,7 +889,9 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -887,8 +899,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
-"सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
+"चैटिंग जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -942,22 +954,26 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
-"जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
+"कनेक्शन जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
+msgstr ""
+"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1001,9 +1017,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
-"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
-"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
+"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
+"Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1064,10 +1081,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
-"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
-"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
-"मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
+"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
+"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
+"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1264,8 +1281,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
+"किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1301,8 +1318,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
-"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1310,8 +1327,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
-"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
+"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1382,7 +1399,8 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
+"जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1659,7 +1677,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच "
+"सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1668,7 +1687,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल कर सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
+"कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1710,7 +1730,9 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
+msgstr ""
+"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
+"क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1847,8 +1869,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
-"जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
+"किया जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1887,8 +1909,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
-"है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
+"रोका गया है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1903,8 +1925,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
-"जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
+"हटा दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1943,8 +1965,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
-"दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
+"एक्सेस की अनुमति दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1967,7 +1989,8 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
+"अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -1977,10 +2000,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
-"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
-"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
-"विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
+"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
+"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
+"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1988,8 +2011,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
-"Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
+"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2127,8 +2150,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2137,8 +2160,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
-"शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
+"%3$s और %4$s शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2152,8 +2175,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
-"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
+"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2200,8 +2223,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
-"तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
+"बतख संबंधी तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2308,8 +2331,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
-"जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
+"नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2330,8 +2353,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
-"की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
+"जिनमें पिन की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2340,8 +2363,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
-"डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
+"चैट को भी डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2379,8 +2402,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
-"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
+"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2522,12 +2545,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
-"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
-"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
-"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
-"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
+"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
+"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
+"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
+"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
+"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
+"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2539,11 +2563,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
-"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
-"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
-"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
+"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
+"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
+"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
+"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
+"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2570,8 +2595,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता है और वाई-फ़ाई "
-"पर आपके IP एड्रेस को छिपाता है।"
+"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता "
+"है और वाई-फ़ाई पर आपके IP एड्रेस को छिपाता है।"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2646,8 +2671,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
-"है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2689,14 +2714,16 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
+"हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
+"अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2721,9 +2748,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
-"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
-"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
+"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
+"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2732,15 +2759,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
-"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
-"क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
+"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
+"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
+msgstr ""
+"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
+"ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2940,8 +2969,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
-"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
+"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
+"उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2954,6 +2984,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo अपलोड की गई फ़ाइलें और जनरेट की "
+"गई इमेज हटा देगा, और आपकी बातचीत से नाम, ईमेल पते और पहचान बताने वाले "
+"मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3083,8 +3116,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP एड्रेस छिपाएं, और "
-"ज़्यादा प्रीमियम सुरक्षा पाएं।"
+"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP "
+"एड्रेस छिपाएं, और ज़्यादा प्रीमियम सुरक्षा पाएं।"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3344,16 +3377,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
+"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
+"एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
-"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
+"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
+"में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3361,8 +3396,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
-"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
+"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
+"सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3469,11 +3505,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
-"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
-"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
-"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
-"होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
+"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
+"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
+"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
+"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3481,8 +3517,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3491,8 +3527,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
-"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
+"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3842,7 +3878,9 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
+msgstr ""
+"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
+"देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3990,11 +4028,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
-"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
-"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
-"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
+"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
+"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
+"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
+"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4050,7 +4088,8 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4058,7 +4097,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
+"ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4139,8 +4179,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"चैट्स एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर की जाती हैं। "
-"आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"चैट्स एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से "
+"स्टोर की जाती हैं। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4149,8 +4189,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
-"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
+"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4162,10 +4202,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
-"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
-"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
+"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
+"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
+"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4188,9 +4229,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
-"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
-"जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
+"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
+"द्वारा गुमनाम रूप से किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4198,7 +4239,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
+"स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4354,8 +4396,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ सर्वर लोकेशन में से "
-"चुनें।"
+"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ "
+"सर्वर लोकेशन में से चुनें।"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4373,8 +4415,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
-"इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
+"ऐप का इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4555,8 +4597,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
-"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
+"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
+"उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4566,9 +4609,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
-"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
-"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
+"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
+"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4577,8 +4620,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
-"हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
+"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4587,9 +4630,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
-"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
-"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
+"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
+"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4631,8 +4674,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
-"(Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
+"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4648,7 +4691,9 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
+msgstr ""
+"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
+"करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4663,8 +4708,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
-"आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
+"%3$sगियर आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4681,7 +4726,9 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
+msgstr ""
+"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
+"करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4694,7 +4741,8 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
+"करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4756,9 +4804,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
-"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
-"क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
+"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
+"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4769,8 +4817,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
-"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
+"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
+"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4839,8 +4888,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
-"%3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
+"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4848,8 +4897,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
-"कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
+"के ऊपरी दाएं कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5050,8 +5099,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
-"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
+"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5505,8 +5554,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup › "
-"Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
+"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5671,7 +5720,8 @@ msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
 msgstr ""
-"चैट की एक कॉपी बनाता है जिसे लिंक खोलने वाला कोई भी व्यक्ति देख और सेव कर सकता है।"
+"चैट की एक कॉपी बनाता है जिसे लिंक खोलने वाला कोई भी व्यक्ति देख और सेव कर "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5925,8 +5975,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
-"जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6243,8 +6293,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और बातचीत को "
-"अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
+"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और "
+"बातचीत को अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6341,8 +6391,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
-"किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6360,8 +6410,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
-"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
+"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6494,7 +6544,7 @@ msgstr "स्रोत पसंद नहीं आया"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "विज़ुअल स्टाइल पसंद नहीं आया"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6610,7 +6660,7 @@ msgstr "जिबूती"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "निर्देशों का पालन नहीं करता"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6698,8 +6748,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
-"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
+"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6708,8 +6758,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
-"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
+"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6825,8 +6875,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6835,8 +6885,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
-"जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
+"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6857,8 +6907,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
-"आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
+"में लोगों को आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6867,8 +6917,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
-"रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
+"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7000,9 +7050,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
-"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
-"करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
+"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
+"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7012,8 +7062,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
-"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
+"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
+"करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7022,8 +7073,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
-"कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
+"चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -7039,8 +7090,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
-"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
+"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
+"हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7055,8 +7107,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
-"होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
+"आसान होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7071,8 +7123,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
-"%1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
+"कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7093,9 +7145,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
-"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
-"सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
+"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
+"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7106,10 +7158,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
-"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
-"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
-"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
+"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
+"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
+"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7124,8 +7177,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
-"सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
+"रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7139,8 +7192,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
-"नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
+"संबंधी कोई जांच नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7174,9 +7227,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
-"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
-"केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
+"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
+"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7204,12 +7257,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
-"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
-"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
-"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
-"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
-"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
+"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
+"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
+"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
+"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
+"(अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7219,8 +7273,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7230,8 +7284,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
-"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
+"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7243,12 +7297,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
-"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
-"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
-"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
-"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
-"की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
+"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
+"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
+"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
+"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7262,13 +7316,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
-"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
-"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
-"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
-"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
-"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
+"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
+"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
+"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
+"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
+"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
+"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
+"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7276,8 +7332,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
-"सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
+"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7286,8 +7342,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
-"अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
+"कृपया इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7296,8 +7352,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7306,8 +7362,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
-"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
+"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7316,7 +7372,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7325,8 +7382,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
-"अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
+"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7335,7 +7392,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7491,8 +7549,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
-"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
+"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
+"एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7500,8 +7559,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
+"%2$s से सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7510,8 +7569,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
-"होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7520,9 +7579,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
-"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
-"ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
+"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
+"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7534,11 +7593,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
-"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
-"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
-"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
-"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
+"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
+"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
+"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
+"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
+"किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7558,8 +7618,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
-"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
+"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7651,9 +7711,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
-"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
-"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
+"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
+"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
+"लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7730,8 +7791,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
-"होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
+"तैयार होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7869,8 +7930,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
-"हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
+"विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7913,8 +7974,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
-"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
+"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8090,8 +8152,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
-"तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
+"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8117,8 +8179,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
-"%6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
+"उपनाम %6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8219,8 +8281,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
-"परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
+"की सचमुच परवाह है।"
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8463,7 +8525,7 @@ msgstr "तेज़"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "तेज़ इमेज जनरेशन"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8510,8 +8572,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
-"मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
+"संंबंधी कार्यों में मदद मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8520,8 +8582,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
-"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
+"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
+"आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8529,8 +8592,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
-"पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
+"वेबसाइट में कॉपी पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8624,7 +8687,9 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
+msgstr ""
+"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
+"जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8702,7 +8767,9 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
+msgstr ""
+"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
+"है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8766,8 +8833,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
-"या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
+"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8790,7 +8857,7 @@ msgstr "फ़ॉलोअप गोपनीय रहते हैं।"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "निर्देशों का पालन किया"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8927,8 +8994,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9009,8 +9076,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
-"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
+"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9296,15 +9363,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और Identity "
-"Theft Restoration."
+"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+msgstr "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9390,8 +9456,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity Theft "
-"Restoration पाएं।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity "
+"Theft Restoration पाएं।"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9400,7 +9466,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration प्राप्त करें।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration "
+"प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9409,8 +9476,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
-"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
+"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9421,8 +9489,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
-"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
+"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9466,8 +9535,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल का ऑप्शनल "
-"एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
+"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल "
+"का ऑप्शनल एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9528,7 +9597,8 @@ msgstr "ऐप प्राप्त करें"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक करें।%2$s"
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
+"करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9550,7 +9620,9 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
+msgstr ""
+"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
+"करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9587,9 +9659,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
-"करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
+"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
+"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9598,8 +9670,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9609,8 +9681,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
+"इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9620,9 +9693,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
-"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
-"पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
+"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9631,8 +9704,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक "
-"करें%4$s पर जाएँ."
+"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ "
+"सिंक करें%4$s पर जाएँ."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9647,8 +9720,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
-"सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
+"\"स्थान सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9657,8 +9730,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
-"%3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
+"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9730,7 +9803,7 @@ msgstr "अच्छी गोपनीयता नीति"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "बढ़िया विज़ुअल स्टाइल"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10353,8 +10426,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
-"तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
+"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10381,8 +10454,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
-"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
+"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10396,8 +10469,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
-"संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
+"गोपनीयता संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10447,8 +10520,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
+"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10596,8 +10669,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
-"बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
+"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10719,8 +10792,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
-"क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
+"कौन-सी हैं और क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10755,8 +10828,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
-"गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
+"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10766,8 +10839,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
-"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
+"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
+"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10782,8 +10856,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
-"की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
+"इंजन%4$s की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10792,8 +10866,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
-"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
+"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10802,15 +10876,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
-"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
-"कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
+"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
+"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
+msgstr ""
+"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10820,15 +10896,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
-"%2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
+"%1$s या %2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
+msgstr ""
+"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
+"खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10871,7 +10949,7 @@ msgstr "इमेज प्रॉम्प्ट्स को Duck.ai %1$s क�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "इमेज क्वालिटी"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10963,7 +11041,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
+"सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10976,8 +11055,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
-"आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
+"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10988,8 +11067,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
-"साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
+"डिवाइस के साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11004,8 +11083,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
-"जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
+"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11341,7 +11420,9 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
+msgstr ""
+"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
+"बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11392,7 +11473,8 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
+"बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11411,9 +11493,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
-"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
-"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
+"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
+"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
+"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11422,8 +11505,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
-"भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
+"अधिक सुरक्षित भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11914,7 +11997,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की सुविधा देता है"
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
+"सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12026,7 +12110,9 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
+msgstr ""
+"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
+"लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12689,8 +12775,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
-"से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
+"अनुमति दें और फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13474,10 +13560,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
-"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
-"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
-"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
+"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
+"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
+"स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14312,8 +14399,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
-"> सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
+"आइकन > सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14322,8 +14409,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14332,8 +14419,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14342,8 +14429,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
-"डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR कोड को स्कैन करें."
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
+"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR "
+"कोड को स्कैन करें."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14371,8 +14459,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
-"कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
+"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14399,8 +14487,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
-"पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
+"पैरामीटर%2$s पेज पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14415,7 +14503,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
+"फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14746,8 +14835,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
-"अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
+"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14761,8 +14850,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा प्रीमियम प्रोटेक्शन के "
-"साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
+"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा "
+"प्रीमियम प्रोटेक्शन के साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14770,8 +14859,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
-"करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
+"नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14779,8 +14868,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
-"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
+"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15033,8 +15122,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
-"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
+"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15190,8 +15279,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है जो उसे "
-"बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
+"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है "
+"जो उसे बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15262,9 +15351,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
-"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
-"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
+"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15273,9 +15363,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
-"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
+"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15285,9 +15376,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
-"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
-"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
+"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
+"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
+"Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15320,8 +15412,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
-"वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
+"Mistral, वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15340,7 +15432,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
+"उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15353,8 +15446,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
-"पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
+"निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15443,8 +15536,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
-"चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15453,8 +15546,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
-"को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
+"निम्नलिखित चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15487,8 +15580,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
-"जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
+"सेशन डिलीट हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15497,8 +15590,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
+"गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15507,8 +15601,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
-"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
+"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
+"नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15661,8 +15756,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
+"सुझावों को प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15724,14 +15819,15 @@ msgstr "खराब फॉर्मेटिंग"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "खराब इमेज क्वालिटी"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा अनाम की गईं।"
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
+"अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16241,8 +16337,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
-"करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
+"लिए प्रेरित करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16261,7 +16357,8 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16292,7 +16389,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
+"टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16522,16 +16620,16 @@ msgstr "रीज़निंग जटिल सवालों के बे�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक "
+"पहुंच जाता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 गुना तेज़ी से होता "
-"है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
+"गुना तेज़ी से होता है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16581,8 +16679,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16591,8 +16689,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
-"पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
+"स्थानीय स्तर पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16602,9 +16700,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
-"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
+"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
+"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
+"जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16746,8 +16845,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
-"घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
+"के आकार को घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16888,8 +16987,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
-"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
+"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16997,8 +17096,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
-"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
+"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17006,8 +17105,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
-"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
+"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17071,9 +17171,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
-"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
-"%1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
+"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
+"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17081,8 +17181,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
+"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17091,9 +17191,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
-"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
-"पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
+"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
+"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17185,9 +17285,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
-"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17196,9 +17297,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
-"%1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17208,10 +17309,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
-"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
-"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
-"की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
+"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
+"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
+"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
+"है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17288,7 +17390,8 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
+"मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17637,8 +17740,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
-"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
+"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17651,7 +17754,9 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
+msgstr ""
+"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
+"सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17811,8 +17916,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
-"क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
+"%5$sनया जोड़ें%6$s) क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17821,8 +17926,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
-"जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
+"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17841,8 +17946,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
-"यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
+"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17910,11 +18015,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
-"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
-"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
-"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
-"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
+"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
+"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
+"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
+"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
+"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17922,8 +18028,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
-"मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
+"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17932,9 +18038,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
-"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
-"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
+"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
+"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
+"संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18055,8 +18162,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
-"“ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
+"Wikipedia पर “ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18075,8 +18182,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
-"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
+"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18084,8 +18191,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
-"होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
+"अनुरोध का उपयोग होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18097,11 +18204,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
-"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
-"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
-"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
-"जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
+"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
+"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
+"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
+"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18204,8 +18311,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18214,8 +18321,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18224,8 +18331,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
-"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
+"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18234,8 +18341,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
-"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
+"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18250,8 +18357,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
-"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
+"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18401,7 +18508,9 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
+msgstr ""
+"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
+"करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18411,13 +18520,17 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
+msgstr ""
+"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
+"करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18466,7 +18579,8 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
+"चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18474,7 +18588,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
+"चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18539,8 +18654,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
-"एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
+"पसंद का कोई एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18662,8 +18777,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
-"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
+"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18786,8 +18901,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
-"सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
+"डिवाइसों पर सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18894,8 +19009,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
-"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
+"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
+"बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18997,8 +19113,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
-"रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
+"हानिकारक रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19047,8 +19163,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप करने में सरल "
-"और किसी भी समय चालू या बंद करने में आसान।"
+"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप "
+"करने में सरल और किसी भी समय चालू या बंद करने में आसान।"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19175,7 +19291,8 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
+"सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19413,9 +19530,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
+"गोपनीयता प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19423,9 +19540,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
-"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
-"प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
+"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
+"खोज सुरक्षा प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19463,7 +19580,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
+"दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19765,7 +19883,9 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
+msgstr ""
+"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
+"में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19804,8 +19924,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
-"आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
+"इमेज या फ़ॉर्मेट आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19814,7 +19934,8 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
+"किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19829,14 +19950,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
-"क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
+"के लिए, %1$sयहाँ क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
+msgstr ""
+"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19891,8 +20014,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
-"प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
+"हिस्सा चुनकर फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20242,8 +20365,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
-"के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
+"इमेज बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20312,8 +20435,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
-"लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
+"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20650,8 +20773,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
-"होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
+"विज़िबिलिटी ज़ीरो होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20706,7 +20829,8 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
+"सकता।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20715,7 +20839,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup आपकी ज़्यादा चैट सेव करता है और उन्हें आपके सभी डिवाइसों पर सिंक करता है।"
+"Sync & Backup आपकी ज़्यादा चैट सेव करता है और उन्हें आपके सभी डिवाइसों पर "
+"सिंक करता है।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20764,25 +20889,26 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
-"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
-"रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
+"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
+"किया हुआ डेटा रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
-"है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
+"कर सकता है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
-"करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
+"चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
+"यहां पेस्ट करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
-"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
-"रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
+"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
+"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20921,8 +21047,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे हमारे मुफ़्त ऐप "
-"में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ऐप में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20931,8 +21057,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से एक्सेस के लिए इसे "
-"हमारे मुफ़्त ब्राउज़र में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
+"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21176,9 +21302,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
-"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
-"या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
+"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
+"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21187,8 +21313,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
-"बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
+"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21197,8 +21323,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Duck.ai टॉगल प्राइवेट सर्च और AI चैट के बीच तुरंत स्विच करने की सुविधा देता है, जिसे "
-"DuckDuckGo द्वारा अनाम बनाया गया है।"
+"Duck.ai टॉगल प्राइवेट सर्च और AI चैट के बीच तुरंत स्विच करने की सुविधा देता "
+"है, जिसे DuckDuckGo द्वारा अनाम बनाया गया है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21228,8 +21354,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
-"कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
+"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21309,8 +21435,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
-"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
+"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21325,8 +21451,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
-"मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
+"पहले कुछ मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21345,9 +21471,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
-"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
-"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
+"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
+"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21385,7 +21511,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21394,8 +21521,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
-"चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
+"वर्ज़न के साथ नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21434,8 +21561,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
-"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
+"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21445,8 +21573,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
-"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
+"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
+"%2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21455,8 +21584,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
-"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
+"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21466,9 +21595,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
-"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
+"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
+"(ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21485,8 +21614,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. पिछली "
-"%1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
+"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. "
+"पिछली %1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21558,7 +21687,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21566,7 +21696,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21594,8 +21725,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स में सबसे ऊपर रखने के "
-"लिए 'पिन करें' चुनें!"
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
+"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21604,7 +21735,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button का इस्तेमाल करें!"
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
+"का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21625,8 +21757,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
-"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
+"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21635,8 +21767,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
-"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
+"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21673,8 +21805,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
-"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
+"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21683,8 +21815,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21694,9 +21827,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
-"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
-"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
+"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
+"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
+"वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21737,7 +21871,9 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
+msgstr ""
+"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21747,8 +21883,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
-"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
+"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
+"चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21757,15 +21894,16 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
-"नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
+"पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
+"सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21888,8 +22026,7 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21898,8 +22035,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
-"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
+"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21909,9 +22046,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
-"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
-"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
+"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
+"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
+"सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21920,8 +22058,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
-"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
+"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21929,8 +22067,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
-"एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
+"माइक्रोफ़ोन का एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21958,7 +22096,9 @@ msgstr "प्राइवेट AI चैट पर टॉगल करें �
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल करें।%3$s"
+msgstr ""
+"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
+"करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22024,7 +22164,7 @@ msgstr "बहुत धीमा है"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "जनरेट होने में बहुत धीमा है"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22138,8 +22278,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
-"हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
+"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22186,7 +22326,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
+msgstr ""
+"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
+"कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22195,7 +22337,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
+"सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22443,7 +22586,8 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
+"अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22468,7 +22612,7 @@ msgstr "कुछ कीवर्ड आज़माएं।"
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "मुफ़्त में आज़माएं"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22641,7 +22785,8 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
+"आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22681,8 +22826,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22691,8 +22836,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
-"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
+"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22893,8 +23038,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
-"उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
+"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23024,8 +23169,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
-"पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
+"%5$sसेट पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -23033,8 +23178,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
-"com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23066,7 +23211,9 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
+msgstr ""
+"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
+"चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23150,8 +23297,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
-"उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
+"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23309,8 +23456,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
-"DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
+"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23435,14 +23582,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
-"बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
+"बनाने के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
+msgstr ""
+"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
+"अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23538,9 +23687,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
-"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
-"नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
+"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
+"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23595,8 +23744,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
-"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23604,8 +23753,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
+"के लिए इस कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23729,8 +23878,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai से शेयर की गई बातचीत देखें - DuckDuckGo की मुफ़्त, गोपनीय AI चैट। इसे अपनी चैट्स "
-"में सेव करें और गोपनीय रूप से बातचीत जारी रखें।"
+"Duck.ai से शेयर की गई बातचीत देखें - DuckDuckGo की मुफ़्त, गोपनीय AI चैट। "
+"इसे अपनी चैट्स में सेव करें और गोपनीय रूप से बातचीत जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23765,8 +23914,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
+"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23775,8 +23924,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
-"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
+"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23785,8 +23934,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"DuckDuckGo पर विज्ञापन देखने के दौरान आपकी प्राइवेसी सुरक्षित रहती है। विज्ञापन क्लिक "
-"Yelp के विज्ञापन नेटवर्क द्वारा मैनेज किए जाते हैं।"
+"DuckDuckGo पर विज्ञापन देखने के दौरान आपकी प्राइवेसी सुरक्षित रहती है। "
+"विज्ञापन क्लिक Yelp के विज्ञापन नेटवर्क द्वारा मैनेज किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23798,8 +23947,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
-"पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23808,8 +23957,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
+"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23818,7 +23967,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23834,8 +23984,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
-"करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
+"साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23845,9 +23995,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
-"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
-"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
+"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
+"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23857,9 +24007,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
-"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
-"के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
+"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
+"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23869,9 +24019,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
-"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
-"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
+"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
+"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
+"स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23924,8 +24075,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
-"नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
+"के लिए नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24075,8 +24226,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
-"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
+"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24096,9 +24247,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
-"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
-"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
+"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
+"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
+"जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24111,8 +24263,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
-"सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
+"गुमनाम रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24124,9 +24276,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
-"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
-"का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
+"जांच कर सकें और समस्या का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24138,16 +24290,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
-"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
-"ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
+"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
+"मामले की जांच करके उसे ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24155,7 +24308,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
+"एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24167,7 +24321,8 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24184,8 +24339,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
-"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
+"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24199,8 +24354,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
-"हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
+"वापस क्यों आए हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24209,8 +24364,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
-"आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
+"वजह से हमें आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24250,8 +24405,9 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
-"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
+"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24277,8 +24433,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. Plus, VPN और बहुत "
-"कुछ पाएँ."
+"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. "
+"Plus, VPN और बहुत कुछ पाएँ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24287,8 +24443,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
-"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
+"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24313,8 +24469,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
-"फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
+"आपके डेटा का फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24323,8 +24479,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
-"बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
+"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24333,19 +24489,23 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते हैं, और "
-"इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
+"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते "
+"हैं, और इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
+msgstr ""
+"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
+"हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
+msgstr ""
+"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24361,15 +24521,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
-"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
-"दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
+"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
+"तुरंत परिणामों में दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
+"ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24378,8 +24539,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन करेंगे, और आपके "
-"बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
+"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन "
+"करेंगे, और आपके बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24388,8 +24549,9 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
-"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24398,8 +24560,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
-"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
+"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24414,7 +24576,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
+"मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24423,8 +24586,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
-"करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
+"फिर से लोड करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24524,7 +24687,9 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
+msgstr ""
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24533,8 +24698,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
-"जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
+"करना जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24548,8 +24713,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
-"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
+"किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24558,8 +24724,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
+"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24569,16 +24736,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
-"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
-"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
+"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
+"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24646,8 +24814,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
-"रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
+"है। पेज को रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24682,7 +24850,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
+"कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24707,11 +24876,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
-"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
-"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
-"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
-"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
+"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
+"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
+"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
+"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
+"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24947,7 +25117,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
+"होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25023,8 +25194,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
-"करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25050,8 +25221,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
-"विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
+"ब्रांडों पर विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25252,8 +25423,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए चैट का "
-"इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
+"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25262,7 +25434,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"चैट हिस्ट्री चालू होने पर, आपकी सबसे हाल की %1$s चैट तक इस डिवाइस पर सेव की जाएंगी।"
+"चैट हिस्ट्री चालू होने पर, आपकी सबसे हाल की %1$s चैट तक इस डिवाइस पर सेव की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25284,8 +25457,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए सीधे आपके "
-"डिवाइस से काम करता है."
+"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए "
+"सीधे आपके डिवाइस से काम करता है."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25534,8 +25707,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
-"नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
+"दोबारा प्राप्त नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25555,7 +25728,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25564,8 +25738,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
-"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
+"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25579,8 +25753,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
-"बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
+"इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25589,22 +25763,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
-"कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
+"हैं या इसे कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
-"कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
+"भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
-"का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
+"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25618,8 +25792,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
-"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
+"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25640,8 +25814,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
-"सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
+"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25734,8 +25908,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
-"अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
+"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25799,8 +25973,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
-"ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
+"2 गुना ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25809,8 +25983,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
-"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
+"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25832,8 +26006,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25843,8 +26018,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
-"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
+"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
+"चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25872,8 +26048,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
-"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
+"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
+"कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25886,8 +26063,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
-"सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
+"करने के लिए सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25936,7 +26113,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
+msgstr ""
+"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25955,7 +26134,8 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25964,9 +26144,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
-"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
-"जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
+"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
+"की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25976,9 +26156,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
-"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
+"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
+"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25992,8 +26172,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
-"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
+"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26053,8 +26233,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से डिस्कनेक्ट "
-"हो जाएँगे."
+"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएँगे."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26064,8 +26244,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
+"स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26075,8 +26256,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
-"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
+"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
+"में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26101,8 +26283,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
-"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
+"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26110,8 +26292,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
-"डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
+"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26120,8 +26302,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
+"दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26134,8 +26316,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26149,8 +26331,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26158,8 +26340,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
-"प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26167,8 +26349,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26176,8 +26358,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
+"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26192,9 +26374,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
-"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
-"का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
+"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
+"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26203,7 +26385,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
+"जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26235,8 +26418,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
-"[%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
+"नहीं है। [%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26251,8 +26434,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
-"जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
+"नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26281,10 +26464,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
-"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
-"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
-"आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
+"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
+"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
+"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26299,8 +26482,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
-"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
+"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
+"जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26314,7 +26498,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26346,8 +26531,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26356,8 +26541,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
-"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
+"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
+"जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26385,8 +26571,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
-"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
+"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
+"यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26395,8 +26582,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
-"कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
+"फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26405,8 +26592,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
-"से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
+"Button की मदद से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26415,7 +26602,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
+"शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26430,8 +26618,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
-"जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
+"इस चैट को अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26740,7 +26928,8 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
+"अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hi_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/hi_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
-"अपना DuckDuckGo सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर "
-"स्विच करें।"
+"%1$s सिर्फ़ Pro प्लान में उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में अपना DuckDuckGo "
+"सब्सक्रिप्शन फिर से अपग्रेड करें, या Plus या मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -220,9 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस "
-"ब्राउज़र में अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
-"पर स्विच करें।"
+"%1$s केवल DuckDuckGo सब्सक्रिप्शन के साथ उपलब्ध है। चैट जारी रखने के लिए इस ब्राउज़र में "
+"अपने सब्सक्रिप्शन को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -231,8 +228,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में "
-"फिर से कोशिश करें।"
+"%1$s फिलहाल उपलब्ध नहीं है। कृपया किसी अन्य मॉडल पर स्विच करें या बाद में फिर से कोशिश "
+"करें।"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -314,9 +311,7 @@ msgstr "%1$s रैंकिंग अभी तक उपलब्ध नही
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। "
-"%2$s"
+msgstr "%1$s बेसिक मॉडलों की तुलना में 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता है। %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -337,9 +332,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल "
-"प्रोवाइडर भी आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस "
-"चैट को अपने सर्वर पर सेव कर सकता है।"
+"%1$s एक भरोसेमंद एक्ज़ीक्यूशन एनवायरमेंट में चलता है। इसका मतलब है कि मॉडल प्रोवाइडर भी "
+"आपके प्रॉम्प्ट्स या मॉडल के जवाबों को नहीं देख सकता, और न ही इस चैट को अपने सर्वर पर सेव "
+"कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -387,8 +382,7 @@ msgstr "%1$s उपयोग किया गया"
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
 msgstr ""
-"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता "
-"है %2$s"
+"%1$s बेसिक मॉडलों की तुलना में 2-5 गुना तक तेज़ी से लिमिट्स का इस्तेमाल करता है %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -427,8 +421,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी "
-"रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s %2$s दिन में (%3$s को) Duck.ai से हट जाएगा। उसके बाद, आप इस चैट को जारी रखने "
+"के लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -439,8 +433,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को "
-"जारी रखने के लिए मॉडल बदल सकते हैं।"
+"%1$s 1 दिन में (%2$s को) Duck.ai से हटने वाला है। उसके बाद, आप इस चैट को जारी रखने के "
+"लिए मॉडल बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -453,8 +447,8 @@ msgstr "%1$s शब्द"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, "
-"फिर %6$sठीक हैं%7$s पर क्लिक करें"
+"%1$sजोड़ें%2$sपर%3$s क्लिक करें %4$sअनुमति दें%5$s पर सही का निशान लगाएं, फिर %6$sठीक "
+"हैं%7$s पर क्लिक करें"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -462,8 +456,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
-"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$sअनुमति दें%2$s %3$sपर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति दें%7$s पर "
+"निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -473,8 +467,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें "
-"%6$sअनुमति दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
+"%1$s%2$sइंस्टॉलेशन जारी रखें%3$s पर क्लिक करें %4$sजोड़ें%5$s पर क्लिक करें %6$sअनुमति "
+"दें%7$s पर निशान लगाएं, फिर %8$sओके%9$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -515,16 +509,14 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर "
-"किया जाता है।"
+"%1$sऔर जानें%2$s कि चैट को DuckDuckGo के सर्वर पर गोपनीय ढंग से कैसे स्टोर किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर "
-"जानें।%2$s"
+"आपके डिवाइस पर चैट निजी तौर पर कैसे स्टोर किए जाते हैं, इस बारे में %1$sऔर जानें।%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -536,9 +528,7 @@ msgstr "होम स्क्रीन पर DuckDuckGo ऐप आइकन �
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से "
-"कोशिश करें।"
+msgstr "%1$sउफ़!%2$s%3$sकुछ गड़बड़ हुई है। कृपया %4$sरीफ्रेश%5$s करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -889,9 +879,7 @@ msgstr "6 घंटे की उपयोग सीमा पूरी हो �
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "6 घंटे की उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -899,8 +887,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके "
-"चैटिंग जारी रख सकते हैं।"
+"6 घंटे की उपयोग सीमा पूरी हो गई है। आप अपनी दैनिक सीमा का इस्तेमाल करके चैटिंग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -954,26 +942,22 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना "
-"कनेक्शन जांचें और फिर से कोशिश करें।"
+"नेटवर्क की समस्या की वजह से Search Assist जवाब नहीं दे पा रहा है। कृपया अपना कनेक्शन "
+"जांचें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "AI Chat का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश "
-"करें।"
+msgstr "Duck.ai का नया वर्ज़न उपलब्ध है! कृपया जारी रखने के लिए इस पेज को रीफ्रेश करें।"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1017,10 +1001,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा देता है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप "
-"जाएगा। जब यह सेटिंग बंद हो तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI "
-"Chat का उपयोग कर सकते हैं।"
+"AI Chat आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा देता "
+"है। इसे बंद करने से DuckDuckGo Search पर AI Chat फ़ीचर छिप जाएगा। जब यह सेटिंग बंद हो "
+"तब भी आप %1$sduckduckgo.com/aichat%2$s पर जाकर AI Chat का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1081,10 +1064,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते "
-"हैं। हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और "
-"अक्सर उससे लिंक करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और "
-"Anthropic, और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"AI की सहायता से दिए गए जवाब फिलहाल फ़ॉलोअप सवालों को सीधे सपोर्ट नहीं करते हैं। "
+"हालांकि, हम फ़ॉलोअप सवालों के लिए %1$sDuck.ai%2$s भी ऑफ़र करते हैं और अक्सर उससे लिंक "
+"करते हैं, जो हमारी निजी AI-संचालित चैट सेवा है जो OpenAI, और Anthropic, और अन्य के चैट "
+"मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1281,8 +1264,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या "
-"किसी मुफ़्त मॉडल पर स्विच करें।"
+"चैट जारी रखने के लिए इस ब्राउज़र में अपने %1$s को फिर से एक्टिवेट करें, या किसी मुफ़्त मॉडल "
+"पर स्विच करें।"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1318,8 +1301,8 @@ msgstr "विज्ञापन"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका "
-"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"%1$s के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग आपकी "
+"व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1327,8 +1310,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और "
-"इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"Microsoft के विज्ञापन नेटवर्क द्वारा विज्ञापन क्लिक प्रबंधित किए जाते हैं और इनका उपयोग "
+"आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1399,8 +1382,7 @@ msgstr "DuckDuckGo एक्सटेंशन जोड़ें"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials "
-"जोड़ें:"
+"एक डाउनलोड के साथ अपने ब्राउज़र पर मुफ़्त में DuckDuckGo Privacy Essentials जोड़ें:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1677,8 +1659,7 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच "
-"सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2–5 गुना तेज़ी से उपयोग सीमा तक पहुंच सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1687,8 +1668,7 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल "
-"कर सकते हैं। %1$s"
+"एडवांस्ड मॉडल अन्य मॉडलों की तुलना में 2-5 गुना तेज़ी से लिमिट का इस्तेमाल कर सकते हैं। %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1730,9 +1710,7 @@ msgstr "जैसे ही वह डाउनलोड होकर खुल�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल "
-"क्लिक करें"
+msgstr "डाइनलोड होने के बाद, ऐक्सटेंशन फ़ाइल को ढूंढें और इंस्टॉल करने के लिए डबल क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1869,8 +1847,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "सभी चैट DuckDuckGo द्वारा अनाम कर दी जाती हैं, और आपकी बातचीत का इस्तेमाल "
-"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं "
-"किया जाता है"
+"DuckDuckGo या मॉडल प्रोवाइडर द्वारा चैट मॉडल को प्रशिक्षित करने के लिए नहीं किया "
+"जाता है"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1909,8 +1887,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से "
-"रोका गया है।"
+"सभी मॉडल प्रदाताओं को आपकी बातचीत के आधार पर अपने AI को प्रशिक्षित करने से रोका गया "
+"है।"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1925,8 +1903,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) "
-"हटा दिया जाता है।"
+"AI प्रोवाइडर को चैट भेजने से पहले सभी पर्सनल मेटाडेटा (जैसे, आपका IP एड्रेस) हटा दिया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1965,8 +1943,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन "
-"एक्सेस की अनुमति दें।"
+"वॉयस चैट का इस्तेमाल करने के लिए सिस्टम सेटिंग में DuckDuckGo माइक्रोफ़ोन एक्सेस की अनुमति "
+"दें।"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1989,8 +1967,7 @@ msgstr "इस चैट के लिए गुमनाम फ़ाइल र
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
 msgstr ""
-"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को "
-"अनुमति दें"
+"DuckDuckGo Private Search पर गोपनीयता का सम्मान करने वाले विज्ञापनों को अनुमति दें"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2000,10 +1977,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स "
-"के जवाबों को बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही "
-"भेजता है, जिनमें डेटा रिटेंशन की लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स "
-"और जवाबों पर अभी भी %3$sप्रोवाइडर की विज़िबिलिटी शून्य%4$s रहती है।"
+"यह %1$s को वेब पर सर्च करने की सुविधा देता है, ताकि वह संबंधित प्रॉम्प्ट्स के जवाबों को "
+"बेहतर बना सके। यह सर्च इंजन पर केवल AI-जनरेटेड क्वेरीज़ ही भेजता है, जिनमें डेटा रिटेंशन की "
+"लिमिट सीमित होती है। %2$s वाले प्रॉम्प्ट्स और जवाबों पर अभी भी %3$sप्रोवाइडर की "
+"विज़िबिलिटी शून्य%4$s रहती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2011,8 +1988,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता "
-"है (Cloud Save का उपयोग करने के लिए आवश्यक है)"
+"डिवाइस पर स्थानीय रूप से संग्रहित की जाने वाली Cloud Save की को अनुमति देता है (Cloud "
+"Save का उपयोग करने के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2150,8 +2127,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2160,8 +2137,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत "
-"%3$s और %4$s शामिल हैं।"
+"लोकप्रिय AI मॉडलों तक अनाम ढंग से पहुंच, जिसमें %1$s, %2$sऔर मुक्त स्रोत %3$s और %4$s "
+"शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2175,8 +2152,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। "
-"चुनें कि इसे कितनी बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
+"वेब कंटेंट के आधार पर सर्च क्वेरी के लिए गुमनाम रूप से जवाब तैयार करता है। चुनें कि इसे कितनी "
+"बार दिखाया जाए, या इसे पूरी तरह से बंद कर दें।"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2223,8 +2200,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे "
-"बतख संबंधी तथ्य बताएं"
+"कोई अतिरिक्त निर्देश जो आप चाहते हैं कि Duck.ai पालन करे। जैसे कि हमेशा मुझे बतख संबंधी "
+"तथ्य बताएं"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2331,8 +2308,8 @@ msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
 msgstr ""
-"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा "
-"नहीं किया जा सकता।"
+"क्या आपको पक्का पता है कि आप अपनी सभी चैट साफ़ करना चाहते हैं? इसे पहले जैसा नहीं किया "
+"जा सकता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2353,8 +2330,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, "
-"जिनमें पिन की गई चैट्स भी शामिल हैं।"
+"क्या आप वाकई हिस्ट्री को बंद करना चाहते हैं? इससे सभी चैट्स डिलीट हो जाएंगी, जिनमें पिन "
+"की गई चैट्स भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2363,8 +2340,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी "
-"चैट को भी डिलीट कर देगा।"
+"क्या आप वाकई हालिया चैट को बंद करना चाहते हैं? यह हाल ही में सेव की गई सभी चैट को भी "
+"डिलीट कर देगा।"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2402,8 +2379,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा "
-"नहीं करते हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
+"हमारी गोपनीयता नीति के अनुसार, हम खुद से कोई निजी जानकारी एकत्रित या साझा नहीं करते "
+"हैं। यह सभी गोपनीयता संरक्षण आपके डिवाइस पर होती है।"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2545,13 +2522,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ "
-"खोजों के लिए गुमनाम रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन "
-"सकते हैं कि Assist को कितनी बार दिखाना है: कभी नहीं (यह खोज परिणामों से "
-"Assist के UI को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप "
-"'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे "
-"बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फिलहाल, AI "
-"की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
+"Assist प्रासंगिक वेब सामग्री को संक्षेप में प्रस्तुत करने के आधार पर कुछ खोजों के लिए गुमनाम "
+"रूप से AI की सहायता से जवाब जनरेट कर सकता है। आप चुन सकते हैं कि Assist को कितनी बार "
+"दिखाना है: कभी नहीं (यह खोज परिणामों से Assist के UI को पूरी तरह हटा देता है), ऑन-"
+"डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ "
+"तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता "
+"है)। फिलहाल, AI की सहायता से दिए गए जवाब केवल अमेरिका (अंग्रेज़ी) क्षेत्र में उपलब्ध हैं।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2563,12 +2539,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, "
-"खोज संबंधी क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, "
-"यह वेब को स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री "
-"से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित "
-"नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद रखना ज़रूरी है कि "
-"जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
+"Assist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब AI की सहायता से जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके "
+"क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम "
+"शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। यह याद "
+"रखना ज़रूरी है कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
 "आधारित होते हैं।"
 
 # smartling.placeholder_format=C
@@ -2595,8 +2570,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता "
-"है और वाई-फ़ाई पर आपके IP एड्रेस को छिपाता है।"
+"कैफ़े, एयरपोर्ट या होटल में, DuckDuckGo VPN आपके कनेक्शन को एन्क्रिप्ट करता है और वाई-फ़ाई "
+"पर आपके IP एड्रेस को छिपाता है।"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2671,8 +2646,8 @@ msgstr "चैट खत्म होने के बाद ऑडियो ह
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
 msgstr ""
-"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर "
-"नहीं किया जाता है।"
+"चैट ट्रांसक्रिप्ट होने के बाद, ऑडियो हमारे द्वारा या OpenAI द्वारा स्टोर नहीं किया जाता "
+"है।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2714,16 +2689,14 @@ msgstr "स्वत: उत्तर"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां "
-"हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। इसमें अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में "
-"अशुद्धियां हो सकती हैं।"
+"सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट किया गया। जवाबों में अशुद्धियां हो सकती हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2748,9 +2721,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, "
-"जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता "
-"है। फिलहाल, Assist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए Assist स्वतः ही दिखाता है। कुछ खोजों के लिए Assist, जानकारी को "
+"गुमनाम रूप से खोज सकता है और उसके बारे में खास जानकारी दे सकता है। फिलहाल, Assist केवल "
+"अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2759,17 +2732,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए "
-"DuckAssist जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल "
-"DuckAssist केवल अंग्रेज़ी क्षेत्रों में उपलब्ध है।"
+"प्रासंगिक खोजों के लिए DuckAssist स्वतः ही दिखाता है। कुछ खोजों के लिए DuckAssist "
+"जानकारी को गुमनाम रूप से खोज और संक्षिप्त कर सकता है। फिलहाल DuckAssist केवल अंग्रेज़ी "
+"क्षेत्रों में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू "
-"ऑटोप्ले करें।"
+msgstr "वीडियो परिणामों पर कर्सर ले जाने पर, छोटे और म्यूट वाले वीडियो प्रीव्यू ऑटोप्ले करें।"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2969,9 +2940,20 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस "
-"और पहचान बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर "
-"उसे अनाम बना देगा।"
+"इस रिपोर्ट को स्टोर करने से पहले, DuckDuckGo आपकी बातचीत से नाम, ईमेल एड्रेस और पहचान "
+"बताने वाले मेटाडेटा जैसी PII (व्यक्तिगत पहचान योग्य जानकारी) हटाकर उसे अनाम बना देगा।"
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3101,8 +3083,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP "
-"एड्रेस छिपाएं, और ज़्यादा प्रीमियम सुरक्षा पाएं।"
+"हमारे सब्सक्रिप्शन के माध्यम से हानिकारक साइटों को ब्लॉक करें, अपना IP एड्रेस छिपाएं, और "
+"ज़्यादा प्रीमियम सुरक्षा पाएं।"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3362,18 +3344,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने "
-"खोज इंजन, ट्रैकर ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s "
-"एक्सटेंशन%3$s में बंडल किया है।"
+"जब हम गोपनीयता संरक्षण जोड़ते हैं तब सामान्य रूप से ब्राउज़ करें। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एन्क्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल किया है।"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज "
-"इंजन, ट्रैकर ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s "
-"में बंडल कर दिया है।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। हमने अपने खोज इंजन, ट्रैकर "
+"ब्लॉकर और एनक्रिप्शन एनफोर्सर को एक ही %1$s%2$s एक्सटेंशन%3$s में बंडल कर दिया है।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3381,9 +3361,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख "
-"ब्राउज़र्स%2$s के लिए गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, "
-"सब कुछ एक ही डाउनलोड में।"
+"सामान्य तौर पर ब्राउज़ करें, और बाकी सबका ध्यान हम रखेंगे। %1$sप्रमुख ब्राउज़र्स%2$s के लिए "
+"गोपनीय खोज, ट्रैकर ब्लॉकिंग और साइट एनक्रिप्शन पाएं, सब कुछ एक ही डाउनलोड में।"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3490,11 +3469,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र "
-"में) में संग्रहित किया जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से "
-"(क्लाउड में रिमोट सर्वर पर) संग्रहित करने के लिए अनाम क्लाउड सेव का उपयोग कर "
-"सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी क्लाउड में संग्रहित "
-"नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं होगा।"
+"डिफ़ॉल्ट रूप से, सेटिंग्स को गैर-व्यक्तिगत ब्राउज़र कुकीज़ (आपके ब्राउज़र में) में संग्रहित किया "
+"जाता है। आप अपनी सेटिंग्स को अधिक स्थायी तरीके से (क्लाउड में रिमोट सर्वर पर) संग्रहित "
+"करने के लिए अनाम क्लाउड सेव का उपयोग कर सकते हैं। व्यक्तिगत रूप से पहचान योग्य कोई भी "
+"जानकारी क्लाउड में संग्रहित नहीं की जाएगी और आपका पासफ़्रेज़ आपके ब्राउज़र से कभी अलग नहीं "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3502,8 +3481,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"डिक्टेशन चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3512,8 +3491,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को "
-"भेजने की सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
+"वॉयस चैट चालू करके, आप इस फ़ीचर के इस्तेमाल के लिए अपना वॉयस डेटा OpenAI को भेजने की "
+"सहमति देते हैं। शुरू करने से पहले हमारे %1$s को देखें।"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3863,9 +3842,7 @@ msgstr "यूआरएल के दिखाई देने का तरी�
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर "
-"देता है"
+msgstr "जब आप स्क्रॉल करते हैं तो हेडर कैसे प्रदर्शित होने और उसका ढंग परिवर्तित कर देता है"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4013,11 +3990,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के "
-"साथ गुमनाम ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि "
-"मॉडलों को सपोर्ट करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat "
-"बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर भी आप "
-"%1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Chat का इस्तेमाल कर सकते हैं।"
+"Chat से (हमारी Duck.ai सेवा के माध्यम से) आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम "
+"ढंग से बातचीत करने की सुविधा मिलती है, जो OpenAI, Anthropic आदि मॉडलों को सपोर्ट "
+"करती है। इस सेटिंग को बंद करने से DuckDuckGo Search पर Chat बटन और लिंक छिप जाएंगे। "
+"हालांकि, यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
+"Chat का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4073,8 +4050,7 @@ msgstr "गोपनीय ढंग से चैट करें"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में मौजूद Duck.ai के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4082,8 +4058,7 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय "
-"ढंग से चैट करें।"
+"हमारे मुफ़्त ब्राउज़र में Duck.ai साइडबार के ज़रिए किसी भी वेबसाइट पर गोपनीय ढंग से चैट करें।"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4164,8 +4139,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"चैट्स एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से "
-"स्टोर की जाती हैं। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"चैट्स एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर की जाती हैं। "
+"आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4174,8 +4149,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर "
-"स्टोर की जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
+"चैट DuckDuckGo सर्वर या रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर पर स्टोर की "
+"जाती हैं। चैट हिस्ट्री बंद करने से पिन की गई चैट्स डिलीट हो जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4187,11 +4162,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
-"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते "
-"हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट "
-"हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और "
-"रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
+"चैट्स आपके डिवाइस में स्टोर होते हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए "
+"जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
+"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई "
+"चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4214,9 +4188,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर "
-"अपलोड की गई सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर "
-"द्वारा गुमनाम रूप से किया जाता है।"
+"%1$s के साथ चैट में ज़ीरो प्रोवाइडर विज़िबिलिटी रहती है, लेकिन Duck.ai पर अपलोड की गई "
+"सभी फ़ाइलों के रिव्यू को %2$s के लिए एक कंटेंट मॉडरेशन प्रोवाइडर द्वारा गुमनाम रूप से किया "
+"जाता है।"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4224,8 +4198,7 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए "
-"स्टोरेज खाली करें।"
+"अटैचमेंट वाली चैट्स सिंक होना बंद हो गई हैं। सिंक फिर से शुरू करने के लिए स्टोरेज खाली करें।"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4381,8 +4354,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ "
-"सर्वर लोकेशन में से चुनें।"
+"हानिकारक साइटों और स्कैम को ब्लॉक करने में मदद के लिए दुनिया भर में 40+ सर्वर लोकेशन में से "
+"चुनें।"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4400,8 +4373,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस "
-"ऐप का इस्तेमाल करना है"
+"किसी स्थान खोज परिणाम के लिए आपको डायरेक्शन की ज़रूरत होने पर चुनें कि किस ऐप का "
+"इस्तेमाल करना है"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4582,9 +4555,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को "
-"लंबे समय तक रख सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर "
-"उन्हें ऑटो-डिलीट कर सकते हैं।"
+"ब्राउज़र डेटा साफ़ करने से चैट डिलीट हो जाती हैं। कुछ ब्राउज़र हालिया चैट को लंबे समय तक रख "
+"सकते हैं या 7 से ज़्यादा दिनों तक AI Chat का उपयोग न करने पर उन्हें ऑटो-डिलीट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4594,9 +4566,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए "
-"बिना, हाल की चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के "
-"बाद अपने-आप हटाया जा सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
+"ब्राउज़र डेटा साफ़ करने से हाल की चैट हट जाती हैं। Duck.ai का इस्तेमाल किए बिना, हाल की "
+"चैट को अनिश्चित काल के लिए सेव किया जा सकता है या 7 दिनों के बाद अपने-आप हटाया जा "
+"सकता है। यह आपके ब्राउज़र पर निर्भर करता है।"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4605,8 +4577,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी "
-"ब्लॉक लिस्ट को हमेशा के लिए सेव करें"
+"ब्राउज़र डेटा क्लियर करने से आपकी ब्लॉक की गई साइटें रीसेट हो जाएंगी। अपनी ब्लॉक लिस्ट को "
+"हमेशा के लिए सेव करें"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4615,9 +4587,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप "
-"प्रश्न %1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो "
-"OpenAI, Anthropic और अन्य के चैट मॉडलों को सपोर्ट करती है।"
+"किसी विषय पर और गहराई से जानने के लिए \"अधिक\" पर क्लिक करें, और फ़ॉलोअप प्रश्न "
+"%1$sDuck.ai%2$s के ज़रिए पूछें, यह हमारी प्राइवेट AI चैट सेवा है जो OpenAI, Anthropic "
+"और अन्य के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4659,8 +4631,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > "
-"प्राथमिकताएं%4$s (Mac पर) क्लिक करें"
+"%1$sसंपादित करें > प्राथमिकताएं%2$s (Windows पर) %3$sSeaMonkey > प्राथमिकताएं%4$s "
+"(Mac पर) क्लिक करें"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4676,9 +4648,7 @@ msgstr "DuckDuckGo एकस्टेंशन को डाउनलोड क�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक "
-"करें"
+msgstr "DuckDuckGo Safari एकस्टेंशन को डाउनलोड करके खोलने के लिए %1$sखोलें%2$s क्लिक करें"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4693,8 +4663,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर "
-"%3$sगियर आइकन%4$s पर क्लिक करें)"
+"शीर्ष मेनू में %1$sSafari%2$s पर क्लिक करें (Windows पर, शीर्ष दाईं ओर %3$sगियर "
+"आइकन%4$s पर क्लिक करें)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4711,9 +4681,7 @@ msgstr "ड्रॉपडाउन में %1$sसेटिंग्स%2$s �
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s "
-"करें।"
+msgstr "%1$sमौजूदा पेज इस्तेमाल करें%2$s पर क्लिक करें, फिर %3$sओके पर क्लिक%4$s करें।"
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4726,8 +4694,7 @@ msgstr "%1$sहां%2$s पर क्लिक करें"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक "
-"करें"
+"Chrome टूलबार (ऊपर से दाहिने) पर %1$ssettings/hamburger आइकन%2$s पर क्लिक करें"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4789,9 +4756,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा "
-"हटा देता है, लेकिन यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी "
-"खोज सेटिंग रीसेट करें%4$s पर क्लिक/टैप नहीं कर देते।"
+"%1$sमेरा डेटा डिलीट करें%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटा देता है, लेकिन "
+"यह आपके ब्राउज़र में तब तक बना रहता है जब तक आप %3$sसभी खोज सेटिंग रीसेट करें%4$s पर "
+"क्लिक/टैप नहीं कर देते।"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4802,9 +4769,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता "
-"है, लेकिन यह आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स "
-"रीसेट%4$s पर क्लिक/टैप नहीं करते।"
+"%1$sमेरा डेटा हटाएं%2$s पर क्लिक करें या टैप करें। यह क्लाउड से डेटा हटाता है, लेकिन यह "
+"आपके ब्राउज़र में तब तक रहता है जब तक आप %3$sसभी सेटिंग्स रीसेट%4$s पर क्लिक/टैप नहीं करते।"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4873,8 +4839,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर "
-"क्लिक करें और %3$sDuckDuckGo%4$s चुनें।"
+"%1$sएड्रेस बार में उपयोग किए गए खोज इंजन%2$s के पास वाले ड्रॉपडाउन मेनू पर क्लिक करें और "
+"%3$sDuckDuckGo%4$s चुनें।"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4882,8 +4848,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र "
-"के ऊपरी दाएं कोने में होता है।"
+"विज्ञापन ब्लॉकर एक्सटेंशन के आइकॉन पर क्लिक करें। यह आम तौर पर आपके ब्राउज़र के ऊपरी दाएं "
+"कोने में होता है।"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5084,8 +5050,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा "
-"सुरक्षित रख सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
+"Cloud Save से आप अपनी चुनी हुई सेटिंग्स एक पासवर्ड द्वारा सर्वर पर ज़्यादा सुरक्षित रख "
+"सकते हैं। यह पूर्ण तरह से वैकल्पिक है।"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5539,8 +5505,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup "
-"› Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
+"दूसरे डिवाइस से कोड कॉपी करें. %1$sDuck.ai Settings › Chats › Sync & Backup › "
+"Sync With Another Device%2$s पर जाएँ और फिर से कोशिश करें."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5705,8 +5671,7 @@ msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
 msgstr ""
-"चैट की एक कॉपी बनाता है जिसे लिंक खोलने वाला कोई भी व्यक्ति देख और सेव कर "
-"सकता है।"
+"चैट की एक कॉपी बनाता है जिसे लिंक खोलने वाला कोई भी व्यक्ति देख और सेव कर सकता है।"
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5960,8 +5925,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट "
-"करना जारी रख सकते हैं।"
+"दैनिक उपयोग सीमा पूरी हो गई है। आप अपनी साप्ताहिक सीमा का इस्तेमाल करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6278,8 +6243,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और "
-"बातचीत को अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
+"लिंक को डिलीट करने से यह काम करना बंद कर देगा. जिन लोगों ने इसे खोला है और बातचीत को "
+"अपनी चैट में जोड़ा है, उनके पास इसकी अपनी कॉपी रहेगी."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6376,8 +6341,8 @@ msgstr "Duck.ai में डिक्टेशन"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम डिक्टेशन को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए नहीं "
+"किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6395,8 +6360,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता "
-"है, ताकि आप बिना टाइप किए भी Duck.ai में चैट कर सकें।"
+"डिक्टेशन आपकी स्पीच को टेक्स्ट में बदलने के लिए OpenAI मॉडल का इस्तेमाल करता है, ताकि आप "
+"बिना टाइप किए भी Duck.ai में चैट कर सकें।"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6526,6 +6491,12 @@ msgid "Dislike source"
 msgstr "स्रोत पसंद नहीं आया"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "निरस्त करें"
@@ -6636,6 +6607,12 @@ msgid "Djibouti"
 msgstr "जिबूती"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6721,8 +6698,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा "
-"नहीं है और AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s इसमें कोई AI सुविधा नहीं है और "
+"AI इमेज फ़िल्टर कर दी गई हैं। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6731,8 +6708,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI "
-"फ़ीचर्स और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
+"क्या आपको AI नहीं चाहिए? %1$snoai.duckduckgo.com%2$s पर जाएं ताकि बिना AI फ़ीचर्स "
+"और बिना AI इमेज फ़िल्टर के साथ खोज सकें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6848,8 +6825,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"छत वाले पंखे की मरम्मत सेवा के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6858,8 +6835,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम "
-"शब्दों में ज़रूरी जानकारी के साथ ईमेल लिखें।"
+"घर के रेफ़्रिजरेरट की मरम्मत के लिए कोटेशन का अनुरोध करते हुए, वेंडर को कम शब्दों में ज़रूरी "
+"जानकारी के साथ ईमेल लिखें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6880,8 +6857,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी "
-"में लोगों को आमंत्रित करने के लिए है।"
+"ऐसी एक सोशल मीडिया पोस्ट हेतु कुछ ऑप्शन ड्राफ्ट करें जो मेरी आगामी पार्टी में लोगों को "
+"आमंत्रित करने के लिए है।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6890,8 +6867,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग "
-"बढ़ाने की मेरी रणनीतियों के बारे में लिखना है।"
+"ऐसी एक पोस्ट के शीर्षक के लिए कुछ ऑप्शन ड्राफ्ट करें जिसमें मुझे टीम सहयोग बढ़ाने की मेरी "
+"रणनीतियों के बारे में लिखना है।"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7023,9 +7000,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। "
-"पेज का कंटेंट तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग "
-"में पेजों को ऑटोमैटिकली अटैच करने का विकल्प न चुना हो।"
+"अब Duck.ai आपके द्वारा देखे जा रहे पेज से संबंधित सवालों के जवाब दे सकता है। पेज का कंटेंट "
+"तभी शामिल होता है जब आप उसे अटैच करते हैं, बशर्ते आपने सेटिंग में पेजों को ऑटोमैटिकली अटैच "
+"करने का विकल्प न चुना हो।"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7035,9 +7012,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। "
-"कृपया अपनी ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) "
-"करें और फिर से कोशिश करें।"
+"Duck.ai आपकी चैट्स को सेव करने के लिए लोकल स्टोरेज एक्सेस नहीं कर सकता। कृपया अपनी "
+"ब्राउज़र सेटिंग्स चेक करें या कोई भी एक्सटेंशन डिसेबल (अक्षम) करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7046,8 +7022,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस "
-"चैट को अब कल जारी रखें।"
+"Duck.ai एक दिन के लिए तय संदेशों की अधिकतम संख्या तक पहुंच गया है। कृपया इस चैट को अब "
+"कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -7063,9 +7039,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन "
-"कंपनी हैं, जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने "
-"हाथ में लेना चाहते हैं।"
+"Duck.ai को DuckDuckGo द्वारा बनाया गया है। हम एक स्वतंत्र ऑनलाइन प्रोटेक्शन कंपनी हैं, "
+"जो उन सभी के लिए है जो अपनी पर्सनल जानकारी का कंट्रोल वापस अपने हाथ में लेना चाहते हैं।"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7080,8 +7055,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी "
-"आसान होगा: https://duck.ai"
+"Duck.ai अभी भी DuckDuckGo का प्रोडक्ट है, लेकिन अब वेब पर इसे याद रखना और भी आसान "
+"होगा: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7096,8 +7071,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम "
-"कोड %1$s को %2$s पर ईमेल करें"
+"Duck.ai फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस अनाम कोड "
+"%1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7118,9 +7093,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता "
-"है। इसे बंद करने से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी "
-"%1$sduck.ai%2$s पर जा सकते हैं सीधे ही।"
+"Duck.ai आपको पॉपुलर AI मॉडल्स के साथ गोपनीय ढंग से प्राइवेट चैट करने देता है। इसे बंद करने "
+"से Duck.ai बटन और लिंक छिप जाते हैं, लेकिन आप अभी भी %1$sduck.ai%2$s पर जा सकते हैं "
+"सीधे ही।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7131,11 +7106,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की "
-"सुविधा मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग "
-"को बंद करने से DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, "
-"यह सेटिंग बंद होने पर भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर "
-"Duck.ai का इस्तेमाल कर सकते हैं।"
+"Duck.ai से आपको थर्ड-पार्टी AI चैट मॉडल के साथ गुमनाम ढंग से बातचीत करने की सुविधा "
+"मिलती है, जिसमें OpenAI, Anthropic और अन्य मॉडल शामिल हैं। इस सेटिंग को बंद करने से "
+"DuckDuckGo Search पर Duck.ai बटन और लिंक छिप जाएंगे। हालांकि, यह सेटिंग बंद होने पर "
+"भी आप %1$shttps://duck.ai%2$s पर जाकर, सीधे तौर पर Duck.ai का इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7150,8 +7124,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी "
-"रख सकते हैं।"
+"हो सकता है कि Duck.ai ने आपकी पिछली चैट हटा दी हों। आप Duck.ai का उपयोग जारी रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7165,8 +7139,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता "
-"संबंधी कोई जांच नहीं होती है।"
+"Duck.ai के जवाब कुछ खास स्रोतों पर आधारित नहीं होते हैं और इनकी सटीकता संबंधी कोई जांच "
+"नहीं होती है।"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7200,9 +7174,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, "
-"बिना साइन अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, "
-"गोपनीयता केंद्रित AI, बिना खाता AI चैट"
+"Duck.ai, DuckDuckGo AI, प्राइवेट AI चैटबॉट, मुफ़्त AI चैट, गुमनाम AI चैट, बिना साइन "
+"अप AI चैट, OpenAI, Anthropic, Llama, Mistral, ओपन सोर्स AI मॉडल, गोपनीयता "
+"केंद्रित AI, बिना खाता AI चैट"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7230,13 +7204,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके "
-"बारे में खास जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार "
-"दिखाना है: कभी नहीं (यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा "
-"देता है), ऑन-डिमांड (सिर्फ़ तभी दिखाता है जब आप 'सहायता' बटन पर क्लिक करते "
-"हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब नतीजे बहुत काम के हों), या अक्सर (कई "
-"तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, DuckAssist सिर्फ़ अमेरिका "
-"(अंग्रेज़ी) में उपलब्ध है।"
+"कुछ खोजों के लिए DuckAssist, जानकारी को गुमनाम रूप से खोज सकता है और उसके बारे में खास "
+"जानकारी दे सकता है। आप चुन सकते हैं कि DuckAssist को कितनी बार दिखाना है: कभी नहीं "
+"(यह खोज परिणामों से DuckAssist के यूआई को पूरी तरह हटा देता है), ऑन-डिमांड (सिर्फ़ तभी "
+"दिखाता है जब आप 'सहायता' बटन पर क्लिक करते हैं), कभी-कभी (सिर्फ़ तभी दिखाता है, जब "
+"नतीजे बहुत काम के हों), या अक्सर (कई तरह की खोजों पर अक्सर दिखाता है)। फ़िलहाल, "
+"DuckAssist सिर्फ़ अमेरिका (अंग्रेज़ी) में उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7246,8 +7219,8 @@ msgid ""
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
+"%1$sDuckDuckGo AI Chat%2$s भी उपलब्ध है, जो एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI के चैट मॉडलों को, और Anthropic को और अन्य को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7257,8 +7230,8 @@ msgid ""
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
 "DuckAssist से फ़ॉलोअप सवालों के जवाब नहीं दिए जा सकते। हालांकि, हमारी ओर से "
-"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा "
-"है जो OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
+"DuckDuckGo %1$sAI Chat%2$s भी उपलब्ध है। यह एक प्राइवेट AI-संचालित चैट सेवा है जो "
+"OpenAI और Anthropic के चैट मॉडलों को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7270,12 +7243,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज "
-"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और "
-"संबंधित साइटों को स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे "
-"जुड़ी खास जानकारी को जनरेट करने के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी "
-"का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल इसके जवाब Wikipedia और "
-"संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया फ़ीचर है। यह गुमनाम रहकर, खोज संबंधी "
+"क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह Wikipedia और संबंधित साइटों को "
+"स्कैन करके उनसे काम की जानकारी जुटाता है। इसके बाद, उससे जुड़ी खास जानकारी को जनरेट करने "
+"के लिए AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। कृपया ध्यान दें कि फ़िलहाल "
+"इसके जवाब Wikipedia और संबंधित कॉन्टेंट पर आधारित होते हैं और इसकी सटीकता की जांच नहीं "
+"की जाती है।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7289,15 +7262,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम "
-"रहकर, खोज संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को "
-"स्कैन करके क्वेरी से जुड़ी सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी "
-"जानकारी के आधार पर कम शब्दों में जवाब देने के लिए, AI-संचालित नेचुरल "
-"लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा एक या दो "
-"स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, "
-"ताकि आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है "
-"कि जवाब, दूसरे स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर "
-"आधारित होते हैं।"
+"DuckAssist, खोज परिणाम दिखाने से जुड़ा एक नया वैकल्पिक फ़ीचर है। यह गुमनाम रहकर, खोज "
+"संबंधी क्वेरी के जवाब जनरेट कर सकता है। ऐसा करने के लिए, यह वेब को स्कैन करके क्वेरी से जुड़ी "
+"सामग्री जुटाता है। इसके बाद, उस सामग्री से जुड़ी जानकारी के आधार पर कम शब्दों में जवाब देने "
+"के लिए, AI-संचालित नेचुरल लैंग्वेज टेक्नोलॉजी का इस्तेमाल करता है। DuckAssist के जवाब हमेशा "
+"एक या दो स्रोतों से सीधे लिंक होते हैं, जिसमें बताया जाता है कि जवाब कहां से आया है, ताकि "
+"आपको आसानी से वहां जाकर ज़्यादा जानकारी मिल सके। यह याद रखना ज़रूरी है कि जवाब, दूसरे "
+"स्रोतों से अपने-आप जनरेट होते हैं और %1$sवेब क्रॉलिंग%2$s पर आधारित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7305,8 +7276,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते "
-"हैं और इनकी सटीकता की जांच नहीं की जाती है।"
+"DuckAssist वाले जवाब सूचीबद्ध स्रोतों के आधार पर स्वचालित ढंग से जनरेट होते हैं और इनकी "
+"सटीकता की जांच नहीं की जाती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7315,8 +7286,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। "
-"कृपया इस चैट को अब कल जारी रखें।"
+"DuckDuckGo AI Chat में एक दिन के संदेशों की अधिकतम संख्या पूरी हो गई है। कृपया इस चैट को "
+"अब कल जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7325,8 +7296,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7335,8 +7306,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के "
-"%2$s और %3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
+"DuckDuckGo AI Chat एक प्राइवेट AI-संचालित चैट सेवा है जो वर्तमान में %1$s के %2$s और "
+"%3$s के %4$s चैट मॉडल को सपोर्ट करती है।"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7345,8 +7316,7 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"DuckDuckGo AI Chat बीटा में है, इसमें गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7355,8 +7325,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो "
-"कृपया इस अनाम कोड %1$s को %2$s पर ईमेल करें"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। अगर यह समस्या बनी रहती है, तो कृपया इस "
+"अनाम कोड %1$s को %2$s पर ईमेल करें"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7365,8 +7335,7 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
 msgstr ""
-"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से "
-"कोशिश करें।"
+"DuckDuckGo AI Chat फिलहाल उपलब्ध नहीं है। पेज को रीफ्रेश करें और फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7522,9 +7491,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी "
-"मेटाडेटा जैसी व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को "
-"एनोनिमाइज़ कर देता है।"
+"DuckDuckGo सुरक्षा की दृष्टि से नाम, ईमेल पते, फ़ोन नंबर और पहचान संबंधी मेटाडेटा जैसी "
+"व्यक्तिगत जानकारी (PII) को ऑटोमैटिकली हटाकर इन रिपोर्टों को एनोनिमाइज़ कर देता है।"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7532,8 +7500,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की "
-"%2$s से सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप Duck.ai की %2$s से "
+"सहमत होते हैं।"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7542,8 +7510,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से "
-"सहमत होते हैं।"
+"DuckDuckGo आपकी चैट को अनाम बनाता है। '%1$s' पर क्लिक करके आप हमारी %2$s से सहमत "
+"होते हैं।"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7552,9 +7520,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता "
-"है, जिसमें Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर "
-"आपको अन्य वेबसाइटों पर ट्रैक करने की कोशिश करते हैं।"
+"DuckDuckGo आपके द्वारा देखी जाने वाली वेबसाइटों पर ट्रैकरों को ब्लॉक करता है, जिसमें "
+"Google और Facebook जैसी कंपनियों के ट्रैकर शामिल हैं, जो अक्सर आपको अन्य वेबसाइटों पर "
+"ट्रैक करने की कोशिश करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7566,12 +7534,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो "
-"यह केवल आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो "
-"आपकी डिवाइस उसे हमें भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर "
-"बनाने के लिए करते हैं और फिर हम तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही "
-"रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने इस तकनीक को कैसे डिज़ाइन "
-"किया है, इसके बारे में और जानें%2$s।"
+"DuckDuckGo को गोपनीयता के लिए बनाया गया है। जब आप स्‍थान सक्षम करते हैं, तो यह केवल "
+"आपके स्थानीय डिवाइस में स्टोर हो जाता है। जब आप खोज करते हैं, तो आपकी डिवाइस उसे हमें "
+"भेजता है, हम उसका उपयोग उस खोज के परिणामों को बेहतर बनाने के लिए करते हैं और फिर हम "
+"तुरंत इसे फेंक देते हैं, जिससे आप गुमनाम ही रहते हैं। %1$sआपकी गोपनीयता की सुरक्षा के लिए हमने "
+"इस तकनीक को कैसे डिज़ाइन किया है, इसके बारे में और जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7591,8 +7558,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक "
-"के बेहतर परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
+"DuckDuckGo केवल आपके अनुमानित स्‍थान का उपयोग करता है। हम सभी को आपके नज़दीक के बेहतर "
+"परिणाम देने की जरूरत है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7684,10 +7651,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक "
-"शब्दों की लंबी सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों "
-"का चयन करते हैं, यह सुनिश्चित करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर "
-"लंबा है।"
+"हर बार जब आप पासफ्रेज़ सुझाव मांगते हैं, तो हमें DuckDuckGo सर्वर से आकस्मिक शब्दों की लंबी "
+"सूची मिलती है। ब्राउज़र में, हम उस सूची से 4-5 आकस्मिक शब्दों का चयन करते हैं, यह सुनिश्चित "
+"करते हुए कि पासफ्रेज़ कम से कम 18-20 अक्षर लंबा है।"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7764,8 +7730,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब "
-"तैयार होगा।"
+"आपके संदेश को एडिट करने से नीचे दिया गया जवाब हट जाएगा और उसकी जगह नया जवाब तैयार "
+"होगा।"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7903,8 +7869,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना "
-"विचार बदल सकते हैं।"
+"अधिक सटीक परिणामों के लिए अनाम स्थान सक्षम करें। आप अक्‍सर बाद में अपना विचार बदल सकते "
+"हैं।"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7947,9 +7913,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते "
-"हैं, लेकिन फिर भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते "
-"हैं।"
+"जगह की जानकारी गुप्त रखने की सुविध चालू करने से ज़्यादा सटीक परिणाम मिलते हैं, लेकिन फिर "
+"भी DuckDuckGo के लिए आपकी खोजें और सटीक स्थान गोपनीय बने रहते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8125,8 +8090,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह "
-"आपके नए पासफ्रेज़ के तहत आपके डेटा को बचाएगा।"
+"एक नया पासफ्रेज़ दर्ज करें और %1$sसेटिंग सहेजें%2$s पर टैप/क्लिक करें। यह आपके नए पासफ्रेज़ के "
+"तहत आपके डेटा को बचाएगा।"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8152,8 +8117,8 @@ msgstr "टेक्स्ट डालें"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s "
-"उपनाम %6$s: d%7$s"
+"निम्नलिखित विवरण दर्ज करें: %1$sनाम%2$s: DuckDuckGo%3$s यूआरएल%4$s: %5$s उपनाम "
+"%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8254,8 +8219,8 @@ msgstr "मैप का विस्तार करें"
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
 msgstr ""
-"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी "
-"की सचमुच परवाह है।"
+"उन लोगों के लिए बेहतरीन ढंग से तैयार किए गए प्रोडक्ट, जिन्हें अपनी प्राइवेसी की सचमुच "
+"परवाह है।"
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8495,6 +8460,12 @@ msgid "Fast"
 msgstr "तेज़"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8539,8 +8510,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार "
-"संंबंधी कार्यों में मदद मिलती है।"
+"आप लोगों से जो फीडबैक मिलती है उससे हमें हमारे प्रोडक्ट अपडेट और सुधार संंबंधी कार्यों में मदद "
+"मिलती है।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8549,9 +8520,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की "
-"कोशिश में मदद मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे "
-"आपने शेयर किया है।"
+"आप लोगों से जो फ़ीडबैक मिलता है उससे हमारे प्रॉडक्ट अपडेट और बेहतर बनाने की कोशिश में मदद "
+"मिलती है। उम्मीद है हम जल्द ही वह समस्या भी हल कर पाएंगे जिसे आपने शेयर किया है।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8559,8 +8529,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी "
-"वेबसाइट में कॉपी पेस्ट करें।"
+"नीचे दी गई सेटिंग को निस्संकोच होकर एडजस्ट करें। उसके बाद, कोड को अपनी वेबसाइट में कॉपी "
+"पेस्ट करें।"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8654,9 +8624,7 @@ msgstr "इमेज खोज परिणामों से AI-जनरे�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर "
-"जानें%2$s"
+msgstr "इमेज खोज परिणामों से ज्ञात AI स्पैम साइटों को फ़िल्टर कर देता है। %1$sऔर जानें%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8734,9 +8702,7 @@ msgstr "अपने नज़दीक के परिणामों को �
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती "
-"है।"
+msgstr "अपने आस-पास के परिणाम खोजें। %1$sआपकी लोकेशन निजी, सुरक्षित और गुमनाम रहती है।"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8800,8 +8766,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई "
-"मेन्यू विकल्प चुनें या कोई बटन क्लिक करें।"
+"DuckDuckGo के लिए विज्ञापन ब्लॉकर बंद करने के निर्देशों का पालन करें। कोई मेन्यू विकल्प चुनें "
+"या कोई बटन क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8819,6 +8785,12 @@ msgstr "फ़ॉलोअप सवाल"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "फ़ॉलोअप गोपनीय रहते हैं।"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8955,8 +8927,8 @@ msgstr "व्यावसायिक रूप से शेयर और उ�
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
 msgstr ""
-"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट "
-"नहीं की जाएंगी।"
+"जो चैट काम की नहीं हैं, उन्हें डिलीट कर स्पेस खाली करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9037,8 +9009,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट "
-"देखें...</strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
+"Mac पर ऐप के मेनू बार से, <strong>DuckDuckGo</strong> &gt; <strong>अपडेट देखें...</"
+"strong> चुनें, फिर <strong>अपडेट इंस्टॉल करें</strong> को चुनें।"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9324,14 +9296,15 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और "
-"Identity Theft Restoration."
+"प्राप्त करें DuckDuckGo VPN, एडवांस्ड Duck.ai, Personal Info Removal, और Identity "
+"Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
+msgstr ""
+"DuckDuckGo VPN, एडवांस्ड Duck.ai, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9417,8 +9390,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity "
-"Theft Restoration पाएं।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, Personal Info Removal, और Identity Theft "
+"Restoration पाएं।"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9427,8 +9400,7 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration "
-"प्राप्त करें।"
+"तेज़, नो-लॉग VPN, ऑप्शनल एडवांस्ड AI चैट, और Identity Theft Restoration प्राप्त करें।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9437,9 +9409,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस "
-"प्राप्त करें, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल "
-"हैं।"
+"DuckDuckGo को सब्सक्राइब करके Duck.ai में एडवांस्ड AI मॉडल्स का एक्सेस प्राप्त करें, जिसमें "
+"हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9450,9 +9421,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo "
-"सब्सक्रिप्शन के साथ, जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी "
-"शामिल हैं।"
+"Duck.ai में एडवांस्ड AI मॉडल मॉडल्स का एक्सेस प्राप्त करें DuckDuckGo सब्सक्रिप्शन के साथ, "
+"जिसमें हमारा VPN और अन्य प्रीमियम गोपनीयता संरक्षण भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9496,8 +9466,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल "
-"का ऑप्शनल एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
+"हमारा तेज़, नो-लॉग VPN पाएं, साथ ही ज़्यादा चैट लिमिट वाले एडवांस्ड AI मॉडल का ऑप्शनल "
+"एक्सेस और कई प्रीमियम प्रोटेक्शन भी पाएं।"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9558,8 +9528,7 @@ msgstr "ऐप प्राप्त करें"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक "
-"करें।%2$s"
+"DuckDuckGo ब्राउज़र मुफ़्त में डाउनलोड करें और %1$sYouTube पर विज्ञापन ब्लॉक करें।%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9581,9 +9550,7 @@ msgstr "यह गाना यहां पाएंः"
 # smartling.placeholder_format=C
 msgctxt "spread_badge"
 msgid "Get your friends to switch and help us grow!"
-msgstr ""
-"आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद "
-"करें!"
+msgstr "आपके दोस्तों को स्विच करने के लिए प्रेरित करें और हमें विकसित होने में मदद करें!"
 
 # smartling.placeholder_format=C
 #. Accessible (screen-reader) label for the onboarding checklist card in the Duck.ai sidebar.
@@ -9620,9 +9587,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में "
-"जाएं और %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › "
-"टेक्स्ट कोड कॉपी करें%4$sपर जाएं"
+"अपने दूसरे ब्राउज़र में %1$sDuck.ai सेटिंग%2$s पर जाएं, या DuckDuckGo ऐप में जाएं और "
+"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें › टेक्स्ट कोड कॉपी "
+"करें%4$sपर जाएं"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9631,8 +9598,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9642,9 +9609,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और "
-"इस कोड को स्कैन करें:"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9654,9 +9620,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और "
-"%3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या "
-"अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में %1$sDuck.ai सेटिंग%2$s पर जाएं और %3$sचैट › "
+"Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएं। या अपनी रिकवरी PDF "
+"पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9665,8 +9631,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ "
-"सिंक करें%4$s पर जाएँ."
+"%1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे डिवाइस के साथ सिंक "
+"करें%4$s पर जाएँ."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9681,8 +9647,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि "
-"\"स्थान सेवाएं\" चालू है।"
+"%1$sसेटिंग > गोपनीयता और सुरक्षा > स्थान सेवाएं%2$s पर जाएं और पक्का करें कि \"स्थान "
+"सेवाएं\" चालू है।"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9691,8 +9657,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे "
-"स्क्रॉल करके %3$sDuckDuckGo%4$s पर जाएं।"
+"यहां जाएं: %1$sसेटिंग > गोपनीयता > अनुमति प्रबंधक > स्थान%2$s, और फिर नीचे स्क्रॉल करके "
+"%3$sDuckDuckGo%4$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9759,6 +9725,12 @@ msgstr "बढ़िया डिज़ाइन"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "अच्छी गोपनीयता नीति"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10381,8 +10353,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist "
-"उत्तरों में मुख्य तथ्यों को हाइलाइट करता है।"
+"महत्वपूर्ण जानकारी तेज़ी से ढूंढने में आपकी सहायता करने के लिए Search Assist उत्तरों में मुख्य "
+"तथ्यों को हाइलाइट करता है।"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10409,8 +10381,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s "
-"दबाएं%3$s। %4$sफिर %5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
+"सूची में DuckDuckGo को सहेजने के लिए अपने कीबोर्ड पर %1$sरिटर्न%2$s दबाएं%3$s। %4$sफिर "
+"%5$sडिफ़ॉल्ट बनाएं%6$s क्लिक करें"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10424,8 +10396,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा "
-"गोपनीयता संरक्षण खो देंगे।"
+"रुके रहें! इसे वापस बदलने पर DuckDuckGo एक्सटेंशन अक्षम हो जाएगा और आप हमारा गोपनीयता "
+"संरक्षण खो देंगे।"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10475,8 +10447,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते "
-"हैं और इनका उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
+"होटल विज्ञापन क्लिक TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं और इनका "
+"उपयोग आपकी व्यक्तिगत जानकारी जुटाने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10624,8 +10596,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह "
-"व्यवहारकुशलता से बात करनी चाहिए और क्या कहना चाहिए?"
+"मुझे अपने सहकर्मी से उनकी लगातार पेंसिल से खट-खट करने के बारे में किस तरह व्यवहारकुशलता से "
+"बात करनी चाहिए और क्या कहना चाहिए?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10747,8 +10719,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ "
-"कौन-सी हैं और क्यों?"
+"मुझे 'नेम ऑफ द विंड' पुस्तक पसंद है। इस तरह की कुछ और अच्छी किताबें/सीरीज़ कौन-सी हैं और "
+"क्यों?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10783,8 +10755,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट "
-"> 'स्थान और गोपनीयता रीसेट करें' पर जाएं%2$s।"
+"यदि ब्राउज़र स्थान अभी भी मौजूद नहीं है, तो %1$sसेटिंग्‍स > सामान्य > रीसेट > 'स्थान और "
+"गोपनीयता रीसेट करें' पर जाएं%2$s।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10794,9 +10766,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > "
-"सेटिंग्‍स > साइट सेटिंग्स > स्थान%2$s पर जाएं, और सुनिश्चित करें कि "
-"DuckDuckGo को स्थान एक्सेस की अनुमति है।"
+"यदि ब्राउज़र स्थान मौजूद नहीं है, तो अपने ब्राउज़र में %1$s⋮ > मेनू > सेटिंग्‍स > साइट सेटिंग्स "
+"> स्थान%2$s पर जाएं, और सुनिश्चित करें कि DuckDuckGo को स्थान एक्सेस की अनुमति है।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10811,8 +10782,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज "
-"इंजन%4$s की सूची में जोड़ना होगा"
+"अगर आपको %1$sDuckDuckGo%2$s दिखाई नहीं दे रहा है तो आपको उसे %3$sअन्य खोज इंजन%4$s "
+"की सूची में जोड़ना होगा"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10821,8 +10792,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, "
-"तो आप सीधे %1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
+"अगर आपको हमारे चैट प्रदाताओं या किसी खास चैट जवाब के बारे में कोई समस्या है, तो आप सीधे "
+"%1$s और %2$s सपोर्ट पेज पर भी जा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10831,17 +10802,15 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर "
-"करने के लिए आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के "
-"रूप में अपने डिवाइस पर सेव कर सकते हैं।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स को रिकवर करने के लिए "
+"आपको इस कोड की ज़रूरत पड़ेगी। आप इस कोड को एक टेक्स्ट फ़ाइल के रूप में अपने डिवाइस पर सेव "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें "
-"%2$s"
+msgstr "अगर आप और सहायता करना चाहते हैं तो, %1$s DuckDuckGo को फेलाने में मदद करें %2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10851,17 +10820,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे "
-"%1$s या %2$s संस्करणों का उपयोग करें।"
+"अगर​ आप जावास्क्रिप्ट के बिना DuckDuckGo का उपयोग करना चाहते, तो कृपया हमारे %1$s या "
+"%2$s संस्करणों का उपयोग करें।"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ "
-"खोलें)"
+msgstr "अगर आप चाहते हैं, तो नई विंडो और नए टैब के सामने होम पेज चुनें (इसके साथ खोलें)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10899,6 +10866,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "इमेज प्रॉम्प्ट्स को Duck.ai %1$s के अनुरूप होना चाहिए।"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10990,8 +10963,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में "
-"सुधार करता है"
+"अपडेट किए गए URL फ़ॉर्मैट, प्लेसमेंट और रंग के साथ नतीजे के बेहतर दिखने में सुधार करता है"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11004,8 +10976,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों "
-"को रीडायरेक्ट करना आवश्यक है। %1$sऔर जानें%2$s।"
+"कुछ पुराने ब्राउज़रों में हमारे सर्वर से खोज लीकेज रोकने के लिए आपके क्लिकों को रीडायरेक्ट करना "
+"आवश्यक है। %1$sऔर जानें%2$s।"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -11016,8 +10988,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य "
-"डिवाइस के साथ सिंक करें” चुनें।"
+"DuckDuckGo ब्राउज़र में, सेटिंग › Sync & Backup पर जाएं और फिर “किसी अन्य डिवाइस के "
+"साथ सिंक करें” चुनें।"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11032,8 +11004,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते "
-"हैं कि हम क्या जानकारी संग्रहित करते हैं।"
+"पारदर्शिता के हित में यह डेटा एन्क्रिप्ट नहीं किया गया है: आप वाकई देख सकते हैं कि हम क्या "
+"जानकारी संग्रहित करते हैं।"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11369,9 +11341,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश "
-"बताएं।"
+msgstr "क्या यह जगह अच्छी है? रिव्यू और रेटिंग के आधार पर इसकी रेपुटेशन का सारांश बताएं।"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11422,8 +11392,7 @@ msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा "
-"बार) ठीक है"
+"मुझसे मेरे DuckDuckGo को उपयोग करने के अनुभव के बारे में पूछना (बहुत ज़्यादा बार) ठीक है"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11442,10 +11411,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और "
-"Microsoft के विज्ञापन नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे "
-"मर्चेंट लैंडिंग पेज पर ले जाते हैं और विज्ञापनों के विपरीत, DuckDuckGo को इन "
-"परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
+"आइटम आपके खोज शब्दों की प्रासंगिकता के आधार पर रैंक किए जाते हैं और Microsoft के विज्ञापन "
+"नेटवर्क के माध्यम से डिलीवर किए जाते हैं। क्लिक सीधे मर्चेंट लैंडिंग पेज पर ले जाते हैं और "
+"विज्ञापनों के विपरीत, DuckDuckGo को इन परिणामों के लिए प्रतिफल नहीं दिया जाता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11454,8 +11422,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और "
-"अधिक सुरक्षित भी है।"
+"10 आकस्मिक अक्षरों और संख्याओं की तुलना में 4-5 शब्दों को याद रखना आसान और अधिक सुरक्षित "
+"भी है।"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11946,8 +11914,7 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की "
-"सुविधा देता है"
+"यह आपको Duck.ai पर सर्च क्वेरी और प्रॉम्प्ट सबमिट करने के बीच स्विच करने की सुविधा देता है"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12059,9 +12026,7 @@ msgstr "लिंक्स:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी "
-"लिस्ट दें।"
+msgstr "इसके लिए मुझे जिन टूल्स, सामग्रियों या ज़रूरी चीज़ों की ज़रूरत होगी, उनकी लिस्ट दें।"
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12724,8 +12689,8 @@ msgstr "माइक्रोनेशिया"
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
 msgstr ""
-"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की "
-"अनुमति दें और फिर से प्रयास करें।"
+"माइक्रोफ़ोन एक्सेस की अनुमति नहीं दी गई। कृपया माइक्रोफ़ोन एक्सेस करने की अनुमति दें और फिर "
+"से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13509,11 +13474,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और "
-"अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट "
-"कनेक्शन खो जाए तो चैट को रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से "
-"पिन की गई चैट डिलीट हो जाएंगी, और नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी "
-"स्टोरेज भी बंद हो जाएगा।"
+"नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से "
+"DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को "
+"रिकवर किया जा सके। चैट हिस्ट्री को डिसेबल करने से पिन की गई चैट डिलीट हो जाएंगी, और "
+"नए प्रॉम्प्ट और रिस्पॉन्स का टेम्पररी स्टोरेज भी बंद हो जाएगा।"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14348,8 +14312,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s "
-"आइकन > सेटिंग्स%5$s पर क्लिक करें"
+"Mac पर, %1$sMaxthon > प्राथमिकताएं पर क्लिक करें%2$s, Windows पर, %3$s %4$s आइकन "
+"> सेटिंग्स%5$s पर क्लिक करें"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14358,8 +14322,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
-"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
+"डिवाइस के साथ सिंक करें%4$s पर जाएँ"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14368,8 +14332,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
-"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
+"डिवाइस के साथ सिंक करें%4$s पर जाएँ और इस कोड को स्कैन करें:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14378,9 +14342,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी "
-"दूसरे डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR "
-"कोड को स्कैन करें."
+"दूसरे डिवाइस पर %1$sDuck.ai सेटिंग%2$s › %3$sचैट › Sync & Backup › किसी दूसरे "
+"डिवाइस के साथ सिंक करें%4$s पर जाएँ. या अपनी रिकवरी PDF पर मौजूद QR कोड को स्कैन करें."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14408,8 +14371,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया "
-"%1$s पेज या उससे कम वाली फ़ाइलें अपलोड करें।"
+"अटैच की गई फ़ाइलों में से एक में हमारी सपोर्ट सीमा से ज़्यादा पेज हैं। कृपया %1$s पेज या उससे "
+"कम वाली फ़ाइलें अपलोड करें।"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14436,8 +14399,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल "
-"पैरामीटर%2$s पेज पर है।"
+"केवल वो सेटिंग्स जिन्हें आपने बदला है। उनकी पूरी जानकारी इस %1$sयूआरएल पैरामीटर%2$s पेज "
+"पर है।"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14452,8 +14415,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में "
-"फिर से प्रयास करें।"
+"उफ़! इस टेक्स्ट का अनुवाद करते समय एक अनपेक्षित त्रुटि हुई है। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14784,8 +14746,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में "
-"हो। हम आपको — अवधि में ट्रैक नहीं करते हैं।"
+"अन्य खोज इंजन आपकी खोजों को ट्रैक करता है भले ही आप गुप्त ब्राउज़िंग मोड में हो। हम आपको — "
+"अवधि में ट्रैक नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14799,8 +14761,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा "
-"प्रीमियम प्रोटेक्शन के साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
+"हमारा तेज़, नो-लॉग VPN ज़्यादा लिमिट वाले स्मार्ट AI चैट्स और ज़्यादा प्रीमियम प्रोटेक्शन के "
+"साथ आता है। सब कुछ एक ही सब्सक्रिप्शन में।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14808,8 +14770,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर "
-"नहीं करते हैं।"
+"हमारी गोपनीयता नीति सरल है: हम आपकी किसी भी निजी जानकारी को एकत्रित या शेयर नहीं "
+"करते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14817,8 +14779,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, "
-"एनक्रिप्शन एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
+"मोबाइल के लिए हमारे गोपनीय ब्राउज़र में हमारा खोज इंजन, ट्रैकर ब्लॉकर, एनक्रिप्शन "
+"एनफोर्सर और बहुत कुछ शामिल है। %1$siOS और Android%2$s पर उपलब्ध।"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15071,8 +15033,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, "
-"ब्राउज़र फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
+"पासफ्रेज़ को दोबारा प्राप्त नहीं किया जा सकता है, क्योंकि हम आपके आईपी पते, ब्राउज़र "
+"फ़िंगरप्रिंट या किसी अन्य जानकारी को फ़ाइल के साथ नहीं जोड़ते हैं।"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15228,8 +15190,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है "
-"जो उसे बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
+"Personal Information Removal उन डेटा ब्रोकर साइट्स पर आपकी जानकारी ढूंढता है जो उसे "
+"बेच रही हैं. फिर हम इसे आपके लिए हटवाने का काम करते हैं."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15300,10 +15262,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो AI की मदद से दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर "
-"जवाब अक्सर मिलते हैं। उन्हें बंद करने और Assist बटन छिपाने के लिए %1$sखोज "
-"सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो AI की मदद से "
+"दिए गए जवाब अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। उन्हें बंद "
+"करने और Assist बटन छिपाने के लिए %1$sखोज सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15312,10 +15273,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। "
-"इस फ़ीचर के काम करने के तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"के दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इस फ़ीचर के काम करने के "
+"तरीके को एडजस्ट करने के लिए या इसे बंद करने के लिए, %1$sDuckAssist सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15325,10 +15285,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, "
-"तो DuckAssist अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते "
-"हैं। इसे बंद करने और Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist "
-"Settings%2$s पर जाएं।"
+"जब आप अपनी खोज क्वेरी को एक सवाल के रूप में और एक पूरे वाक्य में डालते हैं, तो DuckAssist "
+"अपने-आप दिखने की संभावना बढ़ जाती है और बेहतर जवाब अक्सर मिलते हैं। इसे बंद करने और "
+"Assist यानी सहायता बटन छिपाने के लिए %1$sDuckAssist Settings%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15361,8 +15320,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, "
-"Mistral, वगैरह।"
+"चैट करने के लिए कोई लोकप्रिय AI चुनें, जैसे GPT-5 mini, Claude Haiku 4.5, Mistral, "
+"वगैरह।"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15381,8 +15340,7 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा "
-"उपलब्ध नहीं होगी।"
+"अपने गंतव्य तक जाने के लिए एक सेवा चुनें। बाहरी ऐप्स में DuckDuckGo सुरक्षा उपलब्ध नहीं होगी।"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15395,8 +15353,8 @@ msgstr "कोई विशिष्ट समस्या चुनें"
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए "
-"निर्देशों का पालन करें।"
+"अपना विज्ञापन ब्लॉकर चुनें और DuckDuckGo पर विज्ञापनों की अनुमति देने के लिए निर्देशों का "
+"पालन करें।"
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15485,8 +15443,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह प्रॉम्प्ट किसी मनुष्य द्वारा बनाया गया था, कृपया निम्नलिखित "
+"चुनौती को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15495,8 +15453,8 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया "
-"निम्नलिखित चुनौती को पूरा करें।"
+"यह पुष्टि करने के लिए कि यह खोज किसी मनुष्य द्वारा की गई थी, कृपया निम्नलिखित चुनौती "
+"को पूरा करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15529,8 +15487,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट "
-"सेशन डिलीट हो जाएगा।"
+"कृपया ध्यान दें: किसी भी मॉडल के जरिए नई चैट शुरू करने से आपका मौजूदा चैट सेशन डिलीट हो "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15539,9 +15497,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या "
-"गैरकानूनी है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों हानिकारक या गैरकानूनी है।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15550,9 +15507,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी "
-"निजी जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या "
-"नुकसानदेह है।"
+"अपना सवाल और जो गलत या आपत्तिजनक जवाब मिला है, यहां पेस्ट करें (अपनी कोई भी निजी "
+"जानकारी शामिल न करें), साथ में बताएं कि यह सामग्री क्यों गैरकानूनी या नुकसानदेह है।"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15705,8 +15661,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या "
-"सुझावों को प्रभावित नहीं करेगा।"
+"साथ ही, Duck Player में आप जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
+"प्रभावित नहीं करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15765,12 +15721,17 @@ msgid "Poor formatting"
 msgstr "खराब फॉर्मेटिंग"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा "
-"अनाम की गईं।"
+"लोकप्रिय AI मॉडल उपलब्ध हैं। किसी अकाउंट की ज़रूरत नहीं है। चैट हमारे द्वारा अनाम की गईं।"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16280,8 +16241,8 @@ msgstr "मुझे प्रॉम्प्ट करें"
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
 msgstr ""
-"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के "
-"लिए प्रेरित करें।"
+"नज़दीकी परिणाम प्राप्त करने के लिए मुझे अपने अनुमानित स्थान का उपयोग करने के लिए प्रेरित "
+"करें।"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16300,8 +16261,7 @@ msgstr "खोजते और ब्राउज़ करते समय अ�
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
 msgstr ""
-"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को "
-"सुरक्षित रखें।"
+"सर्च करते समय, ब्राउज़ करते समय, और AI का इस्तेमाल करते हुए अपने डेटा को सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16332,8 +16292,7 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का "
-"टेक्स्ट यहां डालें।]"
+"नीचे दिए गए टेक्स्ट को और संक्षिप्त बनाने के लिए कुछ सुझाव दें। [अपना खुद का टेक्स्ट यहां डालें।]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16563,16 +16522,16 @@ msgstr "रीज़निंग जटिल सवालों के बे�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक "
-"पहुंच जाता है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन यह 2-5 गुना जल्दी उपयोग सीमा तक पहुंच जाता "
+"है। %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
 msgstr ""
-"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 "
-"गुना तेज़ी से होता है। %1$s"
+"रीज़निंग का तरीका ज़्यादा विस्तृत है, लेकिन इसमें लिमिट्स का इस्तेमाल 2-5 गुना तेज़ी से होता "
+"है। %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16622,8 +16581,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16632,8 +16591,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर "
-"स्थानीय स्तर पर स्टोर की जाती हैं।"
+"हालिया चैट DuckDuckGo सर्वर या दूसरे रिमोट सर्वर के बजाय आपके डिवाइस पर स्थानीय स्तर "
+"पर स्टोर की जाती हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16643,10 +16602,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स "
-"भेजे जाने के बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर "
-"पर स्टोर रहते हैं, ताकि यदि आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया "
-"जा सके।"
+"हाल की चैट्स आपके डिवाइस पर लोकली स्टोर होती हैं। नए प्रॉम्प्ट और रिस्पॉन्स भेजे जाने के "
+"बाद एन्क्रिप्ट किए जाते हैं और अस्थायी रूप से DuckDuckGo सर्वर पर स्टोर रहते हैं, ताकि यदि "
+"आपका इंटरनेट कनेक्शन खो जाए तो चैट को रिकवर किया जा सके।"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16788,8 +16746,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट "
-"के आकार को घटाता है"
+"परिणामों के अंदर और आसपास के अतिरिक्त स्पेस हटाता है और परिणाम टाइटल टेक्स्ट के आकार को "
+"घटाता है"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16930,8 +16888,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने "
-"ब्राउज़र के &quot;रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
+"DuckDuckGo को फिर से लोड करें, इसके लिए निर्देशों का पालन करें या अपने ब्राउज़र के &quot;"
+"रीफ्रेश&quot; या &quot;रीलोड&quot; बटन पर क्लिक करें।"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17039,8 +16997,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप "
-"से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
+"\"पूछें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई देते "
+"हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17048,9 +17006,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर "
-"स्वचालित रूप से दिखाई देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित "
-"होते हैं।"
+"\"जनरेट करें\" बटन को हटा देता है जिससे प्रासंगिक खोजों के लिए उत्तर स्वचालित रूप से दिखाई "
+"देते हैं। कैश्ड उत्तर हमेशा स्वचालित रूप से प्रदर्शित होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17114,9 +17071,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए "
-"DuckDuckGo को भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए "
-"आपकी अनाम प्रतिक्रिया भी %1$s के साथ शेयर की जाती है।"
+"रिपोर्ट गुमनाम हैं और हमारी खोज सेवा को बेहतर बनाने में मदद करने के लिए DuckDuckGo को "
+"भेजी जाती हैं। उनकी सेवाओं को बेहतर बनाने में सहायता के लिए आपकी अनाम प्रतिक्रिया भी "
+"%1$s के साथ शेयर की जाती है।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17124,8 +17081,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई "
-"भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्टें गुमनाम रहती हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17134,9 +17091,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें "
-"आपने इस पेज लोड के दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने "
-"फ़ीडबैक में कोई भी व्यक्तिगत या पहचान योग्य जानकारी शामिल न करें।"
+"DuckDuckGo को भेजी गई रिपोर्ट में वे सभी टेक्स्ट शामिल होते हैं, जिन्हें आपने इस पेज लोड के "
+"दौरान अनुवाद के लिए कहा था, और वे गुमनाम हैं। कृपया अपने फ़ीडबैक में कोई भी व्यक्तिगत या "
+"पहचान योग्य जानकारी शामिल न करें।"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17228,10 +17185,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। AI की मदद से दिए गए जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"हैं।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। AI की मदद से दिए गए "
+"जवाब हमारी %1$sसेवा की शर्तों%2$s के अधीन हैं।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17240,9 +17196,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। DuckAssist हमारी %1$sसेवा की शर्तों%2$s के अधीन है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। DuckAssist हमारी "
+"%1$sसेवा की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17252,11 +17208,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें "
-"चिकित्सा, कानूनी, वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना "
-"जाना चाहिए। ये वेब सामग्री के आधार पर तैयार किए जाते हैं और इनमें कुछ "
-"गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा की शर्तों%2$s के अधीन "
-"है।"
+"सारे रिस्पॉन्स या जवाब केवल शिक्षात्मक उद्देश्यों के लिए हैं और इन्हें चिकित्सा, कानूनी, "
+"वित्तीय, निवेश या अन्य पेशेवर सलाह के रूप में नहीं माना जाना चाहिए। ये वेब सामग्री के आधार "
+"पर तैयार किए जाते हैं और इनमें कुछ गलतियां भी हो सकती हैं। Search Assist हमारी %1$sसेवा "
+"की शर्तों%2$s के अधीन है।"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17333,8 +17288,7 @@ msgstr "परिणामों में ब्लॉक की गई सा�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में "
-"मैनेज कर सकते हैं।"
+"परिणामों में ब्लॉक की गई साइटें नहीं दिखाई जातीं, आप उन्हें अपने %1$s में मैनेज कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17683,8 +17637,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और "
-"एन्क्रिप्टेड स्टोरेज के साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
+"अपने डिवाइस पर अपनी सबसे नई 30 चैट तक स्थानीय रूप से सेव करें, और एन्क्रिप्टेड स्टोरेज के "
+"साथ इससे अधिक चैट सहेजने का विकल्प भी उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17697,9 +17651,7 @@ msgstr "अपनी सबसे हाल की 30 चैट तक को �
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच "
-"सुरक्षित रखें।"
+msgstr "एंड-टू-एंड एनक्रिप्शन के साथ अपने Duck.ai चैट्स को अपने डिवाइसों के बीच सुरक्षित रखें।"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17859,8 +17811,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या "
-"%5$sनया जोड़ें%6$s) क्लिक करें"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s (या %5$sनया जोड़ें%6$s) "
+"क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17869,8 +17821,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर "
-"क्लिक करें (या %5$sनया जोड़ें%6$s)।"
+"नीचे स्क्रॉल करें और %1$sपता बार में खोजें%2$s ढूंढें। %3$sबदलें%4$s पर क्लिक करें (या %5$sनया "
+"जोड़ें%6$s)।"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17889,8 +17841,8 @@ msgstr "नीचे स्क्रॉल करें और सूची म�
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह "
-"आपकी लोकेशन यानी स्थान का इस्तेमाल कर सके।"
+"नीचे स्क्रॉल करते हुए %1$sDuckDuckGo%2$s पर जाएं और इसे अनुमति दें कि यह आपकी लोकेशन "
+"यानी स्थान का इस्तेमाल कर सके।"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -17958,12 +17910,11 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा "
-"करने के लिए यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक "
-"संक्षिप्त जवाब तैयार करता है। आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी "
-"नहीं, केवल मांग पर (जब आप 'Assist' पर क्लिक करें), कभी-कभी (जब यह बहुत "
-"प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू हो)। फिलहाल, Search Assist "
-"केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
+"Search Assist आपके खोज प्रश्नों के जवाब गुमनाम तरीके से तैयार करता है। ऐसा करने के लिए "
+"यह वेब पर संबंधित सामग्री खोजता है और फिर AI की मदद से एक संक्षिप्त जवाब तैयार करता है। "
+"आप चुन सकते हैं कि यह कितनी बार दिखाई दे: कभी नहीं, केवल मांग पर (जब आप 'Assist' पर "
+"क्लिक करें), कभी-कभी (जब यह बहुत प्रासंगिक हो), या अक्सर (जब कई तरह की खोज पर लागू "
+"हो)। फिलहाल, Search Assist केवल कुछ अंग्रेज़ी भाषी क्षेत्रों में ही उपलब्ध है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17971,8 +17922,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय "
-"जानकारी नहीं मिली। कुछ और सर्च करके देखें।"
+"Search Assist को इस प्रश्न का उत्तर जनरेट करने के लिए पर्याप्त विश्वसनीय जानकारी नहीं "
+"मिली। कुछ और सर्च करके देखें।"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17981,10 +17932,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब "
-"तैयार करता है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि "
-"संबंधित सामग्री मिल सके, और फिर मिली जानकारी के आधार पर AI की मदद से एक "
-"संक्षिप्त उत्तर तैयार करता है।"
+"Search Assist एक वैकल्पिक फ़ीचर है जो खोज प्रश्नों के लिए गुमनाम रूप से जवाब तैयार करता "
+"है। ऐसा करने के लिए, यह %1$sवेब पर खोजबीन करता है%2$s ताकि संबंधित सामग्री मिल सके, "
+"और फिर मिली जानकारी के आधार पर AI की मदद से एक संक्षिप्त उत्तर तैयार करता है।"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18105,8 +18055,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे "
-"Wikipedia पर “ducks” को खोजा जाएगा।"
+"%1$s शॉर्टकट के ज़रिए अन्य साइटों को खोजें: \"!w ducks” खोजने पर सीधे Wikipedia पर "
+"“ducks” को खोजा जाएगा।"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18125,8 +18075,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र "
-"में गोपनीय वेब खोज जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
+"हमारे ऐप या एक्सटेंशन के साथ गुप्त रूप से खोज करें, अपने पसंदीदा ब्राउज़र में गोपनीय वेब खोज "
+"जोड़ें या सीधा %1$sduckduckgo.com%2$s पर खोजें।"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18134,8 +18084,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट "
-"अनुरोध का उपयोग होगा)"
+"खोज के प्रश्न यूआरएल में शामिल हैं (अगर ऑफ़ किया गया तब खोज द्वारा पोस्ट अनुरोध का उपयोग "
+"होगा)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18147,11 +18097,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल "
-"स्टोरेज में रखा जाता है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके "
-"अपनी सेटिंग को क्लाउड में किसी रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते "
-"हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान योग्य जानकारी स्टोर नहीं की "
-"जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं जाएगा।"
+"खोज सेटिंग को आपके ब्राउज़र में गैर-व्यक्तिगत ब्राउज़र की कुकीज़ और लोकल स्टोरेज में रखा जाता "
+"है. हालांकि, आप चाहें तो Cloud Save का इस्तेमाल करके अपनी सेटिंग को क्लाउड में किसी "
+"रिमोट सर्वर पर गुमनाम रूप से भी सेव कर सकते हैं। क्लाउड में कोई भी व्यक्तिगत रूप से पहचान "
+"योग्य जानकारी स्टोर नहीं की जाएगी, और आपका पासफ्रेज़ कभी भी आपके ब्राउज़र से बाहर नहीं "
+"जाएगा।"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18254,8 +18204,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18264,8 +18214,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी डिवाइस से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18274,8 +18224,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित "
-"रूप से स्टोर करें, और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके ढेर सारी चैट्स सुरक्षित रूप से स्टोर करें, "
+"और उन्हें अपने सभी सिंक किए गए डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18284,8 +18234,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप "
-"से स्टोर करें, और उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
+"हमारे सर्वर पर एंड-टू-एंड एनक्रिप्शन का उपयोग करके अपनी चैट्स सुरक्षित रूप से स्टोर करें, और "
+"उन्हें अपने सभी डिवाइसों से एक्सेस करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18300,8 +18250,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर "
-"किया गया। आपके अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
+"एंड-टू-एंड एनक्रिप्शन के साथ DuckDuckGo के सर्वर पर सुरक्षित रूप से स्टोर किया गया। आपके "
+"अलावा कोई भी आपका डेटा नहीं देख सकता, हम भी नहीं।"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18451,9 +18401,7 @@ msgstr "Safari मेनू से %1$s'इस वेबसाइट के ल�
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज "
-"करें"
+msgstr "%1$sकस्टम%2$s चुनें और इनपुट फ़ील्ड में %3$shttps://duckduckgo.com%4$s दर्ज करें"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18463,17 +18411,13 @@ msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट �
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक "
-"करें।"
+msgstr "%1$sDuckDuckGo%2$s चुनें और %3$sडिफ़ॉल्ट के रूप में सेट करें%4$s पर क्लिक करें।"
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18522,8 +18466,7 @@ msgstr "ड्रॉपडाउन मेनू से %1$sएड-ऑन प्
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sमेनू > सेटिंग%4$s (Windows पर) चुनें"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18531,8 +18474,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) "
-"चुनें"
+"%1$sOpera > प्राथमिकताएं%2$s (Mac पर) या %3$sOpera > विकल्प%4$s (Windows पर) चुनें"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18597,8 +18539,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी "
-"पसंद का कोई एक विकल्प) चुनें"
+"%1$sइस वेबपेज को अपना एकमात्र होमपेज बनाएं%2$s (या अन्य विकल्पों में से अपनी पसंद का कोई "
+"एक विकल्प) चुनें"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18720,8 +18662,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब "
-"देना है। ये निर्देश आगे चलकर आपके सभी वार्तालापों पर लागू होंगे।"
+"यह आपके संदेशों के साथ AI मॉडलों को निर्देश भेजता है कि उन्हें कैसे जवाब देना है। ये निर्देश आगे "
+"चलकर आपके सभी वार्तालापों पर लागू होंगे।"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18844,8 +18786,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी "
-"डिवाइसों पर सिंक रख सकें।"
+"चैट हिस्ट्री चालू करने के बाद Sync & Backup सेट करें ताकि अपनी चैट को सभी डिवाइसों पर "
+"सिंक रख सकें।"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18952,9 +18894,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की "
-"सटीकता बेहतर हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं "
-"बताता है।"
+"AI मॉडलों के साथ शहर वाली आसपास की लोकेशन शेयर करें ताकि उनके जवाबों की सटीकता बेहतर "
+"हो। Duck.ai कभी भी आपकी सटीक लोकेशन हमें या AI मॉडल को नहीं बताता है।"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19056,8 +18997,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और "
-"हानिकारक रिपोर्ट के लिए आवश्यक है)"
+"DuckDuckGo के साथ अपना प्रॉम्प्ट और चैट रिस्पॉन्स शेयर करें (गैरकानूनी और हानिकारक "
+"रिपोर्ट के लिए आवश्यक है)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19106,8 +19047,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप "
-"करने में सरल और किसी भी समय चालू या बंद करने में आसान।"
+"हमारे नो-लॉग, तेज़ VPN के साथ अपनी ऑनलाइन गतिविधि को सुरक्षित रखें। सेटअप करने में सरल "
+"और किसी भी समय चालू या बंद करने में आसान।"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19234,8 +19175,7 @@ msgstr "DuckAssist <sup>बीटा</sup> दिखाएं"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर "
-"सकते हैं।)"
+"DuckAssist को अक्सर दिखाएं। (आप चाहें तो इसे पूरी तरह से %1$sबंद%2$s भी कर सकते हैं।)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19473,9 +19413,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की "
-"गोपनीयता प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"गोपनीय रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज की गोपनीयता "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19483,9 +19423,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी "
-"खोज हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे "
-"खोज सुरक्षा प्रभावित नहीं होती है।"
+"यह याद दिलाने के लिए एक रिमाइंडर दिखाता है कि DuckDuckGo पर हरेक सर्च यानी खोज "
+"हमेशा सुरक्षित रहती है। इसे बंद करने से रिमाइंडर छिप जाता है, मगर इससे खोज सुरक्षा "
+"प्रभावित नहीं होती है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19523,8 +19463,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर "
-"दिखाता है"
+"DuckDuckGo गोपनीयता न्यूज़लेटर के लिए साइन अप करने के लिए सामयिक रिमांडर दिखाता है"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19826,9 +19765,7 @@ msgstr "कभी-कभी"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों "
-"में बताएं।"
+msgstr "माफ़ करें, मैं मदद करने में असमर्थ हूं। कृपया अपनी इमेज का आइडिया अलग शब्दों में बताएं।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19867,8 +19804,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी "
-"इमेज या फ़ॉर्मेट आज़माएं।"
+"माफ़ करें, अपलोड की गई इमेज को प्रोसेस नहीं किया जा सका। कृपया कोई दूसरी इमेज या फ़ॉर्मेट "
+"आज़माएं।"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19877,8 +19814,7 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन "
-"किया गया है।"
+"माफ़ करें, यह कोड गलत है। कृपया सुनिश्चित करें कि सही कोड को दर्ज या स्कैन किया गया है।"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19893,16 +19829,14 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने "
-"के लिए, %1$sयहाँ क्लिक करें%2$s।"
+"क्षमा करें, इन परिणामों को प्रदर्शित करने में त्रुटि हुई। फिर से प्रयास करने के लिए, %1$sयहाँ "
+"क्लिक करें%2$s।"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास "
-"करें।"
+msgstr "क्षमा करें, हम आपका फ़ीडबैक सबमिट नहीं कर सके। कृपया बाद में फिर से प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19957,8 +19891,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा "
-"हिस्सा चुनकर फिर से प्रयास करें।"
+"सोर्स टेक्स्ट बहुत लंबा है, इसे संक्षेप में बताना संभव नहीं है। थोड़ा छोटा हिस्सा चुनकर फिर से "
+"प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20308,8 +20242,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक "
-"इमेज बनाने के लिए बाद में वापस आएं।"
+"Duck.ai में ज़्यादा लिमिट पाने के लिए DuckDuckGo को सब्सक्राइब करें, या अधिक इमेज बनाने "
+"के लिए बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20378,8 +20312,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' "
-"वाले कार्ड पर लिखने के लिए वाक्य सुझाएं?"
+"सर्जरी करवाकर ठीक हो रहे किसी व्यक्ति को देने लायक 'स्वास्थ्य शुभकामनाएं' वाले कार्ड पर "
+"लिखने के लिए वाक्य सुझाएं?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20716,8 +20650,8 @@ msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
 msgstr ""
-"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर "
-"विज़िबिलिटी ज़ीरो होगी"
+"स्विच करने पर आपकी चैट एक ऐसे मॉडल को भेज दी जाएगी, जिसमें प्रोवाइडर विज़िबिलिटी ज़ीरो "
+"होगी"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20772,8 +20706,7 @@ msgstr "Sync & Backup चालू है!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा "
-"सकता।"
+"18 महीने तक निष्क्रिय रहने के बाद, Sync & Backup डेटा को रिकवर नहीं किया जा सकता।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20782,8 +20715,7 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup आपकी ज़्यादा चैट सेव करता है और उन्हें आपके सभी डिवाइसों पर "
-"सिंक करता है।"
+"Sync & Backup आपकी ज़्यादा चैट सेव करता है और उन्हें आपके सभी डिवाइसों पर सिंक करता है।"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20832,26 +20764,25 @@ msgid ""
 msgstr ""
 "सिंक रिकवरी कोड\n"
 "\n"
-" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai "
-"चैट को सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक "
-"किया हुआ डेटा रिकवर कर सकते हैं।\n"
+" रिकवरी कोड की मदद से आप कई डिवाइस पर अपने पासवर्ड, ऑटोफ़िल डेटा और Duck.ai चैट को "
+"सिंक कर सकते हैं, और अगर किसी डिवाइस का एक्सेस खो जाए, तो अपना सिंक किया हुआ डेटा "
+"रिकवर कर सकते हैं।\n"
 "\n"
 "इस जानकारी को सुरक्षित और गोपनीय रखें।\n"
-"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस "
-"कर सकता है।\n"
+"जिस किसी के पास भी इस कोड का एक्सेस होगा, वह आपके सिंक किए गए डेटा को एक्सेस कर सकता "
+"है।\n"
 "\n"
 "%1$s\n"
 "\n"
 "यह कोड कैसे काम करता है?\n"
 "1. अपने ब्राउज़र में Duck.ai पर जाएं और Duck.ai सेटिंग खोलें।\n"
-"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" "
-"चुनें\n"
-"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड "
-"यहां पेस्ट करें\" कहा गया है\n"
+"2. \"Sync & Backup चालू करें\" चुनें, फिर \"सिंक किया गया डेटा रिकवर करें\" चुनें\n"
+"3. ऊपर दिए गए रिकवरी कोड को कॉपी करें और उसे वहां पेस्ट करें जहां \"अपना कोड यहां पेस्ट "
+"करें\" कहा गया है\n"
 "\n"
-"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक "
-"DuckDuckGo ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट "
-"कर दिया जाएगा और उसे रीस्टोर नहीं किया जा सकेगा।"
+"अगर आप Sync & Backup चालू होने के बाद भी 18 महीने से ज़्यादा समय तक DuckDuckGo "
+"ब्राउज़र का इस्तेमाल नहीं करते हैं, तो आपका डेटा सर्वर से डिलीट कर दिया जाएगा और उसे "
+"रीस्टोर नहीं किया जा सकेगा।"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20990,8 +20921,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे "
-"हमारे मुफ़्त ऐप में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी हों, तेज़ी से एक्सेस के लिए इसे हमारे मुफ़्त ऐप "
+"में पाएं।"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21000,8 +20931,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से "
-"एक्सेस के लिए इसे हमारे मुफ़्त ब्राउज़र में पाएं।"
+"Duck.ai को हर जगह अपने साथ रखें। आप कहीं भी ब्राउज़ कर रहे हों, तेज़ी से एक्सेस के लिए इसे "
+"हमारे मुफ़्त ब्राउज़र में पाएं।"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21245,9 +21176,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई "
-"जानकारी को किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम "
-"मामलों में इसमें पासवर्ड, या भुगतान विवरण शामिल होते हैं।"
+"इसका मतलब हैं कि आपके डिवाइस और इस लिंक के पीछे के वेबपेज के बीच भेजी गई जानकारी को "
+"किसी तीसरे पक्ष द्वारा इंटरसेप्ट किए जाने का जोखिम बढ़ रहा है। कम मामलों में इसमें पासवर्ड, "
+"या भुगतान विवरण शामिल होते हैं।"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21256,8 +21187,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी "
-"सेटिंग्स में कोई भी बदलाव करने की अनुमति देता है।"
+"Cloud Save बुकमार्कलेट आपको क्लाउड में ऑटोमैटिकली सेव करने के लिए अपनी सेटिंग्स में कोई भी "
+"बदलाव करने की अनुमति देता है।"
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21266,8 +21197,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Duck.ai टॉगल प्राइवेट सर्च और AI चैट के बीच तुरंत स्विच करने की सुविधा देता "
-"है, जिसे DuckDuckGo द्वारा अनाम बनाया गया है।"
+"Duck.ai टॉगल प्राइवेट सर्च और AI चैट के बीच तुरंत स्विच करने की सुविधा देता है, जिसे "
+"DuckDuckGo द्वारा अनाम बनाया गया है।"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21297,8 +21228,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और "
-"सिर्फ़ आप ही इसे एक्सेस कर सकते हैं।"
+"'एनक्रिप्शन की' केवल आपके ब्राउज़र के लोकल स्टोरेज में सेव रहती है, और सिर्फ़ आप ही इसे एक्सेस "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21378,8 +21309,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी "
-"ब्राउज़र सेटिंग जांचें और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
+"इस चैट को लोकल स्टोरेज में सेव करने के दौरान कोई गड़बड़ी हुई। कृपया अपनी ब्राउज़र सेटिंग जांचें "
+"और सुनिश्चित करें कि लोकल डेटा स्टोरेज चालू है।"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21394,8 +21325,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से "
-"पहले कुछ मिनट इंतज़ार करें।"
+"खोज परिणाम दिखाने में अभी भी गड़बड़ी हो रही है। कृपया दोबारा कोशिश करने से पहले कुछ "
+"मिनट इंतज़ार करें।"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21414,9 +21345,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर "
-"ब्लॉक करके, संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका "
-"डिफ़ॉल्ट खोज इंजन बनाकर गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
+"इन ब्राउज़र अनुमतियों को आपके द्वारा देखी जाने वाली वेबसाइटों पर छिपे ट्रैकर ब्लॉक करके, "
+"संभव होने पर कनेक्शन एन्क्रिप्ट करके और DuckDuckGo को आपका डिफ़ॉल्ट खोज इंजन बनाकर "
+"गोपनीयता सुरक्षा जोड़ने के लिए उपयोग किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21454,8 +21385,7 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की "
-"कोशिश करें।"
+"यह AI मॉडल अब उपलब्ध नहीं है। किसी दूसरे मॉडल के साथ नई चैट शुरू करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21464,8 +21394,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए "
-"वर्ज़न के साथ नई चैट शुरू करें।"
+"AI मॉडल के इस वर्ज़न के लिए अब सपोर्ट उपलब्ध नहीं है। इस मॉडल के सबसे नए वर्ज़न के साथ नई "
+"चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21504,9 +21434,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की "
-"गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
-"लिए %4$s देखें)।"
+"यह बातचीत Duck.ai (%1$s) के जरिए %2$s के %3$s मॉडल का इस्तेमाल करके जनरेट की गई। "
+"AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21516,9 +21445,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई "
-"चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए "
-"%2$s देखें)."
+"यह बातचीत Duck.ai (%1$s) में कई चैट मॉडल इस्तेमाल करके तैयार की गई थी. एआई चैट में गलत "
+"या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के लिए %2$s देखें)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21527,8 +21455,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक "
-"जानकारी भी प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
+"यह बातचीत Duck.ai वॉयस चैट (%1$s) से जनरेट हुई थी। AI गलत या आपत्तिजनक जानकारी भी "
+"प्रदान कर सकता है। (ज़्यादा जानकारी के लिए %2$s देखें।)"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21538,9 +21466,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के "
-"जरिए जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है "
-"(ज़्यादा जानकारी के लिए %4$s देखें)।"
+"यह बातचीत %2$s के %3$s मॉडल का इस्तेमाल करके DuckDuckGo AI Chat (%1$s) के जरिए "
+"जनरेट की गई। AI चैट में गलत या आपत्तिजनक जानकारी दिखाई दे सकती है (ज़्यादा जानकारी के "
+"लिए %4$s देखें)।"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21557,8 +21485,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. "
-"पिछली %1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
+"यह डिवाइस अब दूसरे डिवाइस पर आपके सिंक किए गए डेटा को ऐक्सेस नहीं कर पाएगा. पिछली "
+"%1$s चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21630,8 +21558,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21639,8 +21566,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच "
-"करें।"
+"इस इमेज प्रकार को सपोर्ट हासिल नहीं है, कृपया कोई JPG, PNG, WebP या GIF अटैच करें।"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21668,8 +21594,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स "
-"में सबसे ऊपर रखने के लिए 'पिन करें' चुनें!"
+"यह केवल एक सैंपल चैट है। इसका मेन्यू (तीन डॉट्स) खोलें, फिर इसे अपनी चैट्स में सबसे ऊपर रखने के "
+"लिए 'पिन करें' चुनें!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21678,8 +21604,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button "
-"का इस्तेमाल करें!"
+"यह केवल एक सैंपल चैट है। इसे डिलीट करने के लिए साइड मेन्यू में Fire Button का इस्तेमाल करें!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21700,8 +21625,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य "
-"मॉडल प्रदाता 'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा डेटा 30 दिनों के अंदर डिलीट कर देता है। अन्य मॉडल प्रदाता "
+"'ज़ीरो डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21710,8 +21635,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल "
-"प्रदाता 'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
+"यह मॉडल प्रदाता इस चैट से जुड़ा कोई भी डेटा स्टोर नहीं करता है। अन्य मॉडल प्रदाता "
+"'सीमित डेटा रिटेंशन' मॉडल का पालन करते हैं।"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21748,8 +21673,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के "
-"साथ सेव करता है, जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
+"यह आपकी चैट्स को DuckDuckGo के सुरक्षित सर्वर पर एंड-टू-एंड एनक्रिप्शन के साथ सेव करता है, "
+"जिसे बाद में किसी भी ब्राउज़र से एक्सेस किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21758,9 +21683,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21770,10 +21694,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप "
-"duckduckgo.com ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख "
-"सकते हैं। हालांकि, %1$s पर हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने "
-"वाले जवाब कभी नहीं दिखाता।"
+"यह सेटिंग आपके ब्राउज़र में स्टोर रहती है, जिसका मतलब है कि अगर आप duckduckgo.com "
+"ब्राउज़र डेटा मिटाते हैं, तो आपको AI से मिले जवाब फिर से दिख सकते हैं। हालांकि, %1$s पर "
+"हमारे पास ऐसा स्टार्ट पेज भी है जो AI से मिलने वाले जवाब कभी नहीं दिखाता।"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21814,9 +21737,7 @@ msgstr "यह वीडियो अब तक यहां देखे जा
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता "
-"है।"
+msgstr "यह वेबपेज एक सुरक्षित, एन्क्रिप्ट किए गए, कनेक्शन (HTTPS) का उपयोग नहीं करता है।"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21826,9 +21747,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup "
-"डिस्कनेक्ट हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी "
-"चैट एक्सेस कर पाएंगे।"
+"इससे इस ब्राउज़र से आपकी सभी Duck.ai चैट डिलीट हो जाएंगी, और Sync & Backup डिस्कनेक्ट "
+"हो जाएगा। आप Sync & Backup से जुड़े दूसरे ब्राउज़र में भी अपनी चैट एक्सेस कर पाएंगे।"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21837,16 +21757,15 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे "
-"पहले जैसा नहीं किया जा सकता है।"
+"यह आपकी सभी हालिया चैट्स को डिलीट कर देगा, सिवाय उनके जो पिन की गई हैं। इसे पहले जैसा "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
 msgstr ""
-"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा "
-"सकता है।"
+"यह आपके द्वारा चुनी गई इमेज को डिलीट कर देगा। इसे पहले जैसा नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -21969,7 +21888,8 @@ msgstr "जारी रखने के लिए, आपको Duck.ai की 
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
+msgstr ""
+"जारी रखने के लिए, आपको DuckDuckGo AI Chat की %1$s और %2$s से सहमत होना होगा"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -21978,8 +21898,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप "
-"प्रिंट करना चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
+"निर्देश प्रिंट करने के लिए:%1$sमैप पर वापस जाएं।%2$sउस रूट को चुनें जिसे आप प्रिंट करना "
+"चाहते हैं।%3$sप्रिंट आइकन पर क्लिक करें।%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21989,10 +21909,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत "
-"होगी जिसे आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर "
-"PDF के रूप में सेव किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync "
-"सेटअप करने के लिए किया था।"
+"अपने सिंक किए गए डेटा को रीस्टोर करने के लिए, आपको उस रिकवरी कोड की ज़रूरत होगी जिसे "
+"आपने पहली बार Sync सेटअप करते समय सेव किया था। यह कोड उस डिवाइस पर PDF के रूप में सेव "
+"किया गया हो सकता है, जिसका इस्तेमाल आपने मूल रूप से Sync सेटअप करने के लिए किया था।"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22001,8 +21920,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo "
-"ब्राउज़र को नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
+"अपनी चैट हिस्ट्री को Duck.ai पर ट्रांसफ़र करने के लिए, कृपया अपने DuckDuckGo ब्राउज़र को "
+"नवीनतम वर्ज़न में अपडेट करें और दोबारा प्रयास करें।"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22010,8 +21929,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को "
-"माइक्रोफ़ोन का एक्सेस दें।"
+"डिक्टेशन का इस्तेमाल करने के लिए, अपने सिस्टम सेटिंग में जाकर ब्राउज़र को माइक्रोफ़ोन का "
+"एक्सेस दें।"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -22039,9 +21958,7 @@ msgstr "प्राइवेट AI चैट पर टॉगल करें �
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल "
-"करें।%3$s"
+msgstr "प्राइवेट AI चैट आज़माने के लिए टॉगल करें या %1$sइसे %2$s मेन्यू में डिसेबल करें।%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22102,6 +22019,12 @@ msgstr "इस स्रोत से बहुत अधिक परिणा�
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "बहुत धीमा है"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22215,8 +22138,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ "
-"करते रहें और देखें हम कितनों को ब्लॉक करते हैं।"
+"DuckDuckGo द्वारा ब्लॉक की गई ट्रैकिंग की कोशिशें यहां दिखाई देंगी। ब्राउज़ करते रहें और देखें "
+"हम कितनों को ब्लॉक करते हैं।"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22263,9 +22186,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में "
-"कैसे पहुंचूं?\""
+msgstr "फ्रेंच में इस अंग्रेजी वाक्य का अनुवाद करें: \"मैं निकटतम मूवी थियेटर में कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22274,8 +22195,7 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी "
-"सिनेमा हॉल तक कैसे पहुंचूं?\""
+"हिन्दी में दिए गए इस वाक्य का अंग्रेज़ी में अनुवाद करें: \"मैं नज़दीकी सिनेमा हॉल तक कैसे पहुंचूं?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22523,8 +22443,7 @@ msgstr "अलग कीवर्ड आज़माएं।"
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी "
-"अक्षम करें।"
+"DuckDuckGo पर अधिक परिणाम देखने के लिए अपने विज्ञापन ब्लॉकर को डिसेबल यानी अक्षम करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22544,6 +22463,12 @@ msgstr "हर मॉडल के साथ आजमा करके देख
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "कुछ कीवर्ड आज़माएं।"
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22716,8 +22641,7 @@ msgstr "हाल ही में जोड़े गए ओपन-सोर्
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source Llama 3.1 and Mixtral"
 msgstr ""
-"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को "
-"आजमाएं"
+"हाल ही में जोड़े गए ओपन-सोर्स यानी मुक्त स्रोत वाले Llama 3.1 और Mixtral को आजमाएं"
 
 # smartling.placeholder_format=C
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
@@ -22757,8 +22681,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22767,8 +22691,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के "
-"लिए %1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
+"क्या आप AI फ़ीचर्स को बंद करने की कोशिश कर रहे हैं? अपनी सेटिंग याद रखने के लिए "
+"%1$sDuckDuckGo No AI%2$s सर्च एक्सटेंशन पर स्विच करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22969,8 +22893,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और "
-"दिखाई देने वाले उत्तर के बीच थोड़ा समय लग सकता है।"
+"जनरेट होते ही DuckAssist के उत्तर टाइप हो जाते हैं। इसे बंद करने से खोज और दिखाई देने वाले "
+"उत्तर के बीच थोड़ा समय लग सकता है।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23100,8 +23024,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर "
-"%5$sसेट पेज%6$s पर क्लिक करें।"
+"%1$sस्टार्टअप पर%2$s के नीचे, %3$sकोई खास पेज खोलें%4$s पर क्लिक करें, फिर %5$sसेट "
+"पेज%6$s पर क्लिक करें।"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -23109,8 +23033,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: "
-"https://duckduckgo.com"
+"%1$sस्टार्टअप पर%2$s के अंतर्गत, %3$sहोमपेज%4$s चुनें और यह डालें: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23142,9 +23066,7 @@ msgstr "%1$sसर्च%2$s सेक्शन के नीचे, %3$sसर�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s "
-"चुनें"
+msgstr "स्टार्टअप चालू करें के अंतर्गत %1$sएक विशिष्ट पेज या कई पेज के सेट खोलें%2$s चुनें"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23228,8 +23150,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 "
-"गुना ज़्यादा उपयोग सीमाएं अनलॉक करें।"
+"Pro में अपग्रेड करके %1$s, बेहतर AI रीज़निंग, और Plus प्लान की तुलना में 2 गुना ज़्यादा "
+"उपयोग सीमाएं अनलॉक करें।"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23387,8 +23309,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने "
-"के लिए DuckDuckGo ब्राउज़र को अपडेट करें"
+"Duck.ai में अपने सब्सक्रिप्शन को एक्टिव करने और एडवांस्ड मॉडल्स एक्सेस करने के लिए "
+"DuckDuckGo ब्राउज़र को अपडेट करें"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23513,16 +23435,14 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज "
-"बनाने के लिए बाद में वापस आएं।"
+"Plus से 2 गुना ज़्यादा लिमिट पाने के लिए Pro में अपग्रेड करें, या अधिक इमेज बनाने के लिए "
+"बाद में वापस आएं।"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में "
-"अपग्रेड करें"
+msgstr "Plus की तुलना में 2 गुना ज़्यादा उपयोग सीमाएं अनलॉक करने के लिए Pro में अपग्रेड करें"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23618,9 +23538,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को "
-"हैकर्स, स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। "
-"मुफ़्त। किसी खाते की ज़रूरत नहीं है।"
+"ChatGPT, Claude और अन्य AI का उपयोग गोपनीय ढंग से निजी तौर पर करें। चैट्स को हैकर्स, "
+"स्कैमर्स और कंपनियों से सुरक्षित रखें। जानकारी गोपनीय बनाए रखें। मुफ़्त। किसी खाते की ज़रूरत "
+"नहीं है।"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23675,8 +23595,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस "
-"कोड का इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपना डेटा वापस पाने के लिए इस कोड का "
+"इस्तेमाल करें। इसे सुरक्षित संभालकर रखें।"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23684,8 +23604,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने "
-"के लिए इस कोड का इस्तेमाल करें।"
+"अगर आप अपने डिवाइस का एक्सेस खो देते हैं, तो अपनी सेव की गई चैट्स वापस पाने के लिए इस "
+"कोड का इस्तेमाल करें।"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23809,8 +23729,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai से शेयर की गई बातचीत देखें - DuckDuckGo की मुफ़्त, गोपनीय AI चैट। "
-"इसे अपनी चैट्स में सेव करें और गोपनीय रूप से बातचीत जारी रखें।"
+"Duck.ai से शेयर की गई बातचीत देखें - DuckDuckGo की मुफ़्त, गोपनीय AI चैट। इसे अपनी चैट्स "
+"में सेव करें और गोपनीय रूप से बातचीत जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23845,8 +23765,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को "
-"Microsoft के विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक को Microsoft के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किया जाता है"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23855,8 +23775,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक "
-"TripAdvisor के विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
+"विज्ञापन देखना DuckDuckGo द्वारा गोपनीयता संरक्षित है। विज्ञापन क्लिक TripAdvisor के "
+"विज्ञापन नेटवर्क द्वारा प्रबंधित किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23865,8 +23785,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"DuckDuckGo पर विज्ञापन देखने के दौरान आपकी प्राइवेसी सुरक्षित रहती है। "
-"विज्ञापन क्लिक Yelp के विज्ञापन नेटवर्क द्वारा मैनेज किए जाते हैं।"
+"DuckDuckGo पर विज्ञापन देखने के दौरान आपकी प्राइवेसी सुरक्षित रहती है। विज्ञापन क्लिक "
+"Yelp के विज्ञापन नेटवर्क द्वारा मैनेज किए जाते हैं।"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23878,8 +23798,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist "
-"सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sAssist सेटिंग%2$s "
+"पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23888,8 +23808,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए "
-"%1$sDuckAssist सेटिंग%2$s पर जाएं।"
+"इस फ़ीचर के काम करने का तरीका एडजस्ट करने या इसे बंद करने के लिए %1$sDuckAssist "
+"सेटिंग%2$s पर जाएं।"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23898,8 +23818,7 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का "
-"पालन करें।"
+"अपने टैबलेट या फ़ोन पर %1$sDuckDuckGo.com%2$s पर जाएं और दिए गए निर्देशों का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23915,8 +23834,8 @@ msgid ""
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
 "अपने दूसरे ब्राउज़र में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > %3$sSync & "
-"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के "
-"साथ सिंक करें%8$s को चुनें।"
+"Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस के साथ सिंक "
+"करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23926,9 +23845,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & "
-"Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक "
-"करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
+"अपने दूसरे ब्राउज़र में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। Sync & Backup के "
+"अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी "
+"रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23938,9 +23857,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai "
-"सेटिंग%2$s > %3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद "
-"%7$sकिसी दूसरे डिवाइस के साथ सिंक करें%8$s को चुनें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाकर %1$sDuck.ai सेटिंग%2$s > "
+"%3$sSync & Backup%4$s > %5$sमैनेज करें%6$s पर जाएं और उसके बाद %7$sकिसी दूसरे डिवाइस "
+"के साथ सिंक करें%8$s को चुनें।"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23950,10 +23869,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की "
-"सेटिंग खोलें। Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी "
-"दूसरे डिवाइस के साथ सिंक करें\" को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड "
-"स्कैन करें।"
+"अपने दूसरे ब्राउज़र या DuckDuckGo ऐप में Duck.ai पर जाएं और Duck.ai की सेटिंग खोलें। "
+"Sync & Backup के अंतर्गत \"चालू करें\" को चुनें और \"किसी दूसरे डिवाइस के साथ सिंक करें\" "
+"को चुनें। या अपनी रिकवरी PDF पर मौजूद QR कोड स्कैन करें।"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24006,8 +23924,8 @@ msgstr "वॉयस चैट समाप्त हो गई"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने "
-"के लिए नहीं किया जाता है।"
+"हम वॉयस चैट को गुमनाम रखते हैं और इसका उपयोग कभी भी AI मॉडल प्रशिक्षित करने के लिए "
+"नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24157,8 +24075,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को "
-"YouTube अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
+"YouTube पर वैयक्तिकृत विज्ञापनों को ब्लॉक करने और अपनी देखने की गतिविधि को YouTube "
+"अनुशंसाओं को प्रभावित करने से रोकने के लिए Duck प्लेयर में देखें।"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24178,10 +24096,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है "
-"क्योंकि हमें वहाँ से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र "
-"कंपनी है और इसका YouTube से कोई संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए "
-"जाते हैं।"
+"यहाँ वीडियो देखने का अर्थ है कि होस्ट की गई वेबसाइट आपको ट्रैक कर सकती है क्योंकि हमें वहाँ "
+"से कॉन्टेंट स्ट्रीम करना होगा। DuckDuckGo एक स्वतंत्र कंपनी है और इसका YouTube से कोई "
+"संबंध नहीं है, जहाँ अधिकांश वीडियो होस्ट किए जाते हैं।"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24194,8 +24111,8 @@ msgstr "हम गुमनाम करते हैं"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को "
-"गुमनाम रख सकते हैं।"
+"आपको अधिक सटीक नतीजे दिखाने के लिए हम%1$s आपके स्थान%2$s की जानकारी को गुमनाम रख "
+"सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24207,9 +24124,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम "
-"जांच कर सकें और समस्या का समाधान कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैरकानूनी जवाब की रिपोर्ट करने "
+"के लिए, कृपया इस बातचीत को DuckDuckGo के साथ शेयर करें ताकि हम जांच कर सकें और समस्या "
+"का समाधान कर सकें।"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24221,17 +24138,16 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की "
-"रिपोर्ट करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस "
-"मामले की जांच करके उसे ठीक कर सकें।"
+"सुधार तभी मुमकिन है, जब कमी नज़र आए। किसी हानिकारक या गैर-कानूनी जवाब की रिपोर्ट "
+"करने के लिए, कृपया अपना प्रॉम्प्ट और जवाब शेयर करें, ताकि हम उस मामले की जांच करके उसे "
+"ठीक कर सकें।"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल "
-"कर सकते हैं।"
+"आपको आस-पास के परिणाम दिखाने के लिए हम आपके अनाम%1$s स्थान%2$s का इस्‍तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24239,8 +24155,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक "
-"एन्क्रिप्टेड है।"
+"हम अटैच की गई फ़ाइलों को पढ़ नहीं पा रहे हैं, क्योंकि उनमें से कम से कम एक एन्क्रिप्टेड है।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24252,8 +24167,7 @@ msgstr "हम विज्ञापनों के साथ आपको फ�
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
 msgstr ""
-"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं "
-"करते हैं।"
+"हम यूज़रनेम या किसी भी व्यक्तिगत रूप से पहचान योग्य जानकारी को संग्रहित नहीं करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24270,8 +24184,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं "
-"करते हैं। हम आपको ट्रैक नहीं करते हैं। कभी भी।"
+"हम आपकी गोपनीय जानकारी स्टोर नहीं करते। हम विज्ञापनों के साथ आपको फ़ॉलो नहीं करते हैं। "
+"हम आपको ट्रैक नहीं करते हैं। कभी भी।"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24285,8 +24199,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां "
-"वापस क्यों आए हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह बताने में आपकी मदद ले सके कि आप आज यहां वापस क्यों आए "
+"हैं:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24295,8 +24209,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस "
-"वजह से हमें आज़माना चाहते हैं:"
+"हम आपको ट्रैक नहीं करते हैं, ताकि यह जानने में आपकी मदद ली जा सके कि आप किस वजह से हमें "
+"आज़माना चाहते हैं:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24336,9 +24250,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे "
-"विज्ञापनकर्ताओं को बेचने के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते "
-"हैं।"
+"हम आपकी खोज का इतिहास स्टोर नहीं करते हैं। इसलिए हमारे पास ऐसे विज्ञापनकर्ताओं को बेचने "
+"के लिए कुछ भी नहीं है जो आपको इंटरनेट पर ट्रैक करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24364,8 +24277,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. "
-"Plus, VPN और बहुत कुछ पाएँ."
+"हम डेटा ब्रोकर साइटों से आपकी व्यक्तिगत जानकारी ढूंढते हैं और हटाते हैं. Plus, VPN और बहुत "
+"कुछ पाएँ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24374,8 +24287,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके "
-"कि आपकी चैट्स का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
+"हमने सभी AI प्रोवाइडर्स के साथ एग्रीमेंट किए हैं ताकि यह पक्का किया जा सके कि आपकी चैट्स "
+"का इस्तेमाल AI को ट्रेन करने के लिए न हो।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24400,8 +24313,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, "
-"आपके डेटा का फायदा उठाकर नहीं।"
+"हम %1$sगोपनीयता का सम्मान करने वाले खोज विज्ञापनों%2$s से पैसा कमाते हैं, आपके डेटा का "
+"फायदा उठाकर नहीं।"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24410,8 +24323,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते "
-"हैं। आप अक्‍सर बाद में अपना विचार बदल सकते हैं।"
+"हम आपके करीब आपके अनाम स्थान का इस्‍तेमाल केवल बेहतर परिणाम देने के लिए करते हैं। आप अक्‍सर "
+"बाद में अपना विचार बदल सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24420,23 +24333,19 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते "
-"हैं, और इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
+"हम आपकी निजी जानकारी के लिए डेटा ब्रोकर साइटों को नियमित तौर से स्कैन करते हैं, और "
+"इस्तेमाल में आसान डैशबोर्ड पर अपनी प्रगति आपके साथ शेयर करते हैं."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते "
-"हैं।"
+msgstr "हम DuckDuckGo को सबके लिए बेहतर बनाने हेतु आपकी गुमनाम फीडबैक पर निर्भर करते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल "
-"हैं।"
+msgstr "हम सभी को आपका खोज का इतिहास प्राप्त करने से रोकते हैं, जिनमें हम भी शामिल हैं।"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24452,16 +24361,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा "
-"सके। %1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार "
-"तुरंत परिणामों में दिखाई ना दें।"
+"हम इस तरह की प्रतिक्रिया का उपयोग करते हैं ताकि DuckDuckGo को बेहतर बनाया जा सके। "
+"%1$s के विवेकानुसार सुझावों को शामिल किया जाएगा। हो सकता है कि सुधार तुरंत परिणामों में "
+"दिखाई ना दें।"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले "
-"ट्रैकर्स को ब्लॉक कर देंगे।"
+"जैसे ही आप ब्राउज़ करेंगे, हम आपके डेटा एकत्र करने का प्रयास करने वाले ट्रैकर्स को ब्लॉक कर देंगे।"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24470,8 +24378,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन "
-"करेंगे, और आपके बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
+"हम आपके ईमेल, नाम, पते और अन्य जानकारी के लिए डेटा ब्रोकर साइटों को स्कैन करेंगे, और आपके "
+"बारे में मिलने वाली किसी भी जानकारी को हटवाने का काम करेंगे."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24480,9 +24388,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। अगर आपको यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क "
-"करें।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। अगर आपको "
+"यह गड़बड़ी लगातार दिखाई दे रही है, तो कृपया %1$s से संपर्क करें।"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24491,8 +24398,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे "
-"हैं। कभी-कभी अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
+"हमें इस समस्या की जानकारी है और फ़िलहाल हम इसे हल करने के लिए काम कर रहे हैं। कभी-कभी "
+"अपने ब्राउज़र का कैशे मिटाने से समस्या हल हो जाती है।"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24507,8 +24414,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार "
-"मेहनत कर रहे हैं।"
+"इस असुविधा के लिए हमें खेद है। हम आपके अनुभव को बेहतर बनाने के लिए लगातार मेहनत कर रहे हैं।"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24517,8 +24423,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज "
-"फिर से लोड करना होगा।"
+"हमने Duck.ai सेवा को अपडेट कर दिया है। बदलाव प्रभावी होने के लिए, हमें पेज फिर से लोड "
+"करना होगा।"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24618,9 +24524,7 @@ msgstr "साप्ताहिक उपयोग सीमा पूरी �
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते "
-"हैं।"
+msgstr "साप्ताहिक उपयोग सीमा पूरी हो गई है। आप %1$s के बाद इस चैट को जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24629,8 +24533,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट "
-"करना जारी रख सकते हैं।"
+"साप्ताहिक उपयोग सीमा पूरी हो गई है। आप अपनी मासिक सीमा का उपयोग करके चैट करना "
+"जारी रख सकते हैं।"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24644,9 +24548,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
-"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं "
-"किया जाता।"
+"Duck.ai में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं "
+"और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24655,9 +24558,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम "
-"उन्हें अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए "
-"नहीं किया जाता।"
+"DuckDuckGo AI Chat में आपका स्वागत है! यहां आपकी सभी चैट गोपनीय रहती हैं, हम उन्हें "
+"अनाम कर देते हैं और उनका इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24667,17 +24569,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित "
-"करता है। यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं "
-"करता है या उनका उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
+"DuckDuckGo AI Chat में आपका स्वागत है! इस चैट सेशन को %1$s का %2$s संचालित करता है। "
+"यहां आपकी सभी चैट निजी हैं और उन्हें DuckDuckGo कभी भी स्टोर नहीं करता है या उनका "
+"उपयोग AI मॉडल को प्रशिक्षित करने में नहीं किया जाता है।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर "
-"सकते हैं।"
+"नए Duck.ai में आपका स्वागत है! अब आप अपनी डाउनलोड की गई चैट्स को इंपोर्ट कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24745,8 +24646,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई "
-"है। पेज को रीलोड करने की कोशिश करें।"
+"हमें वाकई खेद है, लेकिन ऐसा लगता है कि Duck.ai को लोड करने में कोई समस्या आई है। पेज को "
+"रीलोड करने की कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24781,8 +24682,7 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए "
-"कुछ विकल्प बताएं।"
+"\"हमें वास्तव में बेहतर काम करना होगा\" के संदर्भ में 'बेहतर' शब्द के लिए कुछ विकल्प बताएं।"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24807,12 +24707,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र "
-"डाउनलोड करने के क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही "
-"संदर्भ लें। जवाब को स्पष्ट हिस्सों में बांटें और हर हिस्से के लिए शीर्षक "
-"दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर विशेष ध्यान दिया गया "
-"हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी अनुभव रखने "
-"वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
+"Duck.ai इस्तेमाल करने में रुचि रखने वाले लोगों के लिए, DuckDuckGo ब्राउज़र डाउनलोड करने के "
+"क्या फ़ायदे हैं? केवल आधिकारिक DuckDuckGo स्रोतों का ही संदर्भ लें। जवाब को स्पष्ट हिस्सों में "
+"बांटें और हर हिस्से के लिए शीर्षक दें, जिसमें Duck.ai इंटीग्रेशन और प्राइवेसी की रक्षा पर "
+"विशेष ध्यान दिया गया हो। इसे संक्षिप्त, सरल और समझने में आसान रखें, ताकि AI या तकनीकी "
+"अनुभव रखने वाले या न रखने वाले लोग भी इसे आसानी से समझ सकें।"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25048,8 +24947,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग "
-"होता है?"
+"Cloud Save बुकमार्कलेट क्या है और यह यूआरएल पैरामीटर बुकमार्कलेट से कैसे अलग होता है?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25125,8 +25023,8 @@ msgstr "आप किस पर फीडबैक देना चाहें�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को "
-"प्रभावित नहीं करेगा।"
+"आप DuckDuckGo में जो देखते हैं, वह YouTube पर आपके रिकमंडेशन या सुझावों को प्रभावित नहीं "
+"करेगा।"
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25152,8 +25050,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद "
-"ब्रांडों पर विचार करना चाहिए?"
+"एक नौसिखिए के तौर पर, इलेक्ट्रिक गिटार खरीदते समय मुझे किन प्रमुख उत्पाद ब्रांडों पर "
+"विचार करना चाहिए?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25354,9 +25252,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए "
-"चैट का इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद "
-"करें।"
+"Duck.ai के साथ, आपकी चैट को अनाम रखा जाता है और AI को प्रशिक्षित करने के लिए चैट का "
+"इस्तेमाल कभी नहीं किया जाता। '%1$s' मेन्यू में इसे कभी भी चालू या बंद करें।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25365,8 +25262,7 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"चैट हिस्ट्री चालू होने पर, आपकी सबसे हाल की %1$s चैट तक इस डिवाइस पर सेव की "
-"जाएंगी।"
+"चैट हिस्ट्री चालू होने पर, आपकी सबसे हाल की %1$s चैट तक इस डिवाइस पर सेव की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25388,8 +25284,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए "
-"सीधे आपके डिवाइस से काम करता है."
+"यह डेटा ब्रोकर साइटों से आपके ईमेल, नाम, पते और अन्य जानकारी को हटाने के लिए सीधे आपके "
+"डिवाइस से काम करता है."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25638,8 +25534,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे "
-"दोबारा प्राप्त नहीं किया जा सकता है।"
+"हां, जब आप इसके साथ काम करते हैं, तो हम डेटा का निस्तारण कर देते हैं और इसे दोबारा प्राप्त "
+"नहीं किया जा सकता है।"
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25659,8 +25555,7 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
-"सकती है।"
+"आप %1$s से चैट कर रहे हैं। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे सकती है।"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25669,8 +25564,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके "
-"DuckDuckGo से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
+"आप चाहें तो यह कर सकते हैं: %1$s या फिर %2$s खोज शॉर्टकट का इस्तेमाल करके DuckDuckGo "
+"से सीधे अन्य खोज इंजनों पर खोज सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25684,8 +25579,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या "
-"इसे कभी भी बंद कर सकते हैं।"
+"आप %1$s के काम करने के तरीके को %2$sखोज सेटिंग%3$s में एडजस्ट कर सकते हैं या इसे कभी भी "
+"बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25694,22 +25589,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते "
-"हैं या इसे कभी भी बंद कर सकते हैं।"
+"आप %1$sखोज सेटिंग%2$s में जाकर Assist के काम करने के तरीके को एडजस्ट कर सकते हैं या इसे "
+"कभी भी बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का "
-"भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuck.ai%2$s का भी इस्तेमाल "
+"कर सकते हैं।"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI "
-"Chat%2$s का भी इस्तेमाल कर सकते हैं।"
+"आप सवालों के जवाब देने या टेक्स्ट को सारांशित करने के लिए %1$sDuckDuckGo AI Chat%2$s "
+"का भी इस्तेमाल कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25723,8 +25618,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में "
-"जाकर बदल सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
+"आपको Search Assist कितनी बार देखना है, इसे %1$sखोज Assist सेटिंग%2$s में जाकर बदल "
+"सकते हैं या इसे पूरी तरह से बंद कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25745,8 +25640,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है "
-"और चाहे तो पहली सेटिंग को डिलीट भी कर सकते हैं।"
+"आप ऐसा अपनी सेटिंग्स को दूसरे पासफ्रेज़ के अंतर्गत सेव करते हुए कर सकते है और चाहे तो पहली "
+"सेटिंग को डिलीट भी कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25839,8 +25734,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको "
-"पहले किसी अन्य साइट को अनब्लॉक करना होगा।"
+"आप अधिकतम %1$s साइटें ही ब्लॉक कर सकते हैं। %2$s को ब्लॉक करने के लिए, आपको पहले किसी "
+"अन्य साइट को अनब्लॉक करना होगा।"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25904,8 +25799,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में "
-"2 गुना ज़्यादा उपयोग सीमाएं।"
+"अब आपको %1$s का एक्सेस हासिल है, बेहतर AI तर्क-क्षमता, और Plus की तुलना में 2 गुना "
+"ज़्यादा उपयोग सीमाएं।"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25914,8 +25809,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN "
-"और अन्य DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
+"अब आपके पास एडवांस्ड AI मॉडल्स का एक्सेस है। आप DuckDuckGo ब्राउज़र में VPN और अन्य "
+"DuckDuckGo सब्सक्रिप्शन सुरक्षा सुविधाओं का उपयोग कर सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25937,9 +25832,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25949,9 +25843,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 "
-"चैट अभी भी लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी "
-"चैट डिलीट नहीं होंगी।"
+"अब आप इस ब्राउज़र से अपनी सेव की गई चैट्स एक्सेस नहीं कर पाएंगे। पिछली 30 चैट अभी भी "
+"लोकल स्टोरेज में उपलब्ध रहेंगी। इससे एन्क्रिप्टेड सर्वर से आपकी चैट डिलीट नहीं होंगी।"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25979,9 +25872,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए "
-"भी Chrome की बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह "
-"कर सकता है:"
+"अभी आप Chrome में गुप्त रूप से खोज रहे हैं। गुप्त रूप से ब्राउज़ करने के लिए भी Chrome की "
+"बजाय हमारे ऐप का उपयोग करेंगे। यह पहले से ही इंस्टॉल हैं और यह कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25994,8 +25886,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम "
-"करने के लिए सुझाव पाएं।"
+"अब आप गोपनीयता के साथ खोज कर रहे हैं। %1$sअपने फुटप्रिंट को और भी अधिक कम करने के लिए "
+"सुझाव पाएं।"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26044,9 +25936,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से "
-"कोशिश करें।"
+msgstr "आप फिलहाल संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26065,8 +25955,7 @@ msgstr "आज की वॉयस चैट सीमा पूरी हो �
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
 msgstr ""
-"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से "
-"कोशिश करें।"
+"आपने अपनी डिक्टेशन इस्तेमाल करने की सीमा पूरी कर ली है। कृपया बाद में फिर से कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26075,9 +25964,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त "
-"हो गई है। सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन "
-"की गई चैट डिलीट नहीं की जाएंगी।"
+"अटैचमेंट वाली Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। "
+"सिंक फिर से शुरू करने के लिए %1$s सबसे पुरानी चैट डिलीट करें। पिन की गई चैट डिलीट नहीं की "
+"जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26087,9 +25976,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई "
-"है। सिंक फिर से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट "
-"कर दें। पिन की गई चैट डिलीट नहीं की जाएंगी।"
+"आपके Duck.ai चैट्स के लिए आपके Sync & Backup स्टोरेज की सीमा समाप्त हो गई है। सिंक फिर "
+"से शुरू करने के लिए, अटैचमेंट वाली %1$s सबसे पुरानी चैट डिलीट कर दें। पिन की गई चैट डिलीट "
+"नहीं की जाएंगी।"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26103,8 +25992,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस "
-"वजह से YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
+"YouTube (Google के अधीन) आपको गुमनाम रूप से वीडियो नहीं देखने देता है । इस वजह से "
+"YouTube के वीडियो यहां देखने पर YouTube/Google को पता लग जाएगा |"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26164,8 +26053,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएँगे."
+"आपका बैकअप DuckDuckGo के सर्वर से डिलीट कर दिया जाएगा. सभी डिवाइस सिंक से डिस्कनेक्ट "
+"हो जाएँगे."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26175,9 +26064,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल "
-"स्टोरेज में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की %1$s चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26187,9 +26075,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से "
-"डिस्कनेक्ट हो जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज "
-"में उपलब्ध होंगी:"
+"आपका बैकअप DuckDuckGo के सर्वर से हटा दिया जाएगा। सभी डिवाइस सिंक से डिस्कनेक्ट हो "
+"जाएंगे। आपकी सबसे हाल की 100 चैट इन ब्राउज़रों के लोकल स्टोरेज में उपलब्ध होंगी:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26214,8 +26101,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता "
-"है।DuckDuckGo के पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
+"आपका ब्राउज़र, आपकी सबसे ज़्यादा देखी गई साइटों की एक सूची प्रदान करता है।DuckDuckGo के "
+"पास कभी भी इस डेटा का एक्सेस नहीं रहता है।"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26223,8 +26110,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo "
-"के पास इस डेटा का कभी भी एक्सेस नहीं रहा है।"
+"आपका ब्राउज़र सबसे ज़्यादा देखी गई साइटों की सूची प्रदान करता है। DuckDuckGo के पास इस "
+"डेटा का कभी भी एक्सेस नहीं रहा है।"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26233,8 +26120,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी "
-"दिखाई दे सकती है।"
+"%1$s के साथ आपकी चैट गोपनीय रहती है। AI चैट में गलत या आपत्तिजनक जानकारी भी दिखाई दे "
+"सकती है।"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26247,8 +26134,8 @@ msgstr "आपकी चैट अब सेव की जा रही है�
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता"
+"आपकी चैट निजी रहती हैं, कभी भी इन्हें सेव नहीं किया जाता या इनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26262,8 +26149,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26271,8 +26158,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI "
-"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट गोपनीय रहती हैं, हम उन्हें अनाम कर देते हैं, और उनका इस्तेमाल AI मॉडलों को "
+"प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26280,8 +26167,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26289,8 +26176,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका "
-"इस्तेमाल AI मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
+"आपकी चैट निजी रहती हैं, हमारे द्वारा कभी सेव नहीं की जाती हैं, और इनका इस्तेमाल AI "
+"मॉडलों को प्रशिक्षित करने के लिए नहीं किया जाता।"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26305,9 +26192,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI "
-"मॉडल्स को प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री "
-"सुरक्षित रखने के लिए इन चरणों का पालन करें।"
+"आपकी चैट अभी भी गोपनीय हैं, जिन्हें हम अनाम कर देते हैं, और इनका उपयोग AI मॉडल्स को "
+"प्रशिक्षित करने के लिए नहीं किया जाता है। अपनी चैट हिस्ट्री सुरक्षित रखने के लिए इन चरणों "
+"का पालन करें।"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26316,8 +26203,7 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें "
-"जहां आपने छोड़ा था।"
+"आपकी चैट्स इंपोर्ट कर दी गई हैं। आगे बढ़ें और Duck.ai में वहीं से जारी रखें जहां आपने छोड़ा था।"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26349,8 +26235,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध "
-"नहीं है। [%2$sउदाहरण संदेश%3$s]"
+"आपका ईमेल पता शेयर नहीं किया जाएगा, %1$sया किन्हीं अनाम खोजों के साथ संबद्ध नहीं है। "
+"[%2$sउदाहरण संदेश%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26365,8 +26251,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए "
-"नहीं किया जाता।"
+"आपकी फ़ीडबैक को अनाम रखा जाता है और इसका इस्तेमाल AI को ट्रेनिंग देने के लिए नहीं किया "
+"जाता।"
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26395,10 +26281,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का "
-"उपयोग करके '512-बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल "
-"आपके ब्राउज़र को छोड़ देती है। हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स "
-"फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी आपके पासफ़्रेज़ को नहीं जानता है।"
+"आपके पासफ़्रेज़ ने %1$sSHA-2%2$s के रूप में ज्ञात सुरक्षित हैश एल्गोरिथम का उपयोग करके '512-"
+"बिट की' जनरेट किया है। केवल 'की' और संबंधित सेटिंग्स फ़ाइल आपके ब्राउज़र को छोड़ देती है। "
+"हम नाम के रूप में 'की' का उपयोग करके सेटिंग्स फ़ाइल को सेव करते हैं। DuckDuckGo कभी भी "
+"आपके पासफ़्रेज़ को नहीं जानता है।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26413,9 +26299,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान "
-"बताने वाला मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे "
-"जोड़ न सकें।"
+"आपके प्रॉम्प्ट DuckDuckGo सर्वर के ज़रिए भेजे जाते हैं और उनसे आपकी पहचान बताने वाला "
+"मेटाडेटा हटा दिया जाता है, ताकि मॉडल प्रदाता आपकी बातचीत को आपसे जोड़ न सकें।"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26429,8 +26314,7 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा "
-"सकते हैं।"
+"आपकी हालिया चैट यहां रहती हैं! आप कभी भी अपनी चैट देख सकते हैं या उन्हें हटा सकते हैं।"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26462,8 +26346,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
-"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
+"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इनेबल करें।"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26472,9 +26356,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे "
-"परमानेंट करने के लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर "
-"जानें%4$s"
+"आपकी सेटिंग सेव कर ली गई हैं, लेकिन कुकीज़ हटाने से वे रीसेट हो जाएंगी। इसे परमानेंट करने के "
+"लिए %1$sDuckDuckGo No AI%2$s एक्सटेंशन इंस्टॉल करें। %3$sऔर जानें%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26502,9 +26385,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए "
-"Chrome के बजाय हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और "
-"यहां दिए गए काम कर सकता है:"
+"फ़िलहाल, आप Chrome में गोपनीय रूप से सर्च कर रहे हैं। ज़्यादा सुरक्षा के लिए Chrome के बजाय "
+"हमारे ब्राउज़र का इस्तेमाल करें। यह पहले से ही इंस्टॉल है और यहां दिए गए काम कर सकता है:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26513,8 +26395,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके "
-"फिर से कोशिश करें।"
+"आपने संदेश की अधिकतम आकार सीमा पार कर ली है। कृपया अपने संदेश को छोटा करके फिर से "
+"कोशिश करें।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26523,8 +26405,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire "
-"Button की मदद से इस बातचीत को मिटाएं।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। आगे बढ़ने के लिए, Fire Button की मदद "
+"से इस बातचीत को मिटाएं।"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26533,8 +26415,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट "
-"शुरू करें।"
+"आप इस बातचीत में अधिकतम चैट अवधि तक पहुंच गए हैं। जारी रखने के लिए एक नई चैट शुरू करें।"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26549,8 +26430,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया "
-"इस चैट को अब कल जारी रखें।"
+"आप एक दिन में भेजे जाने वाले संदेशों की अधिकतम संख्या तक पहुंच गए हैं। कृपया इस चैट को अब कल "
+"जारी रखें।"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26859,8 +26740,7 @@ msgstr "ऑफ़िशियल वेबसाइट"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s "
-"अक्षर है)"
+"या जो रंग आप चाहते है उसका कलर कोड लिखे, जैसे %1$s (%2$s एक एनकोडेड %3$s अक्षर है)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -96,8 +95,7 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -316,8 +314,7 @@ msgstr "Ljestvica %1$s još nije dostupna"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
+msgstr "%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -388,8 +385,7 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
+msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -533,8 +529,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -973,8 +968,7 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -2670,8 +2664,7 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2983,6 +2976,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Prije pohrane ovog izvješća, DuckDuckGo će ukloniti prenesene datoteke i "
+"generirane slike te anonimizirati tvoj razgovor uklanjanjem osobnih podataka "
+"poput imena, adresa e-pošte i identifikacijskih metapodataka."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3134,8 +3130,7 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3877,8 +3872,7 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4729,8 +4723,7 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5375,8 +5368,7 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
+msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5618,8 +5610,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6503,8 +6494,7 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6557,7 +6547,7 @@ msgstr "Ne sviđa mi se izvor"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Ne sviđa mi se vizualni stil"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6673,7 +6663,7 @@ msgstr "Džibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Ne slijedi upute"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7092,8 +7082,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7417,8 +7406,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7578,8 +7566,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
-"jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
+"Duck.ai-jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7587,8 +7575,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7807,8 +7794,7 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8235,8 +8221,7 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8541,7 +8526,7 @@ msgstr "Brzo"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Brzo generiranje slike"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8607,8 +8592,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
-"mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
+"web-mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8749,8 +8734,7 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8877,7 +8861,7 @@ msgstr "Dodatna pitanja ostaju privatna."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Slijedio je upute"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8983,8 +8967,7 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9621,8 +9604,7 @@ msgstr "Preuzmi aplikaciju"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
+msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9826,7 +9808,7 @@ msgstr "Dobra pravila o zaštiti privatnosti"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Dobar vizualni stil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10216,8 +10198,7 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10660,8 +10641,7 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10920,8 +10900,7 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10973,7 +10952,7 @@ msgstr "Upute za slike moraju biti u skladu s Duck.ai %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Kvaliteta slike"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11235,8 +11214,7 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr ""
-"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -12800,8 +12778,7 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -15523,8 +15500,7 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
+msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15579,8 +15555,7 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15844,7 +15819,7 @@ msgstr "Loše formatiranje"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Loša kvaliteta slike"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17012,8 +16987,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
-"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
+"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -17024,8 +16999,7 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17781,8 +17755,7 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17824,8 +17797,7 @@ msgstr "Pozdravi Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
+msgstr "Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17980,8 +17952,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18282,8 +18253,7 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18333,8 +18303,7 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18383,8 +18352,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18576,8 +18544,7 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18696,8 +18663,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18944,8 +18910,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19019,8 +18984,7 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19329,8 +19293,7 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19657,8 +19620,7 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19730,14 +19692,12 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19928,8 +19888,7 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19977,8 +19936,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20058,8 +20016,7 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20264,22 +20221,19 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20317,15 +20271,14 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
-"mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
+"web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21393,8 +21346,7 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21838,8 +21790,7 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21893,8 +21844,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
+msgstr "Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21923,8 +21873,7 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22094,8 +22043,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
-"%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
+"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22149,15 +22098,13 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Prebaci se na privatno AI čavrljanje ili %1$sonemogući u postavkama%2$s."
+msgstr "Prebaci se na privatno AI čavrljanje ili %1$sonemogući u postavkama%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
+msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22205,8 +22152,7 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22224,7 +22170,7 @@ msgstr "Presporo"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Presporo za generiranje"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22660,8 +22606,7 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22673,7 +22618,7 @@ msgstr "Pokušaj s manje ključnih riječi."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Isprobaj besplatno"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23031,8 +22976,7 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23202,8 +23146,7 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23255,8 +23198,7 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23278,15 +23220,13 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23386,8 +23326,7 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23639,8 +23578,7 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr ""
-"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -24093,8 +24031,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
-"u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
+"PDF-u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24381,8 +24319,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24881,8 +24818,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
-"ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
+"Duck.ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24896,8 +24833,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -25187,8 +25123,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
-"a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
+"URL-a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25263,8 +25199,7 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25296,8 +25231,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25315,8 +25249,7 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25779,8 +25712,7 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25871,15 +25803,13 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25918,8 +25848,7 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26100,8 +26029,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26206,14 +26134,12 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26403,8 +26329,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26465,8 +26390,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
-"ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26660,8 +26585,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -27007,8 +26931,7 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hr_HR/LC_MESSAGES/duckduckgo.po
+++ b/locales/hr_HR/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -95,7 +96,8 @@ msgstr "AI modeli %1$s i %2$s"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
+msgstr ""
+"%1$s se pojavljuje u nekim od najboljih rezultata za ovo pretraživanje."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -314,7 +316,8 @@ msgstr "Ljestvica %1$s još nije dostupna"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
+msgstr ""
+"%1$s doseže uporabna ograničenja 2 do 5 puta ranije nego osnovni modeli. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -385,7 +388,8 @@ msgstr "%1$s rabljeno"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
+msgstr ""
+"%1$s troši uporabna ograničenja do 2 do 5 puta brže od osnovnih modela %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -529,7 +533,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
+msgstr ""
+"%1$sPritisni i drži%2$s ikonu aplikacije DuckDuckGo na početnom zaslonu"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -968,7 +973,8 @@ msgstr "Dostupna je nova verzija AI Chata! Osvježi ovu stranicu za nastavak."
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
+msgstr ""
+"Dostupna je nova verzija usluge Duck.ai! Osvježi ovu stranicu za nastavak."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -2664,7 +2670,8 @@ msgstr "Nakon završetka čavrljanja, zvuk ne pohranjujemo ni mi ni OpenAI."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
+msgstr ""
+"Zvuk ne pohranjujemo ni mi ni OpenAI nakon što se čavrljanje transkribira."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2966,6 +2973,18 @@ msgstr ""
 "metapodataka."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3115,7 +3134,8 @@ msgstr "Blokiraj ovu stranicu iz svih rezultata"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
+msgstr ""
+"Blokiraj alate za praćenje i preuzmi kontrolu nad svojim osobnim podacima"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3857,7 +3877,8 @@ msgstr "Promjena načina prikaza URL-ova rezultata"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
+msgstr ""
+"Promjena načina prikaza zaglavlja i njegova ponašanja tijekom pomicanja"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4708,7 +4729,8 @@ msgstr "Klikni %1$sPostavke%2$s u padajućem izborniku."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
+msgstr ""
+"Klikni %1$sUpotrijebi trenutačne stranice%2$s zatim %3$sklikni U redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5353,7 +5375,8 @@ msgstr "Nastavi blokirati oglase"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
+msgstr ""
+"Nedavna čavrljanja nastavi ovdje. Možeš ih i izbrisati pomoću Fire Buttona."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5595,7 +5618,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
+msgstr ""
+"Nije moguće učitati tvoj kôd za oporavak. Zatvori ovo i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6479,7 +6503,8 @@ msgstr "Onemogući i isključi"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
+msgstr ""
+"Onemogućiti povijest čavrljanja i prekinuti vezu s uslugom Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6527,6 +6552,12 @@ msgstr "Ne sviđa mi se dizajn"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Ne sviđa mi se izvor"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6637,6 +6668,12 @@ msgstr "Rezultat u diviziji"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Džibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7055,7 +7092,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
+msgstr ""
+"Duck.ai je najbolji u našem privatnom i besplatnom DuckDuckGo pregledniku!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7379,7 +7417,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
+msgstr ""
+"DuckDuckGo AI Chat trenutačno nije dostupan. Pokušaj ponovno nešto kasnije."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7539,8 +7578,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš "
-"Duck.ai-jeve %2$s."
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš Duck.ai-"
+"jeve %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7548,7 +7587,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
+msgstr ""
+"DuckDuckGo anonimizira tvoje razgovore. Klikom na '%1$s' prihvaćaš naše %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7767,7 +7807,8 @@ msgstr "Slika se uređuje..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
+msgstr ""
+"Uređivanjem tvoje poruke uklonit će se odgovor ispod nje i generirati novi."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8194,7 +8235,8 @@ msgstr "Ekvatorska Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
+msgstr ""
+"Brzo izbriši svoje podatke o pregledavanju koristeći naš %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8496,6 +8538,12 @@ msgid "Fast"
 msgstr "Brzo"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8559,8 +8607,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje "
-"web-mjesto."
+"Prilagodi donje postavke, a zatim samo kopiraj i zalijepi kôd na svoje web-"
+"mjesto."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8701,7 +8749,8 @@ msgstr "Pronađi <b>%1$s</b> u mapi za preuzimanje"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
+msgstr ""
+"Pronađi DuckDuckGo u prikazanom popisu i klikni %1$sPostavi za zadano%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8825,6 +8874,12 @@ msgid "Follow-ups remain private."
 msgstr "Dodatna pitanja ostaju privatna."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8928,7 +8983,8 @@ msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
+msgstr ""
+"Besplatni i privatni razgovori, mi ih anonimiziramo. Nije potreban račun."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9565,7 +9621,8 @@ msgstr "Preuzmi aplikaciju"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
+msgstr ""
+"Nabavi besplatni preglednik DuckDuckGo %1$si blokiraj oglase na YouTubeu.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9764,6 +9821,12 @@ msgstr "Dobar dizajn"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Dobra pravila o zaštiti privatnosti"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10153,7 +10216,8 @@ msgstr "Pomozi nam poboljšati DuckDuckGo"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
+msgstr ""
+"Pomozi nam poboljšati DuckDuckGo pretraživanja svojim povratnim informacijama"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10596,7 +10660,8 @@ msgstr "Kako funkcionira"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
+msgstr ""
+"Koliko često želiš da se pojave odgovori uz pomoć umjetne inteligencije?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10855,7 +10920,8 @@ msgstr "Ako nas ipak želiš podržati, %1$spomozi proširiti DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
+msgstr ""
+"Želiš li koristiti DuckDuckGo bez JavaScripta, koristi %1$s ili %2$s verziju."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10902,6 +10968,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Upute za slike moraju biti u skladu s Duck.ai %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11163,7 +11235,8 @@ msgstr "Lako pregledavanje rezultata pretraživanja za slike i videozapise"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Infinite Scroll for Images, Videos, and Shopping"
-msgstr "Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
+msgstr ""
+"Lako pregledavanje rezultata pretraživanja slika, videozapisa i kupovina"
 
 # smartling.placeholder_format=C
 #. Feedback option when AI response is accurate
@@ -12727,7 +12800,8 @@ msgstr "Mikronezija"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
+msgstr ""
+"Pristup mikrofona je uskraćen. Dopusti pristup mikrofonu i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -15449,7 +15523,8 @@ msgstr "Prikvačeno"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
+msgstr ""
+"Prikvačena čavrljanja pojavit će se na vrhu tvojih nedavnih čavrljanja."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15504,7 +15579,8 @@ msgstr "Ispuni sljedeći upit i potvrdi da je ovo pretraživanje izvršio čovje
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
+msgstr ""
+"Opiši zašto je odgovor na čavrljanju štetan ili nezakonit. (neobavezno)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15763,6 +15839,12 @@ msgstr "Poljski"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Loše formatiranje"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16930,8 +17012,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb "
-"&quot;Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
+"Ponovno učitaj DuckDuckGo slijedeći upute ili klikom na gumb &quot;"
+"Osvježi&quot; (Refresh) ili &quot;Ponovno učitaj&quot; (Reload) u "
 "pregledniku."
 
 # smartling.placeholder_format=C
@@ -16942,7 +17024,8 @@ msgstr "Zapamti moj izbor"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
+msgstr ""
+"Zapamti moj odabir (ovo se može promijeniti u %1$s%2$s%3$sPostavkama%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17698,7 +17781,8 @@ msgstr "Spremi do 30 svojih najnovijih čavrljanja lokalno na svom uređaju."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
+msgstr ""
+"Spremi svoja Duck.ai čavrljanja između uređaja pomoću end-to-end šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17740,7 +17824,8 @@ msgstr "Pozdravi Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
+msgstr ""
+"Pozdravi Duck.ai – besplatno, privatno AI čavrljanje tvrtke DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17895,7 +17980,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
+msgstr ""
+"Listaj prema dolje do %1$sUsluga%2$s i klikni na %3$sAdresna traka%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18196,7 +18282,8 @@ msgstr "Pretraži putem DuckDuckGoa"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
+msgstr ""
+"Pretražuj, pregledavaj i privatno razgovaraj u našem besplatnom pregledniku"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18246,7 +18333,8 @@ msgstr "Drugo mišljenje"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
+msgstr ""
+"Sigurno spremi i sinkroniziraj svoja čavrljanja na svim svojim uređajima."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18295,7 +18383,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
+msgstr ""
+"Sigurno pohranjeno na DuckDuckGo poslužitelju s end-to-end šifriranjem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18487,7 +18576,8 @@ msgstr "Odaberi %1$sDuckDuckGo%2$s u padajućem izborniku zadanih tražilica"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$sDuckDuckGo%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18606,7 +18696,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
+msgstr ""
+"Odaberi %1$ssvoj preglednik%2$s na popisu i %3$sdopusti%4$s pristup lokaciji"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18853,7 +18944,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
+msgstr ""
+"Ručno postavi lokaciju ili provjeri jesu li omogućene lokacijske usluge."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -18927,7 +19019,8 @@ msgstr "Podijeli"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
+msgstr ""
+"Podijeli DuckDuckGo i pomozi prijateljima u vraćanju njihove privatnosti!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19236,7 +19329,8 @@ msgstr "Prikaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
+msgstr ""
+"Češće prikazuj DuckAssist. (Također ga možeš potpuno %1$sisključiti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19563,7 +19657,8 @@ msgstr "Prikazuje poruku dobrodošlice na vrhu stranice rezultata pretraživanja
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
+msgstr ""
+"Prikazuje poruku dobrodošlice korisnicima Androida u EU, u izborniku postavki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19635,12 +19730,14 @@ msgstr "Nazivi web-mjesta"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
+msgstr ""
+"Pretraživanje web lokacija privremeno je nedostupno. Radimo na rješenju."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
+msgstr ""
+"Stranice koje blokiraš bit će skrivene iz svih tvojih rezultata pretraživanja"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19831,7 +19928,8 @@ msgstr "Ponekad"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
+msgstr ""
+"Žao mi je što ne mogu pomoći, molim te opiši svoju sliku na drugačiji način."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19879,7 +19977,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
+msgstr ""
+"Nažalost, ovaj je kôd nevažeći. Provjeri je li unesen ili skeniran točan kôd."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19959,7 +20058,8 @@ msgstr "Izvorni tekst je izbrisan"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
+msgstr ""
+"Izvorni tekst je predug za sažimanje. Pokušaj ponovno s kraćim odabirom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20164,19 +20264,22 @@ msgstr "Ostani na DuckDuckGou"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših e-novosti o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
+msgstr ""
+"Ostani zaštićen i informiran putem naših biltena o zaštiti privatnosti."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20214,14 +20317,15 @@ msgstr "Zaustavi generiranje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
+msgstr ""
+"Onemogući skrivene alate za praćenje koji vrebaju na drugim web-mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
 msgstr ""
-"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim "
-"web-mjestima."
+"Onemogući većinu skrivenih alata za praćenje koji vrebaju na drugim web-"
+"mjestima."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21289,7 +21393,8 @@ msgstr "Priložene datoteke prelaze ukupno ograničenje veličine od %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
+msgstr ""
+"Zvučni zapis nije moguće obraditi. Pokušaj ponovno snimiti zvučni zapis."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21733,7 +21838,8 @@ msgstr "Za pravilno funkcioniranje ove stranice potreban je Javascript."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
+msgstr ""
+"Sadržaj ove stranice bit će poslan alatu Duck.ai zajedno s tvojom porukom"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21787,7 +21893,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
+msgstr ""
+"Ovo podijeljeno čavrljanje ne može se otvoriti. Poveznica je možda nepotpuna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21816,7 +21923,8 @@ msgstr "Ovaj je prijevod pogrešan"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
+msgstr ""
+"Ovaj se videozapis ovdje još ne može gledati. Možeš ga pogledati na %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21986,8 +22094,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš "
-"ispisati.%3$sKlikni na ikonu za ispis.%4$s"
+"Za ispis uputa:%1$svrati se na kartu.%2$sOdaberi rutu koju želiš ispisati."
+"%3$sKlikni na ikonu za ispis.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22041,13 +22149,15 @@ msgstr "Danas"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Prebaci se na privatno AI čavrljanje ili %1$sonemogući u postavkama%2$s."
+msgstr ""
+"Prebaci se na privatno AI čavrljanje ili %1$sonemogući u postavkama%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
+msgstr ""
+"Prebaci se na privatni AI chat ili ga %1$sonemogući u izborniku %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22095,7 +22205,8 @@ msgstr "Previše oglasa"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
+msgstr ""
+"Previše zahtjeva. Molimo te da napraviš kratku pauzu i pokušaš ponovno."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22108,6 +22219,12 @@ msgstr "Previše rezultata iz ovog izvora"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Presporo"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22543,13 +22660,20 @@ msgstr "Pokušaj omogućiti anonimnu lokaciju za točnije rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
+msgstr ""
+"Pokušaj eksperimentirati sa svakim modelom - oni će dati različite odgovore."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Pokušaj s manje ključnih riječi."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22907,7 +23031,8 @@ msgstr "Uključi %1$sPreciznu lokaciju%2$s za preciznije rezultate"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
+msgstr ""
+"Uključi Duck Player za gledanje vidoezapisa na YouTubeu bez ciljanih oglasa"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23077,7 +23202,8 @@ msgstr "Nije moguće poslati povratne informacije"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
+msgstr ""
+"Nije moguće povezivanje s glasovnim čavrljanjem, pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23129,7 +23255,8 @@ msgstr "Pod %1$sOtvori s%2$s odaberi %3$sOdređenu stranicu ili stranice%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
+msgstr ""
+"Pod %1$sPRI POKRETANJU > Početna stranica%2$s unesi: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23151,13 +23278,15 @@ msgstr "Pod %1$sTraži%2$s, klikni %3$sUpravljaj tražilicama...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
+msgstr ""
+"Pod Pri pokretanju odaberi %1$sOtvori određenu stranicu ili skup stranica%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Pod Pretraživanje klikni padajući izbornik i odaberi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23257,7 +23386,8 @@ msgstr "Otključaj uz pretplatu na DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
+msgstr ""
+"Otključaj napredne AI modele i viša ograničenja uz pretplatu na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23509,7 +23639,8 @@ msgctxt ""
 "Description prompting Plus subscribers to upgrade to Pro for higher image "
 "generation limits"
 msgid "Upgrade to Pro to unlock 2x higher limits"
-msgstr "Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
+msgstr ""
+"Nadogradi na Pro verziju za otključavanje dva puta veće količine generiranja"
 
 # smartling.placeholder_format=C
 #. Description shown to Plus subscribers who have reached their image generation limit, encouraging them to upgrade to Pro.
@@ -23962,8 +24093,8 @@ msgid ""
 msgstr ""
 "Posjeti Duck.ai u svom drugom pregledniku ili u aplikaciji DuckDuckGo i "
 "otvori Postavke Duck.ai. Odaberi „Uključi“ pod Sync & Backup i odaberi "
-"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery "
-"PDF-u."
+"„Sinkronizacija s drugim uređajem“. Ili skeniraj QR kôd na svom Recovery PDF-"
+"u."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24250,7 +24381,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
+msgstr ""
+"Ne možemo pročitati priložene datoteke jer je barem jedna od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24749,8 +24881,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem "
-"Duck.ai. Pokušaj ponovo učitati stranicu."
+"Stvarno nam je žao, ali čini se da je došlo do problema s učitavanjem Duck."
+"ai. Pokušaj ponovo učitati stranicu."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24764,7 +24896,8 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
+msgstr ""
+"Koji su neki argumenti, protuargumenti i pobijanja koncepta biljne prehrane?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -25054,8 +25187,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra "
-"URL-a označenog apleta?"
+"Što je to označeni aplet za Cloud Save i kako se razlikuje od parametra URL-"
+"a označenog apleta?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25130,7 +25263,8 @@ msgstr "O čemu želiš pružiti povratne informacije?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
+msgstr ""
+"Ono što gledaš u DuckDuckGou neće utjecati na tvoje preporuke na YouTubeu."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25162,7 +25296,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
+msgstr ""
+"Kada je to omogućeno, Duck.ai će prikazivati izravne odgovore u čavrljanju."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25180,7 +25315,8 @@ msgstr "Gdje gledati <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
+msgstr ""
+"Tamo gdje piše Početna stranica, klikni %1$sPostavi na trenutnu stranicu%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25643,7 +25779,8 @@ msgstr "Da, novi korisnik!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
+msgstr ""
+"Da, mi se rješavamo podataka kad ti više ne trebaju i nemoguće ih je vratiti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25734,13 +25871,15 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
+msgstr ""
+"Ovo možeš promijeniti u svakom trenutku u %1$sPostavke pretraživanja%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
+msgstr ""
+"Ovo čavrljanje možeš nastaviti kada se tvoje ograničenje resetira: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25779,7 +25918,8 @@ msgstr "Možeš nastaviti razgovarati koristeći svoje mjesečno ograničenje."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
+msgstr ""
+"Sada možeš spremiti do 100 čavrljanja na ovom uređaju. Sretno čavrljanje!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25960,7 +26100,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
+msgstr ""
+"Ovu poruku više nećeš vidjeti osim ako ne izbrišeš podatke svog preglednika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26065,12 +26206,14 @@ msgstr "Dosegao si maksimalno trajanje glasovnog čavrljanja za jednu sesiju."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
+msgstr ""
+"Dosegao si ograničenje glasovnog čavrljanja za danas. Pokušaj ponovno sutra."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
+msgstr ""
+"Dosegnuto je tvoje ograničenje korištenja diktata. Pokušaj ponovno kasnije."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26260,7 +26403,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
+msgstr ""
+"Tvoji su razgovori privatni i nikada se ne koriste za učenje AI modela."
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26321,8 +26465,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u "
-"Duck.ai."
+"Vaši su razgovori uvezeni. Samo naprijed i nastavi tamo gdje si stao u Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26516,7 +26660,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
+msgstr ""
+"Premašena je maksimalna duljina poruke. Skrati poruku i pokušaj ponovno."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26862,7 +27007,8 @@ msgstr "službenu web lokaciju"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
+msgstr ""
+"ili napiši šifru boje koju želiš, npr. %1$s (%2$s je kodirani znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
-"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
-"válts a Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
+"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
+"Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -504,7 +504,8 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr ""
+"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -526,13 +527,15 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr ""
+"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr ""
+"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -889,7 +892,8 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr ""
+"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1014,9 +1018,8 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
-"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
-"Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
+"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1080,9 +1083,8 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
-"linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
+"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1985,7 +1987,8 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr ""
+"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2555,9 +2558,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
-"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
-"érhetők el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
+"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
+"el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2664,18 +2667,21 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr ""
+"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2924,7 +2930,8 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr ""
+"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2976,6 +2983,18 @@ msgstr ""
 "A jelentés tárolása előtt a DuckDuckGo anonimizálja a beszélgetésedet az "
 "olyan személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
 "e-mail-címek és az azonosításra alkalmas metaadatok."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3127,7 +3146,8 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr ""
+"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3875,7 +3895,8 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr ""
+"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4087,8 +4108,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
-"Duck.ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
+"ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4639,8 +4660,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
-"%1$sDuck.ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
+"ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4667,13 +4688,15 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr ""
+"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr ""
+"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4707,7 +4730,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr ""
+"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4788,7 +4812,8 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr ""
+"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5515,7 +5540,8 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr ""
+"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6566,6 +6592,12 @@ msgid "Dislike source"
 msgstr "Nem tetszik a forrás"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Bezárás"
@@ -6674,6 +6706,12 @@ msgstr "Divíziórekord"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Dzsibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7002,7 +7040,8 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr ""
+"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7095,7 +7134,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr ""
+"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7138,8 +7178,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
-"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
+"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -7147,7 +7187,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr ""
+"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7161,9 +7202,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
-"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
-"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
+"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
+"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7247,8 +7288,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
-"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
+"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -7296,8 +7337,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
+"alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7425,7 +7466,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr ""
+"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7576,8 +7618,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
-"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
+"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7868,7 +7910,8 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr ""
+"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -7969,7 +8012,8 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr ""
+"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8101,13 +8145,15 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr ""
+"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8121,7 +8167,8 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr ""
+"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8157,13 +8204,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr ""
+"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr ""
+"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8559,6 +8608,12 @@ msgid "Fast"
 msgstr "Gyors"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8879,8 +8934,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
-"Duck.ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
+"ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8892,6 +8947,12 @@ msgstr "Kapcsolódó kérdés"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "A kapcsolódó kérdések privátak maradnak."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8997,7 +9058,8 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr ""
+"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9249,13 +9311,15 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr ""
+"Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9496,9 +9560,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
-"AI-csevegést, a személyes adatok eltávolítására szolgáló Personal Info "
-"Removal, és a személyazonosság helyreállításához használható Identity Theft "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
+"csevegést, a személyes adatok eltávolítására szolgáló Personal Info Removal, "
+"és a személyazonosság helyreállításához használható Identity Theft "
 "Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9508,8 +9572,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
-"AI-csevegést, és a személyazonosság helyreállításához használható Identity "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
+"csevegést, és a személyazonosság helyreállításához használható Identity "
 "Theft Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9532,9 +9596,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
-"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
-"adatvédelmi szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
+"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
+"szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9563,7 +9627,8 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
+msgstr ""
+"DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9760,7 +9825,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr ""
+"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9848,6 +9914,12 @@ msgstr "Jó dizájn"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Jó adatvédelmi szabályzat"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10237,7 +10309,8 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr ""
+"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10939,7 +11012,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr ""
+"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11001,6 +11075,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr ""
 "A képpromptoknak meg kell felelniük a Duck.ai %1$s dokumentumában "
 "foglaltaknak."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11140,7 +11220,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr ""
+"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12468,7 +12549,8 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr ""
+"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14564,7 +14646,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr ""
+"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14935,9 +15018,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
-"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
-"és Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
+"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
+"Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15563,7 +15646,8 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
+msgstr ""
+"A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15604,7 +15688,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15612,7 +15697,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr ""
+"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15823,8 +15909,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
-"YouTube-javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
+"javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15881,6 +15967,12 @@ msgstr "lengyel"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Rossz formázás"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16660,13 +16752,15 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr ""
+"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16678,13 +16772,15 @@ msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
+msgstr ""
+"Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
+msgstr ""
+"Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17053,7 +17149,8 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr ""
+"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17343,8 +17440,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
-"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
+"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17439,7 +17536,8 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr ""
+"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17854,7 +17952,8 @@ msgstr "Üdvözöl a Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
+msgstr ""
+"Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18046,7 +18145,8 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr ""
+"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18458,7 +18558,8 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr ""
+"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -18524,7 +18625,8 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr ""
+"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18580,8 +18682,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
-"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
+"com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18629,7 +18731,8 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr ""
+"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18640,7 +18743,8 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr ""
+"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18683,7 +18787,8 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr ""
+"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18708,7 +18813,8 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr ""
+"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -19068,7 +19174,8 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr ""
+"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19095,8 +19202,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
-"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
+"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -19188,7 +19295,8 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr ""
+"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19495,7 +19603,8 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr ""
+"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19658,12 +19767,14 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr ""
+"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19681,7 +19792,8 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr ""
+"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19709,7 +19821,8 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr ""
+"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19786,7 +19899,8 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr ""
+"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -21251,7 +21365,8 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr ""
+"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -21430,18 +21545,21 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr ""
+"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr ""
+"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21653,7 +21771,8 @@ msgstr "Ezen a héten"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
+msgstr ""
+"Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21790,8 +21909,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21799,8 +21918,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
-"GIF-fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
+"fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21918,9 +22037,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21930,9 +22049,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
-"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
-"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
+"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
+"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -21976,7 +22095,8 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr ""
+"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22154,8 +22274,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
-"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
+"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -22266,6 +22386,12 @@ msgstr "Túl sok találat ebből a forrásból"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Túl lassú"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22547,7 +22673,8 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr ""
+"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22698,20 +22825,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr ""
+"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr ""
+"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Próbálj kevesebb kulcsszót használni."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22757,7 +22892,8 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr ""
+"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22796,7 +22932,8 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr ""
+"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23073,7 +23210,8 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr ""
+"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23306,7 +23444,8 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr ""
+"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23415,8 +23554,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
-"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
+"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23438,8 +23577,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
-"DuckDuckGo-előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
+"előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23998,8 +24137,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Tekints meg egy Duck.ai-ból megosztott beszélgetést – ingyenes, privát "
-"AI-csevegés a DuckDuckGo kínálatában. Mentsd el a saját csevegéseid közé, és "
+"Tekints meg egy Duck.ai-ból megosztott beszélgetést – ingyenes, privát AI-"
+"csevegés a DuckDuckGo kínálatában. Mentsd el a saját csevegéseid közé, és "
 "folytasd privát módon."
 
 # smartling.placeholder_format=C
@@ -24104,9 +24243,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
-"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
-"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
+"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
+"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -24145,8 +24284,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
-"QR-kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
+"kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24199,8 +24338,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
-"MI-modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
+"modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24350,9 +24489,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
-"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
-"ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
+"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24421,14 +24559,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr ""
+"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr ""
+"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24470,7 +24610,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr ""
+"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24643,7 +24784,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr ""
+"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24835,8 +24977,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel "
-"mesterségesintelligencia-modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24848,14 +24990,15 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a "
-"mesterségesintelligencia-modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
+"modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr ""
+"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24954,7 +25097,8 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr ""
+"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25341,7 +25485,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr ""
+"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25359,7 +25504,8 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr ""
+"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25861,7 +26007,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr ""
+"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25921,7 +26068,8 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr ""
+"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25960,7 +26108,8 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr ""
+"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26233,7 +26382,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr ""
+"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26504,19 +26654,22 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr ""
+"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr ""
+"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -26674,7 +26827,8 @@ msgstr "A megosztott linkjeid itt találhatók: %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr ""
+"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26734,7 +26888,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr ""
+"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -27043,8 +27198,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
-"%3$s-karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
+"karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hu_HU/LC_MESSAGES/duckduckgo.po
+++ b/locales/hu_HU/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a DuckDuckGo-"
-"előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy válts a "
-"Plus vagy az ingyenes modellre."
+"A(z) %1$s csak a Pro verzióval érhető el. Frissítsd újra a "
+"DuckDuckGo-előfizetésedet ebben a böngészőben a csevegés folytatásához, vagy "
+"válts a Plus vagy az ingyenes modellre."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -504,8 +504,7 @@ msgstr "%1$sTudj meg többet%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
+msgstr "%1$sTudd meg, hogyan őrizzük meg a tartózkodási helyed bizalmasságát%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -527,15 +526,13 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
+msgstr "%1$sTovábbi részletek%2$s a csevegések eszközön való privát tárolásáról."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
+msgstr "%1$sNyomd meg hosszan%2$s a DuckDuckGo alkalmazás ikonját a kezdőképernyőn"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -892,8 +889,7 @@ msgstr "Elérted a 6 órás használati limitet."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
+msgstr "Elérted a 6 órás használati limitet. A csevegést %1$s után folytathatod."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1018,8 +1014,9 @@ msgstr ""
 "Az AI Chat segítségével névtelen beszélgetéseket folytathatsz harmadik felek "
 "mesterséges intelligencián alapuló csevegési modelljeivel. Ennek "
 "kikapcsolása elrejti az AI Chat funkciót a DuckDuckGo Search "
-"szolgáltatásban. Ha a beállítás ki van kapcsolva, a %1$sduckduckgo.com/"
-"aichat%2$s oldalra látogatva továbbra is elérheted az AI Chatet."
+"szolgáltatásban. Ha a beállítás ki van kapcsolva, a "
+"%1$sduckduckgo.com/aichat%2$s oldalra látogatva továbbra is elérheted az AI "
+"Chatet."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1083,8 +1080,9 @@ msgstr ""
 "Az AI-alapú válaszokra jelenleg nem tehetők fel közvetlenül további "
 "kérdések. Azonban ha újabb kérdést szeretnél feltenni, az OpenAI, az "
 "Anthropic, valamint más szolgáltatók csevegési modelljeit is támogató "
-"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a %1$sDuck."
-"ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak linkjét."
+"mesterségesintelligencia-alapú privát csevegési szolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatát is felajánljuk, és gyakran megjelenítjük annak "
+"linkjét."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1987,8 +1985,7 @@ msgstr "Adatvédelmet tiszteletben tartó hirdetések engedélyezése"
 #. Title of the upload consent prompt shown before the first image/file upload in a chat with a zero-provider-visibility model, shown inside an in-chat permission card in Duck.ai
 msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid "Allow anonymous file review for this chat?"
-msgstr ""
-"Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
+msgstr "Engedélyezed a névtelen módon végzett fájlellenőrzést ehhez a csevegéshez?"
 
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
@@ -2558,9 +2555,9 @@ msgstr ""
 "felhasználói felületét a keresési eredményekből), Igény szerint (csak az "
 "Asszisztens gombra kattintás esetén jelennek meg az AI-alapú válaszok), Néha "
 "(csak akkor jelenik meg AI-alapú válasz, ha nagyon releváns), illetve "
-"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az AI-"
-"alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában érhetők "
-"el."
+"Gyakran (gyakrabban jelenik meg, szélesebb körű keresések esetén). Az "
+"AI-alapú válaszok egyelőre csak az Egyesült Államok (angol) régiójában "
+"érhetők el."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2667,21 +2664,18 @@ msgstr "Hang"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés befejezése után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
+msgstr "A hanganyagot a csevegés átírása után mi nem tároljuk, és az OpenAI sem."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2930,8 +2924,7 @@ msgstr "Vonalkód"
 #. Prompt sent to the AI when the user taps the "Is it worth taking?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Based on this page, is this course worth taking?"
-msgstr ""
-"Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
+msgstr "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2995,6 +2988,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"A jelentés tárolása előtt a DuckDuckGo eltávolítja a feltöltött fájlokat és "
+"a generált képeket, majd anonimizálja a beszélgetésedet az olyan "
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, valamint az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3146,8 +3143,7 @@ msgstr "Webhely blokkolása minden találatból"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
+msgstr "Blokkold a nyomkövetőket, és vedd át az irányítást a személyes adataid felett"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3895,8 +3891,7 @@ msgstr "Módosítja az eredmények URL-jeinek megjelenítési módját"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
+msgstr "Módosítja a fejléc megjelenítési módját és viselkedését görgetés közben."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4108,8 +4103,8 @@ msgstr "Privát csevegés"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített Duck."
-"ai segítségével."
+"Csevegj privátban bármely webhelyen az ingyenes böngészőnkbe beépített "
+"Duck.ai segítségével."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4660,8 +4655,8 @@ msgid ""
 msgstr ""
 "Kattints a „Több” lehetőségre, ha többet meg szeretnél tudni egy témáról, és "
 "tegyél fel kapcsolódó kérdéseket az OpenAI, az Anthropic és további "
-"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a %1$sDuck."
-"ai%2$s használatával."
+"csevegési modelleket támogató privát AI-csevegőszolgáltatásunk, a "
+"%1$sDuck.ai%2$s használatával."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4688,15 +4683,13 @@ msgstr "Kattints a %1$sHozzáadás%2$s lehetőségre"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
+msgstr "Kattints az %1$sEngedélyezés%2$slehetőségre, majd a %3$sHozzáadás%4$s gombra."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
+msgstr "Kattints a %1$sKeresési beállítások módosítása%2$s sorra a lenyíló menüben"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4730,8 +4723,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
+msgstr "Kattints a bal oldali sáv %1$sAdatvédelem és szolgáltatások%2$s elemére."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4812,8 +4804,7 @@ msgstr "Kattints a %1$sBeállítás alapértelmezettként%2$s lehetőségre lent
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
+msgstr "Kattints a %1$sKeresőszolgáltatók%2$s lehetőségre a bővítménytípusoknál"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -5540,8 +5531,7 @@ msgstr "Másolás"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
+msgstr "Másold ki és illeszd be az %1$sabout:preferences#search%2$s címet a címsorba"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6595,7 +6585,7 @@ msgstr "Nem tetszik a forrás"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nem tetszik a vizuális stílus"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6711,7 +6701,7 @@ msgstr "Dzsibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nem követi az utasításokat"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7040,8 +7030,7 @@ msgstr "Dobd ide a fotókat vagy PDF-fájlokat"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
+msgstr "A Duck Player segítségével célzott hirdetések nélkül nézheted a YouTube-ot"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7134,8 +7123,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
+msgstr "A Duck.ai a privát és ingyenes DuckDuckGo böngészőnkben működik a legjobban!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7178,8 +7166,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el e-"
-"mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
+"A Duck.ai átmenetileg nem érhető el. Ha ez továbbra is fennáll, küldd el "
+"e-mailben a névtelenségi funkcióhoz szükséges %1$s kódot a következő címre: "
 "%2$s"
 
 # smartling.placeholder_format=C
@@ -7187,8 +7175,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
+msgstr "A Duck.ai átmenetileg nem érhető el. Frissítsd az oldalt, és próbálkozz újra."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7202,9 +7189,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű MI-"
-"modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, de "
-"továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
+"A Duck.ai lehetővé teszi, hogy privát módon beszélgess népszerű "
+"MI-modellekkel. A kikapcsolása elrejti a Duck.ai gombjait és hivatkozásait, "
+"de továbbra is felkeresheted közvetlenül a %1$sduck.ai%2$s webhelyet."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7288,8 +7275,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes AI-"
-"csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
+"Duck.ai, DuckDuckGo AI, privát AI chatbot, csevegőrobot, ingyenes "
+"AI-csevegés, anonim AI-csevegés, AI-csevegés regisztráció nélkül, OpenAI, "
 "Anthropic, Llama, Mistral, nyílt forráskódú AI modellek, adatvédelemre "
 "összpontosító AI, fiók nélküli AI-csevegés"
 
@@ -7337,8 +7324,8 @@ msgid ""
 msgstr ""
 "A DuckAssist nem tud utólagos kérdésekre válaszolni, viszont kínálatunkban "
 "többek között az OpenAI és az Anthropic csevegési modelljeit támogató "
-"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy mesterségesintelligencia-"
-"alapú privát csevegési szolgáltatás."
+"%1$sDuckDuckGo AI Chat%2$s is elérhető, amely egy "
+"mesterségesintelligencia-alapú privát csevegési szolgáltatás."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7466,8 +7453,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
+msgstr "A DuckDuckGo AI Chat átmenetileg nem érhető el. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7618,8 +7604,8 @@ msgid ""
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
 "A DuckDuckGo automatikusan anonimizálja ezeket a jelentéseket az olyan "
-"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az e-mail-"
-"címek, a telefonszámok és az azonosításra alkalmas metaadatok."
+"személyazonosításra alkalmas adatok eltávolításával, mint a nevek, az "
+"e-mail-címek, a telefonszámok és az azonosításra alkalmas metaadatok."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7910,8 +7896,7 @@ msgstr "Emeld ki a fontos információkat a válaszokban"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Enable 'Sites can ask for my location.'"
-msgstr ""
-"Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
+msgstr "Engedélyezd a „Webhelyek kérhetik a tartózkodási helyemet” lehetőséget."
 
 # smartling.placeholder_format=C
 #. Button shown during outages to enable AI features
@@ -8012,8 +7997,7 @@ msgstr "Diktálás engedélyezése a Duck.ai felületén"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
+msgstr "Az anonim hely használatához engedélyezd a készülékeden a helymeghatározást"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8145,15 +8129,13 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
+msgstr "Győződj meg arról, hogy a „Helyszolgáltatások” %1$sengedélyezve vannak%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a „Hely” %1$sengedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8167,8 +8149,7 @@ msgstr ""
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
+msgstr "Győződj meg arról, hogy a Hely %1$sEngedélyezés%2$s értékre van állítva"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8204,15 +8185,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
+msgstr "Győződj meg arról, hogy a böngészőben engedélyezve van a helyhozzáférés"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
+msgstr "Győződj meg arról, hogy böngésződben engedélyezve van a helyhozzáférés."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8611,7 +8590,7 @@ msgstr "Gyors"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Gyors képgenerálás"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8934,8 +8913,8 @@ msgstr ""
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
 msgstr ""
-"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új Duck."
-"ai felületre"
+"Kövesd az alábbi lépéseket, ha szeretnéd átvinni a csevegéseket az új "
+"Duck.ai felületre"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8952,7 +8931,7 @@ msgstr "A kapcsolódó kérdések privátak maradnak."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Követte az utasításokat"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9058,8 +9037,7 @@ msgstr "Ingyenes és privát csevegések, általunk anonimizálva"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
+msgstr "Ingyenes és privát csevegések, általunk anonimizálva. Nincs szükség fiókra."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9311,15 +9289,13 @@ msgstr "Általános célú mesterséges intelligencia, beépített erős moderá
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített gyenge moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített gyenge moderálással"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Általános célú mesterséges intelligencia, beépített közepes moderálással"
+msgstr "Általános célú mesterséges intelligencia, beépített közepes moderálással"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9560,9 +9536,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, a személyes adatok eltávolítására szolgáló Personal Info Removal, "
-"és a személyazonosság helyreállításához használható Identity Theft "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, a személyes adatok eltávolítására szolgáló Personal Info "
+"Removal, és a személyazonosság helyreállításához használható Identity Theft "
 "Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9572,8 +9548,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett AI-"
-"csevegést, és a személyazonosság helyreállításához használható Identity "
+"Vedd igénybe a gyors, naplózásmentes VPN-t, a választható fejlett "
+"AI-csevegést, és a személyazonosság helyreállításához használható Identity "
 "Theft Restoration funkciókat."
 
 # smartling.placeholder_format=C
@@ -9596,9 +9572,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez DuckDuckGo-"
-"előfizetéssel, amely a VPN-megoldásunk mellett további prémium adatvédelmi "
-"szolgáltatásokat is tartalmaz."
+"Szerezz hozzáférést a Duck.ai fejlett AI-modelljeihez "
+"DuckDuckGo-előfizetéssel, amely a VPN-megoldásunk mellett további prémium "
+"adatvédelmi szolgáltatásokat is tartalmaz."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9627,8 +9603,7 @@ msgstr "Kérj számítógépes segítséget"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
+msgstr "DuckDuckGo-előfizetéssel magasabb felhasználási limiteket vehetsz igénybe."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9825,8 +9800,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
+msgstr "Lépj az %1$sAdatvédelem és biztonság > Helymeghatározás%2$s lehetőségre"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9919,7 +9893,7 @@ msgstr "Jó adatvédelmi szabályzat"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Jó vizuális stílus"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10309,8 +10283,7 @@ msgstr "Segíts nekünk a DuckDuckGo fejlesztésében"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
+msgstr "A visszajelzéseddel segítesz nekünk a DuckDuckGo-keresések fejlesztésében"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -11012,8 +10985,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
+msgstr "Ha támogatni szeretnél minket, segíts a %1$sDuckDuckGo terjesztésében%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11080,7 +11052,7 @@ msgstr ""
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Képminőség"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11220,8 +11192,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
-msgstr ""
-"A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
+msgstr "A fenti menüben válaszd az %1$sEszközök%2$s > %3$sBeállítások%4$s lehetőséget"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12549,8 +12520,7 @@ msgstr "Ügyelj rá, hogy minden szó helyesen legyen írva."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
+msgstr "Ne felejtse el bejelölni, hogy %1$s„Legyen ez az alapértelmezett keresőm”%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -14646,8 +14616,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
+msgstr "Hoppá! Váratlan hiba történt a szöveg fordítása közben. Próbáld újra később."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -15018,9 +14987,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, titkosítás-"
-"végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS és "
-"Android%2$s rendszerhez is elérhető."
+"Mobiltelefonos böngészőnk keresőmotorunkat, követésvédelmünket, "
+"titkosítás-végrehajtónkat stb. magában foglalva áll rendelkezésedre. %1$siOS "
+"és Android%2$s rendszerhez is elérhető."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15646,8 +15615,7 @@ msgstr "Kitűzött"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
+msgstr "A kitűzött csevegések a legutóbbi csevegések felső részében jelennek meg."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15688,8 +15656,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
+msgstr "A következő feladat elvégzésével igazold, hogy az utasítást ember adta."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15697,8 +15664,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
+msgstr "A következő feladat elvégzésével igazold, hogy a keresést ember végezte."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15909,8 +15875,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a YouTube-"
-"javaslataidat."
+"Ráadásul az, amit a Duck Playerben nézel, nem fogja befolyásolni a "
+"YouTube-javaslataidat."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15972,7 +15938,7 @@ msgstr "Rossz formázás"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Rossz képminőség"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16752,15 +16718,13 @@ msgstr "Érvelő mesterséges intelligencia, magas szintű beépített moderáci
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, alacsony szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
+msgstr "Érvelő mesterséges intelligencia, közepes szintű beépített moderációval"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16772,15 +16736,13 @@ msgstr "Érveléssel jobb válaszok kaphatók az összetett kérdésekre."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször hamarabb éri el a használati limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
+msgstr "Az érvelés alaposabb, de 2–5-ször gyorsabban fogyasztja a limitet. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17149,8 +17111,7 @@ msgstr "Választott beállítás megjegyzése"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
+msgstr "Jegyezze meg a választásomat (módosítható a %1$s%2$s%3$sBeállításokban%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17440,8 +17401,8 @@ msgid ""
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
 "A válaszok kizárólag tájékoztatási célokat szolgálnak, és nem minősülnek "
-"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az AI-"
-"alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
+"orvosi, jogi, pénzügyi, befektetési vagy egyéb szakmai tanácsnak. Az "
+"AI-alapú válaszok a %1$sSzolgáltatási feltételek%2$s hatálya alá esnek."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17536,8 +17497,7 @@ msgstr "A találatok nem tartalmazzák a blokkolt webhelyeket."
 #. Informational banner shown at the top of the Maps search results panel when the user has blocked Yelp or TripAdvisor in their settings. Explains why ratings, reviews, and other details may be missing from place listings.
 msgctxt "Exclusion message at top of maps vertical"
 msgid "Results exclude information from blocked sites."
-msgstr ""
-"A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
+msgstr "A találatok nem tartalmazzák a blokkolt webhelyekről származó információkat."
 
 # smartling.placeholder_format=C
 #. Message that appears when results exclude blocked sites
@@ -17952,8 +17912,7 @@ msgstr "Üdvözöl a Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
+msgstr "Üdvözöl a Duck.ai – ingyenes, privát AI-csevegés a DuckDuckGo kínálatában."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18145,8 +18104,7 @@ msgstr "Keresés"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
+msgstr "A helyileg közelebbi találatokhoz a keresési kifejezés legyen inkább „%1$s”?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18558,8 +18516,7 @@ msgstr "Fényképek megtekintése"
 #. Text for a button that links to the terms of use and privacy policy page.
 msgctxt "Secondary button text in active privacy modal"
 msgid "See Privacy Policy and Terms of Service"
-msgstr ""
-"Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
+msgstr "Tekintse meg az Adatvédelmi szabályzatot és a Szolgáltatási feltételeket"
 
 # smartling.placeholder_format=C
 #. Text of the secondary button in the modal that allows the user to open the terms and privacy policy page.
@@ -18625,8 +18582,7 @@ msgstr "További információ: %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
+msgstr "További vásárlási találatok megtekintése a népszerű kiskereskedők kínálatából"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18682,8 +18638,8 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a %3$shttps://duckduckgo."
-"com%4$s címet a beviteli mezőbe"
+"Válaszd az %1$sEgyéni%2$s lehetőséget, és írd be a "
+"%3$shttps://duckduckgo.com%4$s címet a beviteli mezőbe"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18731,8 +18687,7 @@ msgstr "Válaszd a %1$sDuckDuckGót%2$s a keresőszolgáltatók listáján"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
+msgstr "Válaszd a %1$sDuckDuckGót%2$s az %3$sAlapértelmezett keresőmotor%4$s menüben"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18743,8 +18698,7 @@ msgstr "Válaszd a %1$sDuckDuckGo%2$s lehetőséget."
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
+msgstr "Válaszd a %1$sKeresőmotorok szerkesztése%2$s menüpontot a legördülő menüben"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18787,8 +18741,7 @@ msgstr "Válaszd ki a %1$sKeresőmotor%2$s lehetőséget"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
+msgstr "Válaszd a %1$sKeresőmotor%2$s lehetőséget, majd az %3$sEgyéb...%4$s opciót"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18813,8 +18766,7 @@ msgstr "Válaszd ki a %1$sBeállítások%2$s opciót a legördülő menüből."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
+msgstr "Válaszd a %1$sBeállítások%2$s, majd a %3$sHaladó beállítások%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -19174,8 +19126,7 @@ msgstr "Megosztás"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
+msgstr "Terjeszd a DuckDuckGót, és segíts a barátaidnak megvédeni az adataikat!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19202,8 +19153,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az AI-"
-"modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
+"A relevancia javítása érdekében oszd meg a városi szintű helyadataidat az "
+"AI-modellekkel. A Duck.ai soha nem árulja el nekünk vagy az AI-modelleknek a "
 "pontos tartózkodási helyedet."
 
 # smartling.placeholder_format=C
@@ -19295,8 +19246,7 @@ msgstr "Beszélgetés megosztása a DuckDuckGóval"
 msgctxt ""
 "Label beside the share-content switch on the Duck.ai response feedback form"
 msgid "Share your prompt and chat response with DuckDuckGo"
-msgstr ""
-"Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
+msgstr "Oszd meg az utasításodat és a beszélgetésben kapott választ a DuckDuckGóval"
 
 # smartling.placeholder_format=C
 #. Variant of the share toggle label that makes sharing mandatory when reporting harmful or illegal content.
@@ -19603,8 +19553,7 @@ msgstr "Minden találat megjelenítése"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
+msgstr "Gyakrabban jelenítse meg a válaszokat. (%1$sKi is kapcsolhatod%2$s ezeket.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19767,14 +19716,12 @@ msgstr "A legtöbbször meglátogatott hivatkozások megjelenítése új lapon"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására a böngésződhöz"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
+msgstr "Alkalmi emlékeztetők megjelenítése a DuckDuckGo hozzáadására az eszközeidhez"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19792,8 +19739,7 @@ msgstr "Oldalszám megjelenítése a találati oldalak töréseinél"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
+msgstr "A DuckDuckGo adatvédelmi hírleveleire való feliratkozási űrlap megjelenítése"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19821,8 +19767,7 @@ msgstr "Üdvözlőüzenet megjelenítése a keresési találati oldal tetején"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
+msgstr "Üdvözlő üzenet megjelenítése az EU-s Android-preferencia menü felhasználóinak"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19899,8 +19844,7 @@ msgstr "Az oldalkeresés átmenetileg nem érhető el. Dolgozunk a megoldáson."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
+msgstr "Az általad blokkolt webhelyek el lesznek rejtve minden keresési találatból"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -21365,8 +21309,7 @@ msgstr "Koppints a címsorban található %1$sengedélyek ikonra%2$s"
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Tap the vertical dots in the DuckDuckGo app."
-msgstr ""
-"Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
+msgstr "Koppints a függőlegesen elhelyezkedő pontokra a DuckDuckGo alkalmazásban."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a teacher in its responses.
@@ -21545,21 +21488,18 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
+msgstr "A csatolt fájlok összmérete meghaladja a maximálisan megengedett %1$s MB-ot."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
+msgstr "A hanganyag feldolgozása sikertelen volt. Próbálkozz újra a felvétellel."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21771,8 +21711,7 @@ msgstr "Ezen a héten"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
+msgstr "Ez a csevegés a Duck.ai-ban marad, és megőrzi számodra privát jellegét."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21909,8 +21848,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt"
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21918,8 +21857,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy GIF-"
-"fájlt."
+"Ez a képtípus nem támogatott. Kérjük, csatolj egy JPG-, PNG-, WebP- vagy "
+"GIF-fájlt."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -22037,9 +21976,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok."
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -22049,9 +21988,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a duckduckgo."
-"com böngészési adatait, előfordulhat, hogy ismét megjelennek a mesterséges "
-"intelligencia segítségével generált válaszok. Ugyanakkor van egy "
+"Ez a beállítás a böngésződben kerül tárolásra, tehát ha törlöd a "
+"duckduckgo.com böngészési adatait, előfordulhat, hogy ismét megjelennek a "
+"mesterséges intelligencia segítségével generált válaszok. Ugyanakkor van egy "
 "kezdőoldalunk, amely soha nem jelenít meg AI-alapú válaszokat: %1$s."
 
 # smartling.placeholder_format=C
@@ -22095,8 +22034,7 @@ msgstr "Ez a videó még nem tekinthető meg itt. Megnézheted itt: %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
+msgstr "Ez a weboldal nem használ biztonságos, titkosított kapcsolatot (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22274,8 +22212,8 @@ msgid ""
 "you originally used to set up Sync."
 msgstr ""
 "A szinkronizált adatok visszaállításához szükség lesz a szinkronizálás első "
-"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód PDF-"
-"fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
+"beállításakor mentett helyreállítási kódra. Lehetséges, hogy ez a kód "
+"PDF-fájlként lett mentve a szinkronizálás beállításához eredetileg használt "
 "eszközre."
 
 # smartling.placeholder_format=C
@@ -22391,7 +22329,7 @@ msgstr "Túl lassú"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Túl lassú a generáláshoz"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22673,8 +22611,7 @@ msgstr "Próbálkozz ezzel: %1$s"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
+msgstr "Próbáld ki a(z) %1$s címet, hogy többé ne jelenjenek meg ilyen üzenetek."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22825,16 +22762,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
+msgstr "A pontosabb eredmények érdekében próbálkozz az anonim hely engedélyezésével."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
+msgstr "Próbálj kísérletezni az egyes modellekkel – különböző válaszokat generálnak."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22846,7 +22781,7 @@ msgstr "Próbálj kevesebb kulcsszót használni."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Ingyenes próba"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22892,8 +22827,7 @@ msgstr "Próbáld ki ingyen"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
+msgstr "Próbáld ki ingyen! Biztonságos VPN, fejlett és privát MI, és még sok más."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22932,8 +22866,7 @@ msgstr "Próbáld ki a böngészőnket,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
+msgstr "Próbáld ki a kezdőoldalunkat, ahol soha nem mutatjuk ezeket az üzeneteket:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23210,8 +23143,7 @@ msgstr "A pontosabb találatokhoz kapcsold be a %1$sPontos hely%2$s funkciót"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
+msgstr "Duck Player bekapcsolása a YouTube célzott hirdetések nélküli megtekintéséhez"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23444,8 +23376,7 @@ msgstr "Az %1$sÁltalános > Kezdőlap%2$s alatt írd be: https://duckduckgo.com
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
+msgstr "A %1$sKeresési beállítások%2$s alatt válaszd a %3$sDuckDuckGo%4$s lehetőséget"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23554,8 +23485,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb MI-"
-"érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
+"Válts Pro verzióra, hogy hozzáférj a(z) %1$s modellhez, a fejlettebb "
+"MI-érveléshez és a Plus csomagnál kétszer magasabb használati korlátokhoz."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23577,8 +23508,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el DuckDuckGo-"
-"előfizetéssel"
+"Fejlett MI-modelleket és nagyobb használati kereteket érhetsz el "
+"DuckDuckGo-előfizetéssel"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -24137,8 +24068,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Tekints meg egy Duck.ai-ból megosztott beszélgetést – ingyenes, privát AI-"
-"csevegés a DuckDuckGo kínálatában. Mentsd el a saját csevegéseid közé, és "
+"Tekints meg egy Duck.ai-ból megosztott beszélgetést – ingyenes, privát "
+"AI-csevegés a DuckDuckGo kínálatában. Mentsd el a saját csevegéseid közé, és "
 "folytasd privát módon."
 
 # smartling.placeholder_format=C
@@ -24243,9 +24174,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: %1$sDuck.ai-"
-"beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd válaszd a "
-"%7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
+"Nyisd meg a Duck.ai-t a másik böngésződben, és lépj ide: "
+"%1$sDuck.ai-beállítások%2$s > %3$sSync & Backup%4$s > %5$sKezelés%6$s, majd "
+"válaszd a %7$sSzinkronizálás másik eszközzel%8$s lehetőséget."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -24284,8 +24215,8 @@ msgstr ""
 "Látogass el a Duck.ai oldalra a másik böngésződben vagy a DuckDuckGo "
 "alkalmazásban, és nyisd meg a Duck.ai beállításait. Válaszd a „Bekapcsolás” "
 "lehetőséget a Sync & Backup alatt, és válaszd a „Szinkronizálás másik "
-"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található QR-"
-"kódot."
+"eszközzel” opciót. Vagy olvasd be a helyreállítási PDF-ben található "
+"QR-kódot."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24338,8 +24269,8 @@ msgstr "A hangcsevegés véget ért"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel MI-"
-"modellek betanítására."
+"A hangcsevegéseket anonim módon kezeljük, és soha nem használjuk fel "
+"MI-modellek betanítására."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24489,8 +24420,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott YouTube-"
-"hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube ajánlásait."
+"Nézd a tartalmat Duck Playerrel, hogy blokkold a személyre szabott "
+"YouTube-hirdetéseket, és a megtekintéseid ne befolyásolják a YouTube "
+"ajánlásait."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24559,16 +24491,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
+msgstr "Anonim%1$s helyed%2$s felhasználásával közeli eredményeket mutathatunk neked."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
+msgstr "Nem tudjuk olvasni a csatolt fájlokat, mert legalább az egyik titkosítva van."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24610,8 +24540,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
+msgstr "Nem követünk téged, ezért tőled kell megkérdeznünk, hogy mi járatban vagy:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24784,8 +24713,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
+msgstr "Blokkoljuk a böngészés közben adataid gyűjtésével próbálkozó nyomkövetőket."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24977,8 +24905,8 @@ msgid ""
 "anonymized by us and not used to train AI models."
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! Minden itt folytatott beszélgetésed privát, "
-"anonimizáljuk azokat, és nem használjuk fel mesterségesintelligencia-"
-"modellek tanítására."
+"anonimizáljuk azokat, és nem használjuk fel "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24990,15 +24918,14 @@ msgid ""
 msgstr ""
 "Üdvözöl a DuckDuckGo AI Chat! A csevegést a(z) %1$s %2$s technológiája "
 "szolgáltatja. Minden itt folytatott beszélgetésed privát, melyeket a "
-"DuckDuckGo soha nem tárol, és nem használ fel a mesterségesintelligencia-"
-"modellek tanítására."
+"DuckDuckGo soha nem tárol, és nem használ fel a "
+"mesterségesintelligencia-modellek tanítására."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
+msgstr "Üdvözöl az új Duck.ai! Mostantól importálhatod a letöltött csevegéseidet."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25097,8 +25024,7 @@ msgstr ""
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
+msgstr "Milyen látnivalókat érdemes megnézni Párizsban annak, aki először jár ott?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25485,8 +25411,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
+msgstr "Engedélyezés esetén a Duck.ai azonnali válaszokat jelenít meg a csevegésben."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25504,8 +25429,7 @@ msgstr "Hol nézhető meg a(z) <strong>%1$s</strong>?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
+msgstr "A kezdőoldalon kattints a %1$sJelenlegi oldal beállítása%2$s lehetőségre."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -26007,8 +25931,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
+msgstr "A DuckDuckGo AI Chat csevegője közvetlenül elérhető a következő címen: %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -26068,8 +25991,7 @@ msgstr "Ezt a %1$sKeresési beállítások%2$s oldalon bármikor módosíthatod"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
+msgstr "A csevegést folytathatod, miután a limited alaphelyzetbe áll ekkor: %1$s."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26108,8 +26030,7 @@ msgstr "A havi limit felhasználásával folytathatod a csevegést."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
+msgstr "Mostantól akár 100 csevegést is menthetsz ezen az eszközön. Csevegj bátran!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26382,8 +26303,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
+msgstr "Elérted az üzenetek pillanatnyi maximális számát. Próbálkozz újra később."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26654,22 +26574,19 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
+msgstr "A csevegések importálva lettek. Folytasd ott, ahol abbahagytad a Duck.ai-ban."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
 msgctxt "Description for the joiner-device success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the success screen after a successful pairing.
 msgctxt "Description for the success screen"
 msgid "Your chats will now sync between these devices."
-msgstr ""
-"A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
+msgstr "A beszélgetéseid mostantól szinkronizálódnak ezek között az eszközök között."
 
 # smartling.placeholder_format=C
 #. Description explaining why delegation is needed for image generation.
@@ -26827,8 +26744,7 @@ msgstr "A megosztott linkjeid itt találhatók: %1$s."
 #. Confirms the recovery succeeded. The Next CTA closes the sheet.
 msgctxt "Body copy on the recover-data success sheet"
 msgid "Your synced chats are being restored to this device."
-msgstr ""
-"A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
+msgstr "A szinkronizált csevegéseket a rendszer erre az eszközre állítja vissza."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26888,8 +26804,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
+msgstr "Elérted a napi üzenetek maximális számát. Holnap folytasd ezt a csevegést."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -27198,8 +27113,8 @@ msgstr "hivatalos webhely"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt %3$s-"
-"karakter)."
+"vagy írd ki a választott szín kódját, pl. %1$s (%2$s egy kódolt "
+"%3$s-karakter)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/hy_AM/LC_MESSAGES/duckduckgo.po
+++ b/locales/hy_AM/LC_MESSAGES/duckduckgo.po
@@ -2380,6 +2380,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5223,6 +5234,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5312,6 +5328,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6777,6 +6798,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7032,6 +7058,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7779,6 +7810,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8703,6 +8739,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12647,6 +12688,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17698,6 +17744,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18056,6 +18107,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -313,7 +313,8 @@ msgstr "Peringkat %1$s belum tersedia"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
+msgstr ""
+"%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -533,7 +534,8 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr ""
+"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -957,14 +959,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr ""
+"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1896,7 +1900,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr ""
+"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2238,7 +2243,8 @@ msgstr "Kapan pun"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr "Siapa saja yang memiliki tautan dapat melihat dan menyimpan salinan obrolan."
+msgstr ""
+"Siapa saja yang memiliki tautan dapat melihat dan menyimpan salinan obrolan."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2315,13 +2321,15 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr ""
+"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr ""
+"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2645,18 +2653,21 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr ""
+"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr ""
+"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2957,6 +2968,18 @@ msgid ""
 msgstr ""
 "Sebelum menyimpan laporan ini, DuckDuckGo akan menganonimkan percakapan "
 "dengan menghapus PII seperti nama, alamat email, dan metadata identifikasi."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3875,7 +3898,8 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr ""
+"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4002,8 +4026,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
-"%1$shttps://duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
+"duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4274,7 +4298,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr ""
+"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4666,7 +4691,8 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr ""
+"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4711,7 +4737,8 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr ""
+"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -6518,6 +6545,12 @@ msgid "Dislike source"
 msgstr "Tidak suka sumber"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Tutup"
@@ -6592,7 +6625,8 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr ""
+"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6626,6 +6660,12 @@ msgstr "Rekor Divisi"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djibouti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6872,8 +6912,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
-"orang-orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
+"orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -7045,7 +7085,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr ""
+"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7135,7 +7176,8 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr ""
+"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7184,7 +7226,8 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr ""
+"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7370,7 +7413,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr ""
+"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7682,9 +7726,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
-"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
-"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
+"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
+"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7913,7 +7957,8 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr ""
+"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8296,7 +8341,8 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr ""
+"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8490,6 +8536,12 @@ msgstr "WP"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Cepat"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8735,7 +8787,8 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr ""
+"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8806,7 +8859,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr ""
+"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8818,6 +8872,12 @@ msgstr "Pertanyaan lanjutan"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Pesan lanjutan tetap pribadi."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9037,8 +9097,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
-"Pembaruan</strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
+"strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9483,7 +9543,8 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
+msgstr ""
+"Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9562,7 +9623,8 @@ msgstr "Dapatkan aplikasinya"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
+msgstr ""
+"Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9760,6 +9822,12 @@ msgstr "Desain bagus"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Kebijakan privasi yang baik"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10718,7 +10786,8 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr ""
+"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10757,7 +10826,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr ""
+"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10903,6 +10973,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Petunjuk gambar harus sesuai dengan Duck.ai %1$s."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Potongan gambar"
@@ -11045,7 +11121,8 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr ""
+"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11537,7 +11614,8 @@ msgstr ""
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr ""
+"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -11950,8 +12028,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
-"Duck.ai"
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -13839,7 +13917,8 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr ""
+"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -15508,13 +15587,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr ""
+"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15769,10 +15850,17 @@ msgid "Poor formatting"
 msgstr "Pemformatan yang buruk"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
+msgstr ""
+"Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15998,7 +16086,8 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr ""
+"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16572,7 +16661,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
+msgstr ""
+"Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17331,7 +17421,8 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr ""
+"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17665,7 +17756,8 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr ""
+"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17893,7 +17985,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr ""
+"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18124,8 +18217,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di "
-"%1$sduckduckgo.com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
+"com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18290,7 +18383,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr ""
+"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18480,7 +18574,8 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr ""
+"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18599,7 +18694,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr ""
+"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19417,7 +19513,8 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
+msgstr ""
+"Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19494,7 +19591,8 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19510,18 +19608,21 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr ""
+"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr ""
+"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19559,7 +19660,8 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr ""
+"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19791,7 +19893,8 @@ msgstr "Terjadi kesalahan saat memuat obrolan yang dibagikan ini."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr ""
+"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20394,7 +20497,8 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr ""
+"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20697,7 +20801,8 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr ""
+"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20718,7 +20823,8 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr ""
+"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20772,7 +20878,8 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr ""
+"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21203,7 +21310,8 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr ""
+"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -21230,7 +21338,8 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr ""
+"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -21342,7 +21451,8 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr ""
+"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21639,14 +21749,16 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr ""
+"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21785,7 +21897,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
+msgstr ""
+"Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21820,7 +21933,8 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr ""
+"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21975,7 +22089,8 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr ""
+"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22007,8 +22122,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
-"DuckDuckGo-mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
+"mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22046,8 +22161,8 @@ msgstr "Beralih ke obrolan AI pribadi atau %1$snonaktifkan di pengaturan%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
-"%2$s.%3$s"
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22108,6 +22223,12 @@ msgstr "Terlalu banyak hasil dari sumber ini"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Terlalu lambat"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22552,6 +22673,12 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Coba kata kunci yang lebih pendek."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23134,7 +23261,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr ""
+"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23538,7 +23666,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr ""
+"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -24756,8 +24885,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
-"Duck.ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
+"ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24779,7 +24908,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr ""
+"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25779,7 +25909,8 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr ""
+"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -26157,7 +26288,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
+msgstr ""
+"Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26528,9 +26660,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
-"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
-"terinstal dan dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
+"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
+"dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/id_ID/LC_MESSAGES/duckduckgo.po
+++ b/locales/id_ID/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -313,8 +313,7 @@ msgstr "Peringkat %1$s belum tersedia"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
+msgstr "%1$s mencapai batas penggunaan 2-5x lebih cepat daripada model dasar. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -534,8 +533,7 @@ msgstr "%1$sTekan lama%2$s ikon aplikasi DuckDuckGo di layar beranda"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
+msgstr "%1$sUps!%2$s%3$sAda yang tidak beres. Silakan %4$srefresh%5$s dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -959,16 +957,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru AI Chat tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
+msgstr "Versi baru Duck.ai tersedia! Silakan refresh halaman ini untuk melanjutkan."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1900,8 +1896,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
+msgstr "Semua penyedia model dicegah melatih AI mereka menggunakan percakapan Anda."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -2243,8 +2238,7 @@ msgstr "Kapan pun"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr ""
-"Siapa saja yang memiliki tautan dapat melihat dan menyimpan salinan obrolan."
+msgstr "Siapa saja yang memiliki tautan dapat melihat dan menyimpan salinan obrolan."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2321,15 +2315,13 @@ msgstr "Apa kamu masih di sana?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
+msgstr "Apakah kamu yakin ingin menghapus semua obrolanmu? Ini tidak bisa dibatalkan."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
+msgstr "Apakah Anda yakin ingin menghapus percakapan ini dan memulai yang baru?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2653,21 +2645,18 @@ msgstr "Suara"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
+msgstr "Audio tidak disimpan oleh kami atau oleh OpenAI setelah obrolan berakhir."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
+msgstr "Audio tidak disimpan oleh kami atau OpenAI setelah obrolan ditranskripsikan."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2980,6 +2969,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Sebelum menyimpan laporan ini, DuckDuckGo akan menghapus file yang diunggah "
+"dan gambar yang dihasilkan, serta akan menganonimkan percakapan dengan "
+"menghapus PII seperti nama, alamat email, dan metadata identifikasi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3898,8 +3890,7 @@ msgstr "Mengubah warna latar belakang hasil hover, modul, dan menu dropdown"
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
+msgstr "Mengubah warna latar belakang saat mengarahkan kursor ke atas suatu hasil"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4026,8 +4017,8 @@ msgstr ""
 "anonim dengan model chat AI pihak ketiga, yang mendukung model dari OpenAI, "
 "Anthropic, dan lainnya. Menonaktifkan pengaturan ini akan menyembunyikan "
 "tombol dan tautan Chat di DuckDuckGo Search. Namun, Anda masih dapat "
-"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi %1$shttps://"
-"duck.ai%2$s langsung."
+"mengakses Chat saat setelan ini dinonaktifkan dengan mengunjungi "
+"%1$shttps://duck.ai%2$s langsung."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4298,8 +4289,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
+msgstr "Periksa halaman status untuk mendapatkan pembaruan mengenai gangguan ini."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4691,8 +4681,7 @@ msgstr "Klik %1$sDi sini%2$s untuk mengunduh ekstensi DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
+msgstr "Klik %1$sBuka%2$s untuk mengunduh dan membuka ekstensi DuckDuckGo di Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4737,8 +4726,7 @@ msgstr "Klik %1$sYa%2$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
+msgstr "Klik %1$spengaturan/ikon hamburger %2$s di bilah alat Chrome (kanan atas)."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -6548,7 +6536,7 @@ msgstr "Tidak suka sumber"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Tidak suka gaya visual"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6625,8 +6613,7 @@ msgstr "Bahasa Tampilan"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Displays a checkmark to the left of results you've visited"
-msgstr ""
-"Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
+msgstr "Menampilkan tanda centang di sebelah kiri hasil yang telah kamu kunjungi"
 
 # smartling.placeholder_format=C
 #. This is the description of a user setting
@@ -6665,7 +6652,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Tidak mengikuti instruksi"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6912,8 +6899,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"Buatlah beberapa opsi untuk postingan media sosial yang mengundang orang-"
-"orang ke pesta saya yang akan datang."
+"Buatlah beberapa opsi untuk postingan media sosial yang mengundang "
+"orang-orang ke pesta saya yang akan datang."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -7085,8 +7072,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
+msgstr "Duck.ai adalah yang terbaik di browser DuckDuckGo pribadi dan gratis kami!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7176,8 +7162,7 @@ msgstr ""
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
 msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid "Duck.ai may display inaccurate or offensive information."
-msgstr ""
-"Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
+msgstr "Duck.ai mungkin menampilkan informasi yang tidak akurat atau menyinggung."
 
 # smartling.placeholder_format=C
 #. Error modal body line 2.
@@ -7226,8 +7211,7 @@ msgstr "Duck.ai ditingkatkan!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
+msgstr "Duck.ai bekerja paling baik di aplikasi DuckDuckGo pribadi dan gratis kamu!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7413,8 +7397,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
+msgstr "DuckDuckGo AI Chat untuk sementara tidak tersedia. Silakan coba lagi nanti."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7726,9 +7709,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi kata-"
-"kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 kata "
-"acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
+"Tiap kali kamu meminta saran frasa sandi, kami menerima daftar berisi "
+"kata-kata acak dari server DuckDuckGo. Di browser, kami kemudian memilih 4—5 "
+"kata acak dari daftar itu, dengan memastikan bahwa frasa sandinya minimal "
 "sepanjang 18—20 karakter."
 
 # smartling.placeholder_format=C
@@ -7957,8 +7940,7 @@ msgstr "Aktifkan Dikte dalam Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
+msgstr "Aktifkan pengaturan lokasi di perangkatmu untuk menggunakan lokasi anonim"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8341,8 +8323,7 @@ msgstr "Jelaskan jawaban yang diterima dengan bahasa yang sederhana."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
+msgstr "Jelaskan konsep dasar lubang hitam kepada saya di tingkat sekolah menengah."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8541,7 +8522,7 @@ msgstr "Cepat"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Pembuatan gambar cepat"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8787,8 +8768,7 @@ msgstr "Temukan hasil yang lebih dekat dari lokasimu."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
+msgstr "Temukan hasil di dekatmu. %1$sLokasimu tetap pribadi, aman, dan anonim."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8859,8 +8839,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
+msgstr "Ikuti langkah-langkah berikut untuk memindahkan obrolanmu ke Duck.ai baru"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8877,7 +8856,7 @@ msgstr "Pesan lanjutan tetap pribadi."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Mengikuti petunjuk"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9097,8 +9076,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Dari bilah menu aplikasi di Mac, pilih <strong>DuckDuckGo</strong> &gt; "
-"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal Pembaruan</"
-"strong>."
+"<strong>Periksa Pembaruan...</strong>, lalu pilih <strong>Instal "
+"Pembaruan</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9543,8 +9522,7 @@ msgstr "Dapatkan bantuan komputer"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
+msgstr "Dapatkan batas penggunaan yang lebih tinggi dengan langganan DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9623,8 +9601,7 @@ msgstr "Dapatkan aplikasinya"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
+msgstr "Dapatkan Browser DuckDuckGo gratis %1$suntuk memblokir iklan di YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9827,7 +9804,7 @@ msgstr "Kebijakan privasi yang baik"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Gaya visual bagus"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10786,8 +10763,7 @@ msgstr "Saya tidak paham informasi ini"
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
 msgid "I don’t want to see any information from DuckDuckGo on this page"
-msgstr ""
-"Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
+msgstr "Saya tidak ingin melihat informasi apa pun dari DuckDuckGo di halaman ini"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -10826,8 +10802,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
+msgstr "Saya memerlukan bantuan/informasi lebih lanjut tentang cara menggunakan Chat"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10976,7 +10951,7 @@ msgstr "Petunjuk gambar harus sesuai dengan Duck.ai %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Kualitas gambar"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11121,8 +11096,7 @@ msgstr "Di menu atas, pilih %1$sAlat%2$s > %3$sPengaturan%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
+msgstr "Di dalam popup, centang %1$sJadikan sebagai mesin pencari default saya%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11614,8 +11588,7 @@ msgstr ""
 #. An instruction to state that a list of companies/trackers will be updated with continued use
 msgctxt "tracker_stats"
 msgid "Keep browsing to see how many we block"
-msgstr ""
-"Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
+msgstr "Teruslah menjelajah untuk melihat jumlah perusahaan/pelacak yang kami blokir"
 
 # smartling.placeholder_format=C
 #. Header above social media links.
@@ -12028,8 +12001,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke Duck."
-"ai"
+"Memungkinkan beralih antara mengirimkan kueri pencarian dan perintah ke "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -13917,8 +13890,7 @@ msgstr "Hasil tidak ditemukan."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
+msgstr "Tidak ada ucapan yang terdeteksi. Coba lagi dan bicaralah ke mikrofonmu."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -15587,15 +15559,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan berbahaya atau ilegal. (opsional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
+msgstr "Tolong jelaskan mengapa respons obrolan ilegal atau berbahaya. (Opsional)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15853,14 +15823,13 @@ msgstr "Pemformatan yang buruk"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Kualitas gambar yang buruk"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
+msgstr "Model AI populer tersedia. Tidak perlu akun. Obrolan dianonimkan oleh kami."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16086,8 +16055,7 @@ msgstr "Harga"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
+msgstr "Harga yang ditampilkan berbeda dengan yang ditampilkan di situs penjual"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16661,8 +16629,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
+msgstr "Penalaran lebih menyeluruh, tetapi menggunakan batas 2-5x lebih cepat. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17421,8 +17388,7 @@ msgstr "Hasil mengecualikan informasi dari situs yang diblokir."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
+msgstr "Hasil tidak termasuk situs yang kamu blokir, yang dapat kamu kelola di %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17756,8 +17722,7 @@ msgstr "Simpan dan Keluar"
 #. Description explaining that sync allows saving more chats than local browser storage.
 msgctxt "Sync feature benefit description"
 msgid "Save more chats than you can in your web browser."
-msgstr ""
-"Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
+msgstr "Simpan lebih banyak obrolan daripada yang kamu bisa di browser web kamu."
 
 # smartling.placeholder_format=C
 #. List item explaining that users can save more chats when Sync & Backup is enabled.
@@ -17985,8 +17950,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
+msgstr "Gulir ke bawah ke bagian %1$sLayanan%2$s, lalu klik %3$sBilah alamat%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18217,8 +18181,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "Cari secara pribadi dengan aplikasi atau ekstensi kami, tambahkan pencarian "
-"web pribadi ke browser favoritmu, atau cari langsung di %1$sduckduckgo."
-"com%2$s."
+"web pribadi ke browser favoritmu, atau cari langsung di "
+"%1$sduckduckgo.com%2$s."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18383,8 +18347,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
+msgstr "Tersimpan dengan aman di server DuckDuckGo dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18574,8 +18537,7 @@ msgstr "Pilih %1$sDuckDuckGo%2$s di menu dropdown Mesin Pencari Default"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
+msgstr "Pilih %1$sDuckDuckGo%2$s dalam daftar dan %3$sbolehkan%4$s akses lokasi"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18694,8 +18656,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
+msgstr "Pilih %1$sbrowser Anda%2$s dalam daftar dan %3$sizinkan akses lokasi%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19513,8 +19474,7 @@ msgstr "Tampilkan bilah samping"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
+msgstr "Tunjukkan tips langkah demi langkah untuk memaksimalkan penggunaan Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19591,8 +19551,7 @@ msgstr "Menampilkan garis horizontal di pemisah halaman hasil"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
+msgstr "Menampilkan tautan ke petunjuk cara menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19608,21 +19567,18 @@ msgstr "Menampilkan tautan yang paling banyak dikunjungi di halaman tab baru"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke browser-mu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
+msgstr "Sesekali menampilkan pengingat untuk menambahkan DuckDuckGo ke perangkatmu"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
+msgstr "Sesekali menampilkan pengingat untuk mendaftar ke nawala privasi DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19660,8 +19616,7 @@ msgstr "Menampilkan pesan selamat datang di atas halaman hasil pencarian"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
+msgstr "Menampilkan pesan selamat datang kepada pengguna menu preferensi Android UE"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19893,8 +19848,7 @@ msgstr "Terjadi kesalahan saat memuat obrolan yang dibagikan ini."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
+msgstr "Terjadi kesalahan saat proses penyimpanan ke server. Silakan coba lagi."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20497,8 +20451,7 @@ msgstr "Sarankan judul untuk postingan blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
+msgstr "Sarankan artikel atau topik terkait yang layak Anda jelajahi selanjutnya."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20801,8 +20754,7 @@ msgstr "Beralih ke model yang lebih efisien"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
+msgstr "Beralihlah ke mesin pencari yang tidak akan pernah melacakmu. Selamanya."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20823,8 +20775,7 @@ msgstr "Beralih ke %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
+msgstr "Beralih akan mengirim obrolan kamu ke model tanpa visibilitas penyedia nol"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20878,8 +20829,7 @@ msgstr "Sync & Backup Diaktifkan!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
+msgstr "Data Sync & Backup tidak dapat dipulihkan setelah 18 bulan tidak aktif."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21310,8 +21260,7 @@ msgstr "Thailand (en)"
 #. Message displayed after the user has submitted feedback. It invites the user to share more feedback.
 msgctxt "Feedback toast"
 msgid "Thank you for your feedback. Have more to share?"
-msgstr ""
-"Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
+msgstr "Terima kasih atas masukan kamu. Apakah kamu punya hal lain untuk dibagikan?"
 
 # smartling.placeholder_format=C
 msgid "Thank you!"
@@ -21338,8 +21287,7 @@ msgstr "Terima kasih atas masukanmu!"
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "Thanks for your patience while we get our ducks in a row!"
-msgstr ""
-"Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
+msgstr "Terima kasih atas kesabaran Anda sementara kami menyelesaikan semuanya!"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and we are unable to show any results.
@@ -21451,8 +21399,7 @@ msgstr "Permintaan tersebut mengalami batas waktu. Silakan coba lagi."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
+msgstr "Server mengalami kesalahan dan tidak dapat menyelesaikan permintaan Anda."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21749,16 +21696,14 @@ msgstr "Gambar ini tidak dapat dibuat."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
+msgstr "Jenis gambar ini tidak didukung, tolong lampirkan JPG, PNG, WebP, atau GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21897,8 +21842,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
+msgstr "Obrolan yang dibagikan ini tidak dapat dibuka. Tautan mungkin tidak lengkap."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21933,8 +21877,7 @@ msgstr "Video ini belum bisa ditonton di sini. Kamu bisa menontonnya di %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
+msgstr "Halaman web ini tidak menggunakan koneksi yang aman dan terenkripsi (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22089,8 +22032,7 @@ msgstr "Untuk melanjutkan, kamu harus menyetujui %1$s dan %2$sDuck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
+msgstr "Untuk melanjutkan, Anda harus menyetujui %1$s dan %2$sDuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22122,8 +22064,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser DuckDuckGo-"
-"mu ke versi terbaru dan coba lagi."
+"Untuk mentransfer riwayat obrolanmu ke Duck.ai, perbarui browser "
+"DuckDuckGo-mu ke versi terbaru dan coba lagi."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22161,8 +22103,8 @@ msgstr "Beralih ke obrolan AI pribadi atau %1$snonaktifkan di pengaturan%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu %2$s."
-"%3$s"
+"Beralih untuk mencoba obrolan AI pribadi atau %1$snonaktifkan di menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22228,7 +22170,7 @@ msgstr "Terlalu lambat"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Terlalu lambat dibuat"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22678,7 +22620,7 @@ msgstr "Coba kata kunci yang lebih pendek."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Coba Gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23261,8 +23203,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
+msgstr "Di bagian %1$sMEMULAI > Halaman beranda%2$s, masukkan: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23666,8 +23607,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
+msgstr "Tingkatkan ke Pro untuk membuka batas penggunaan 2x lebih tinggi dari Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -24885,8 +24825,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat Duck."
-"ai. Coba muat ulang halaman."
+"Kami benar-benar minta maaf, tetapi tampaknya ada masalah saat memuat "
+"Duck.ai. Coba muat ulang halaman."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24908,8 +24848,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
+msgstr "Apa saja faktor yang perlu dipertimbangkan saat membeli monitor komputer?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25909,8 +25848,7 @@ msgstr "Kamu bisa menemukan file <b>%1$s</b> di folder unduhanmu."
 # smartling.placeholder_format=C
 #. A link to the settings to where the user can hide the private search reminder from the filter bar of search results
 msgid "You can hide this reminder in %sSearch Settings%s"
-msgstr ""
-"Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
+msgstr "Anda dapat menyembunyikan pengingat ini di %1$sPengaturan Pencarian%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -26288,8 +26226,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
+msgstr "Obrolan Duck.ai kamu sedang disinkronkan dengan enkripsi ujung ke ujung."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26660,9 +26597,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami alih-"
-"alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah terinstal dan "
-"dapat:"
+"Anda sedang menelusuri secara pribadi di Chrome. Gunakan browser kami "
+"alih-alih Chrome untuk perlindungan yang lebih baik. Aplikasi sudah "
+"terinstal dan dapat:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/io_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/io_XX/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6759,6 +6780,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7014,6 +7040,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7761,6 +7792,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8681,6 +8717,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12615,6 +12656,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17656,6 +17702,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18014,6 +18065,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/is_IS/LC_MESSAGES/duckduckgo.po
+++ b/locales/is_IS/LC_MESSAGES/duckduckgo.po
@@ -2373,6 +2373,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5216,6 +5227,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Hunsa"
@@ -5305,6 +5321,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6763,6 +6784,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7016,6 +7042,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7763,6 +7794,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8683,6 +8719,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12621,6 +12662,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17672,6 +17718,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18031,6 +18082,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prófaðu færri leitarorð."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -532,8 +532,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -892,8 +891,7 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1022,8 +1020,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
-"aichat%2$s."
+"anche quando questa impostazione è disattivata visitando "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1094,8 +1092,7 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr ""
-"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1512,8 +1509,7 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr ""
-"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1996,8 +1992,7 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2261,8 +2256,7 @@ msgstr "Qualsiasi data"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr ""
-"Chiunque abbia il link può visualizzare e salvare una copia della chat."
+msgstr "Chiunque abbia il link può visualizzare e salvare una copia della chat."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2675,15 +2669,13 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2988,8 +2980,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
-"mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi "
+"e-mail e metadati identificativi."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -3002,6 +2994,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Prima di archiviare questo report, DuckDuckGo rimuoverà i file caricati e le "
+"immagini generate e renderà anonima la tua conversazione eliminando le "
+"informazioni personali, come nomi, indirizzi e-mail e metadati "
+"identificativi."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3137,14 +3133,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr ""
-"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -4826,8 +4820,7 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4880,21 +4873,18 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr ""
-"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr ""
-"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5538,8 +5528,7 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5651,8 +5640,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6590,7 +6578,7 @@ msgstr "Non mi piace la fonte"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Non mi piace lo stile visivo"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6706,7 +6694,7 @@ msgstr "Gibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Non segue le istruzioni"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7169,8 +7157,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
-"mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
+"un'e-mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7263,8 +7251,7 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -8133,8 +8120,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8186,15 +8172,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8478,8 +8462,7 @@ msgstr "Esplora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8598,7 +8581,7 @@ msgstr "Veloce"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Generazione rapida di immagini"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8936,7 +8919,7 @@ msgstr "Le domande di approfondimento restano private."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Ha seguito le istruzioni"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9072,8 +9055,7 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9516,8 +9498,7 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9886,7 +9867,7 @@ msgstr "Privacy policy soddisfacente"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Stile visivo soddisfacente"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10076,8 +10057,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10472,8 +10452,7 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10723,8 +10702,7 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10974,8 +10952,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11038,7 +11015,7 @@ msgstr "I prompt per le immagini devono rispettare i %1$s di Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Qualità dell'immagine"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11184,8 +11161,7 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12203,8 +12179,7 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12315,8 +12290,7 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13104,8 +13078,7 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14009,15 +13982,13 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -15662,15 +15633,13 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15928,7 +15897,7 @@ msgstr "Formattazione insufficiente"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Qualità dell'immagine insufficiente"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16465,8 +16434,7 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16772,8 +16740,7 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -17096,8 +17063,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
-"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
+"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17114,8 +17081,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr ""
-"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17869,8 +17835,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
-"end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18420,8 +18386,7 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18471,8 +18436,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18481,8 +18446,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
-"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
+"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18637,27 +18602,24 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
-"com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18772,8 +18734,7 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18869,8 +18830,7 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19690,14 +19650,12 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr ""
-"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19718,8 +19676,7 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19848,8 +19805,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19996,8 +19952,7 @@ msgstr "Si è verificato un errore"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr ""
-"Si è verificato un errore durante il caricamento di questa chat condivisa."
+msgstr "Si è verificato un errore durante il caricamento di questa chat condivisa."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -20009,8 +19964,7 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20040,8 +19994,7 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20117,8 +20070,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20431,8 +20383,7 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20915,8 +20866,7 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr ""
-"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20937,8 +20887,7 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -21002,8 +20951,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup salva più chat e le sincronizza su tutti i tuoi dispositivi."
+msgstr "Sync & Backup salva più chat e le sincronizza su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21063,8 +21011,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
-"ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
+"Duck.ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -21868,8 +21816,7 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21967,8 +21914,7 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -22020,8 +21966,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
+msgstr "Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -22279,16 +22224,15 @@ msgstr "Oggi"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Attiva la chat AI privata oppure %1$sdisabilitala nelle impostazioni%2$s."
+msgstr "Attiva la chat AI privata oppure %1$sdisabilitala nelle impostazioni%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu %2$s."
-"%3$s"
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22354,7 +22298,7 @@ msgstr "Troppo lento"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Troppo lento a generare"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22459,8 +22403,7 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22476,8 +22419,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22792,8 +22734,7 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22805,7 +22746,7 @@ msgstr "Prova con meno parole chiave."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Provala gratuitamente"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23376,8 +23317,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
-"duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23406,8 +23347,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
-"%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
+"ricerca...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23421,8 +23362,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -24113,8 +24053,7 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24534,8 +24473,7 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24704,8 +24642,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24949,8 +24886,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25176,8 +25112,7 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25404,8 +25339,7 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -26014,8 +25948,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26242,8 +26175,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26340,8 +26272,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26353,8 +26284,7 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26424,8 +26354,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
-"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia end-"
-"to-end."
+"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia "
+"end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26805,8 +26735,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26840,8 +26769,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26930,8 +26858,7 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/it_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/it_IT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -532,7 +532,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
+msgstr ""
+"%1$sPremi a lungo%2$s l'icona dell'app DuckDuckGo nella schermata principale"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -891,7 +892,8 @@ msgstr "Limite di utilizzo di 6 ore raggiunto."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo di 6 ore raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1020,8 +1022,8 @@ msgstr ""
 "AI Chat consente di conversare in modo anonimo con modelli di chat di terze "
 "parti dotati di intelligenza artificiale. Disattivando questa funzione, AI "
 "Chat verrà nascosta su DuckDuckGo Search. È comunque possibile accedervi "
-"anche quando questa impostazione è disattivata visitando "
-"%1$sduckduckgo.com/aichat%2$s."
+"anche quando questa impostazione è disattivata visitando %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1092,7 +1094,8 @@ msgstr ""
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
 msgctxt "duckassist"
 msgid "AI-assisted answers have been turned off!"
-msgstr "Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
+msgstr ""
+"Le risposte assistite dall'intelligenza artificiale sono state disattivate!"
 
 # smartling.placeholder_format=C
 #. Negative feedback suggestion for when user dislikes AI-generated content
@@ -1509,7 +1512,8 @@ msgstr "Aggiungi una casella di ricerca di %1$s al tuo sito!"
 #. Prompt to add locations on a map in order to get directions.
 msgctxt "directions"
 msgid "Add a starting point and destination to find a route."
-msgstr "Aggiungi un punto di partenza e una destinazione per trovare un percorso."
+msgstr ""
+"Aggiungi un punto di partenza e una destinazione per trovare un percorso."
 
 # smartling.placeholder_format=C
 #. Label on the AI model card indicating the model supports file uploads.
@@ -1992,7 +1996,8 @@ msgstr "Vuoi consentire la revisione anonima dei file per questa chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
+msgstr ""
+"Consenti annunci che rispettano la privacy su Private Search DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2256,7 +2261,8 @@ msgstr "Qualsiasi data"
 msgctxt ""
 "Share modal info bullet about public access, shown once the link exists"
 msgid "Anyone with the link can view and save a copy of the chat."
-msgstr "Chiunque abbia il link può visualizzare e salvare una copia della chat."
+msgstr ""
+"Chiunque abbia il link può visualizzare e salvare una copia della chat."
 
 # smartling.placeholder_format=C
 msgid "Anywhere"
@@ -2669,13 +2675,15 @@ msgstr "Audio"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
+msgstr ""
+"L'audio non viene memorizzato né da noi né da OpenAI dopo la fine della chat."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2980,8 +2988,20 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Prima di archiviare questo rapporto, DuckDuckGo renderà anonima la tua "
-"conversazione eliminando le informazioni personali, come nomi, indirizzi "
-"e-mail e metadati identificativi."
+"conversazione eliminando le informazioni personali, come nomi, indirizzi e-"
+"mail e metadati identificativi."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3117,12 +3137,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
+msgstr ""
+"L'elenco dei blocchi non è esaustivo e potrebbe contenere imprecisioni."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block most trackers as you browse."
-msgstr "Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
+msgstr ""
+"Blocca la maggior parte dei sistemi di tracciamento durante la navigazione."
 
 # smartling.placeholder_format=C
 #. Menu option to block a site from the displayed results
@@ -4804,7 +4826,8 @@ msgstr "Clicca sulla %1$slente di ingrandimento%2$s nella barra di ricerca"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
+msgstr ""
+"Clicca sulla lente di ingrandimento nella casella di ricerca in alto a destra"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4857,18 +4880,21 @@ msgstr "Clicca sui %1$spuntini di sospensione%2$s nella barra degli strumenti."
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %slock icon%s on the address bar."
-msgstr "Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
+msgstr ""
+"Clicca sull'%1$sicona di blocco%2$s presente nella barra degli indirizzi."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Click the %spermissions icon%s in the address bar"
-msgstr "Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
+msgstr ""
+"Clicca sull'%1$sicona delle autorizzazioni%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
+msgstr ""
+"Clicca sull'icona dell'anatra in alto nel browser per effettuare una ricerca!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -5512,7 +5538,8 @@ msgstr "Copia"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
+msgstr ""
+"Copia e incolla %1$sabout:preferences#search%2$s nella barra degli indirizzi"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5624,7 +5651,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
+msgstr ""
+"Impossibile caricare il codice di recupero. Chiudi questa finestra e riprova."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6559,6 +6587,12 @@ msgid "Dislike source"
 msgstr "Non mi piace la fonte"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Chiudi"
@@ -6667,6 +6701,12 @@ msgstr "Record girone"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Gibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7129,8 +7169,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai non è al momento disponibile. Se il problema persiste, invia "
-"un'e-mail con il codice anonimo %1$s a %2$s"
+"Duck.ai non è al momento disponibile. Se il problema persiste, invia un'e-"
+"mail con il codice anonimo %1$s a %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7223,7 +7263,8 @@ msgstr "Duck.ai è stato aggiornato!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
+msgstr ""
+"Duck.ai funziona al meglio nella nostra app DuckDuckGo, privata e gratuita!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -8092,7 +8133,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
+msgstr ""
+"Assicurati che l'opzione \"Servizi di localizzazione\" sia %1$sattivata%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8144,13 +8186,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
+msgstr ""
+"Assicurati che il tuo browser sia autorizzato ad accedere alla posizione."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8434,7 +8478,8 @@ msgstr "Esplora Duck.ai"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
+msgstr ""
+"Esplora gli ultimi aggiornamenti di prodotti e funzionalità di DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8548,6 +8593,12 @@ msgstr "FT"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Veloce"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8882,6 +8933,12 @@ msgid "Follow-ups remain private."
 msgstr "Le domande di approfondimento restano private."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -9015,7 +9072,8 @@ msgstr "Condivisione e uso commerciale gratuiti"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
+msgstr ""
+"Libera spazio eliminando le chat. Le chat fissate non verranno eliminate."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9458,7 +9516,8 @@ msgstr "Iniziamo"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
+msgstr ""
+"Ottieni una VPN + altre due protezioni in un unico semplice abbonamento."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9824,6 +9883,12 @@ msgid "Good privacy policy"
 msgstr "Privacy policy soddisfacente"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
 msgctxt "shortbelieve"
 msgid "Goodies"
@@ -10011,7 +10076,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
+msgstr ""
+"Indicami i passaggi fondamentali per la sostituzione di un tergicristallo."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10406,7 +10472,8 @@ msgstr "Nascondi il tuo indirizzo e-mail"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
+msgstr ""
+"Nasconde i termini di ricerca dalla scheda e dalla cronologia del browser"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10656,7 +10723,8 @@ msgstr "Come funziona"
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
+msgstr ""
+"Quanto vuoi che appaiano le risposte assistite dall'intelligenza artificiale?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10906,7 +10974,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
+msgstr ""
+"Se vuoi supportarci in altri modi, %1$saiuta a diffondere DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10964,6 +11033,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "I prompt per le immagini devono rispettare i %1$s di Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11109,7 +11184,8 @@ msgstr "Nel menu in alto seleziona %1$sStrumenti%2$s > %3$sImpostazioni%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
+msgstr ""
+"Nel popup, seleziona %1$sImposta come provider di ricerca predefinito%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -12127,7 +12203,8 @@ msgstr "Link:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
+msgstr ""
+"Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12238,7 +12315,8 @@ msgstr "Carica altre immagini durante lo scorrimento"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
+msgstr ""
+"Carica altri risultati in Immagini, Video e Shopping durante lo scorrimento"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13026,7 +13104,8 @@ msgstr "Limite mensile raggiunto"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
+msgstr ""
+"Limite di utilizzo mensile raggiunto. Puoi continuare questa chat dopo %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13930,13 +14009,15 @@ msgstr "Nessun sistema di tracciamento bloccato nell'ultima ora"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching!"
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche!"
 
 # smartling.placeholder_format=C
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
+msgstr ""
+"Nessun tracciamento, nessuna pubblicità mirata, solo semplici ricerche."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -15581,13 +15662,15 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
+msgstr ""
+"Descrivi perché la risposta nella chat è dannosa o illegale. (facoltativo)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
+msgstr ""
+"Descrivi perché la risposta nella chat è illegale o dannosa. (Opzionale)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15840,6 +15923,12 @@ msgstr "Polacco"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Formattazione insufficiente"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16376,7 +16465,8 @@ msgstr "Proteggi i tuoi dati durante le ricerche e la navigazione."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
+msgstr ""
+"Proteggi i tuoi dati durante le ricerche, la navigazione e l'uso dell'AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16682,7 +16772,8 @@ msgstr "Schede recenti"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
+msgstr ""
+"Lo spazio di archiviazione delle chat recenti può essere regolato in %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -17005,8 +17096,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante "
-"&quot;Aggiorna&quot; o &quot;Ricarica&quot; del browser."
+"Ricarica DuckDuckGo seguendo le istruzioni o facendo clic sul pulsante &quot;"
+"Aggiorna&quot; o &quot;Ricarica&quot; del browser."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17023,7 +17114,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
 msgid "Remember my choice (this can be changed in %sSettings%s)"
-msgstr "Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
+msgstr ""
+"Ricorda la mia scelta (può essere modificata nelle %1$sImpostazioni%2$s)"
 
 # smartling.placeholder_format=C
 #. Button to be reminded later to update, shown in a banner that appears in Duck.ai when a subscribed user is using an old version of the DuckDuckGo browser.
@@ -17777,8 +17869,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia "
-"end-to-end."
+"Salva le tue chat di Duck.ai tra i tuoi dispositivi con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18328,7 +18420,8 @@ msgstr "Seconda opinione"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
+msgstr ""
+"Salva e sincronizza in modo sicuro le tue chat su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18378,8 +18471,8 @@ msgstr ""
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18388,8 +18481,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia "
-"end-to-end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
+"Archiviati in modo sicuro sul server di DuckDuckGo con crittografia end-to-"
+"end. Nessuno tranne te può vedere i tuoi dati, nemmeno noi."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18544,24 +18637,27 @@ msgstr ""
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Scegli %1$sPersonalizzata%2$s e digita nel campo "
-"%3$shttps://duckduckgo.com%4$s"
+"Scegli %1$sPersonalizzata%2$s e digita nel campo %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sAggiungi come predefinito%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
+msgstr ""
+"Seleziona %1$sDuckDuckGo%2$s e clicca su %3$sImposta come predefinito%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18676,7 +18772,8 @@ msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sImpostazioni avanzate%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
+msgstr ""
+"Seleziona %1$sImpostazioni%2$s, poi %3$sMotore di ricerca predefinito%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18772,7 +18869,8 @@ msgstr "Testo selezionato da %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
+msgstr ""
+"Il testo selezionato è troppo lungo. Riprova con una selezione più breve."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19592,12 +19690,14 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows horizontal lines at result page breaks"
-msgstr "Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
+msgstr ""
+"Mostra linee orizzontali a ogni interruzione della pagina dei risultati"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
+msgstr ""
+"Mostra link per le istruzioni su come aggiungere DuckDuckGo al tuo browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19618,7 +19718,8 @@ msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo al tuo browser"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
+msgstr ""
+"Mostra promemoria occasionali per aggiungere DuckDuckGo ai tuoi dispositivi"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19747,7 +19848,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
+msgstr ""
+"I siti che blocchi saranno nascosti da tutti i tuoi risultati di ricerca"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19894,7 +19996,8 @@ msgstr "Si è verificato un errore"
 #. Error toast shown when a shared chat cannot be opened and no more specific reason is available.
 msgctxt "Generic toast for share view load failures"
 msgid "Something went wrong loading this shared chat."
-msgstr "Si è verificato un errore durante il caricamento di questa chat condivisa."
+msgstr ""
+"Si è verificato un errore durante il caricamento di questa chat condivisa."
 
 # smartling.placeholder_format=C
 #. Error message indicating that the user's settings weren't able to be saved.
@@ -19906,7 +20009,8 @@ msgstr "Qualcosa è andato storto durante il salvataggio nel server, riprova."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
+msgstr ""
+"Si è verificato un problema durante l'attivazione di Sync & Backup. Riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19936,7 +20040,8 @@ msgstr "A volte"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
+msgstr ""
+"Mi dispiace, non posso aiutarti. Descrivi la tua immagine in un modo diverso."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20012,7 +20117,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
+msgstr ""
+"Spiacenti, non siamo riusciti a inviare il tuo feedback. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20325,7 +20431,8 @@ msgstr "Interrompi la generazione"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
+msgstr ""
+"Impedisci ai sistemi di tracciamento nascosti di apparire su altri siti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20808,7 +20915,8 @@ msgstr "Passa a un modello più efficiente"
 # smartling.placeholder_format=C
 #. Text prompting  users to switch their current search engine to the DuckDuckGo private search engine.
 msgid "Switch to the search engine that doesn't track you. Ever."
-msgstr "Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
+msgstr ""
+"Passa al motore di ricerca che non raccoglie i tuoi dati di navigazione. Mai."
 
 # smartling.placeholder_format=C
 #. Re-activates a stacked second opinion, making it the current answer again.
@@ -20829,7 +20937,8 @@ msgstr "Passato a %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
+msgstr ""
+"Il passaggio invierà la chat a un modello senza visibilità zero lato provider"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20893,7 +21002,8 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup salva più chat e le sincronizza su tutti i tuoi dispositivi."
+msgstr ""
+"Sync & Backup salva più chat e le sincronizza su tutti i tuoi dispositivi."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20953,8 +21063,8 @@ msgstr ""
 "%1$s\n"
 "\n"
 "Come funziona il codice?\n"
-"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di "
-"Duck.ai.\n"
+"1. Apri il browser e vai su Duck.ai, quindi apri le impostazioni di Duck."
+"ai.\n"
 "2. Seleziona \"Attiva Sync & Backup\", poi \"Recupera dati sincronizzati\"\n"
 "3. Copia il codice di recupero sopra e incollalo nello spazio \"Incolla qui "
 "il tuo codice\"\n"
@@ -21758,7 +21868,8 @@ msgstr "Questa immagine non può essere creata."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
+msgstr ""
+"Questo tipo di immagine non è supportato, allega un file JPG, PNG, WebP o GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21856,7 +21967,8 @@ msgstr "Questa pagina richiede Javascript per funzionare."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
+msgstr ""
+"Il contenuto di questa pagina verrà inviato con il tuo messaggio a Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21908,7 +22020,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
+msgstr ""
+"Impossibile aprire questa chat condivisa. Il link potrebbe essere incompleto."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -22166,15 +22279,16 @@ msgstr "Oggi"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Attiva la chat AI privata oppure %1$sdisabilitala nelle impostazioni%2$s."
+msgstr ""
+"Attiva la chat AI privata oppure %1$sdisabilitala nelle impostazioni%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu "
-"%2$s.%3$s"
+"Attiva per provare la chat AI privata oppure %1$sdisabilitala nel menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22235,6 +22349,12 @@ msgstr "Troppi risultati da questa fonte"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Troppo lento"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22339,7 +22459,8 @@ msgstr "Sistemi di tracciamento bloccati nell'ultima ora"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
+msgstr ""
+"I sistemi di tracciamento bloccati da DuckDuckGo vengono visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22355,7 +22476,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
+msgstr ""
+"I tentativi di tracciamento bloccati da DuckDuckGo verranno visualizzati qui"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22670,13 +22792,20 @@ msgstr "Prova ad abilitare la posizione anonima per risultati più accurati."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
+msgstr ""
+"Prova a sperimentare con ogni modello: ciascuno fornirà risposte diverse."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prova con meno parole chiave."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23247,8 +23376,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: "
-"https://duckduckgo.com"
+"In %1$sAll'avvio%2$s, seleziona %3$sPagina Iniziale%4$s e inserisci: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23277,8 +23406,8 @@ msgstr ""
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di "
-"ricerca...%4$s"
+"Nella sezione %1$sRicerca%2$s, clicca su %3$sGestisci motori di ricerca..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23292,7 +23421,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
+msgstr ""
+"In \"Ricerca\" clicca sul menu a tendina e seleziona %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23983,7 +24113,8 @@ msgstr "Visualizza i prezzi per il tuo soggiorno"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
+msgstr ""
+"La visualizzazione degli annunci è protetta dalla privacy di DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24403,7 +24534,8 @@ msgstr "Non memorizziamo nomi utente né informazioni personali."
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
+msgstr ""
+"Non memorizziamo le tue informazioni personali e non ti tracciamo. Mai."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24572,7 +24704,8 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
+msgstr ""
+"Ci affidiamo alla tua opinione anonima per migliorare DuckDuckGo per tutti."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24816,7 +24949,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
+msgstr ""
+"Ti diamo il benvenuto al nuovo Duck.ai! Ora puoi importare le chat scaricate."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25042,7 +25176,8 @@ msgstr "Quali sono i piatti da provare in questo caso?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
+msgstr ""
+"Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25269,7 +25404,8 @@ msgstr "Su cosa vuoi dare un'opinione?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
+msgstr ""
+"Ciò che guardi in DuckDuckGo non influenzerà i tuoi consigli su YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25878,7 +26014,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
+msgstr ""
+"Puoi modificarle in qualsiasi momento in %1$sImpostazioni di ricerca%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26105,7 +26242,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Non vedrai più questo messaggio a meno che non elimini i dati del browser."
+msgstr ""
+"Non vedrai più questo messaggio a meno che non elimini i dati del browser."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26202,7 +26340,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Hai raggiunto la durata massima della chat vocale per una singola sessione."
+msgstr ""
+"Hai raggiunto la durata massima della chat vocale per una singola sessione."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26214,7 +26353,8 @@ msgstr "Hai raggiunto il limite di chat vocale per oggi. Riprova domani."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
+msgstr ""
+"Hai raggiunto il limite di utilizzo della dettatura. Riprova più tardi."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26284,8 +26424,8 @@ msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
 msgstr ""
-"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia "
-"end-to-end."
+"Le tue chat di Duck.ai sono in fase di sincronizzazione con crittografia end-"
+"to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26665,7 +26805,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
+msgstr ""
+"Hai superato la dimensione massima del messaggio. Accorcialo e riprova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26699,7 +26840,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
+msgstr ""
+"Hai raggiunto il numero massimo di messaggi giornalieri. Continua domani."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26788,7 +26930,8 @@ msgstr "di %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
+msgstr ""
+"di DuckDuckGo, protezione online scelta da milioni di persone ogni giorno."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,7 +189,10 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -198,7 +201,10 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
+msgstr ""
+"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
+"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,7 +219,10 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
+"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -221,7 +230,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
+msgstr ""
+"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -324,8 +335,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution "
-"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
+"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
+"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
+"バーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -410,7 +422,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
+"てこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -420,7 +434,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
+msgstr ""
+"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
+"このチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -432,7 +448,9 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
+msgstr ""
+"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
+"をクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -440,8 +458,8 @@ msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
-"%8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
+"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -451,8 +469,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして "
-"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
+"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -460,7 +478,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
+msgstr ""
+"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
+"一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -478,7 +498,8 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr ""
+"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -492,7 +513,9 @@ msgstr "%1$s詳細情報%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
+msgstr ""
+"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
+"ら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -510,7 +533,8 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr ""
+"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -868,7 +892,8 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr ""
+"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -921,21 +946,27 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
+msgstr ""
+"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
+"て、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
+msgstr ""
+"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -979,8 +1010,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
-"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
+"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
+"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1040,7 +1072,11 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
+msgstr ""
+"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
+"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
+"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
+"用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1236,7 +1272,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
+msgstr ""
+"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
+"り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1271,14 +1309,18 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
+"イリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
+msgstr ""
+"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
+"ファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1348,7 +1390,9 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
+msgstr ""
+"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
+"ます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1624,7 +1668,9 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
+msgstr ""
+"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
+"す。%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1632,7 +1678,9 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
+msgstr ""
+"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
+"す。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1668,13 +1716,16 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr ""
+"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
+msgstr ""
+"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
+"ください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1809,7 +1860,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr ""
+"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
+"元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1847,7 +1900,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
+msgstr ""
+"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1861,7 +1916,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
+msgstr ""
+"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
+"ど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1899,7 +1956,9 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
+msgstr ""
+"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1930,14 +1989,19 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr ""
+"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
+"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
+"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
+msgstr ""
+"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
+"場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2074,7 +2138,9 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2082,7 +2148,9 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
+msgstr ""
+"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
+"セスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2095,7 +2163,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
+msgstr ""
+"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
+"択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2141,7 +2211,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
+msgstr ""
+"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
+"えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2267,7 +2339,9 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
+msgstr ""
+"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
+"べてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2275,7 +2349,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
+msgstr ""
+"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
+"最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2312,7 +2388,9 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr ""
+"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
+"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2454,9 +2532,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
-"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
+"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
+"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
+"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
+"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
+"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2467,7 +2548,12 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+msgstr ""
+"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
+"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
+"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
+"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
+"とを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2492,7 +2578,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非表示にして保護します。"
+msgstr ""
+"DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非"
+"表示にして保護します。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2566,7 +2654,8 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr ""
+"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2607,18 +2696,24 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
+"ります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
+msgstr ""
+"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
+"場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
+msgstr ""
+"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2637,7 +2732,10 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
+msgstr ""
+"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
+"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
+"す。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2646,14 +2744,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist "
-"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
+"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
+"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
+"利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr ""
+"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2852,7 +2952,21 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
+msgstr ""
+"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
+"などのPIIを削除することで、会話を匿名化します。"
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2981,12 +3095,15 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示などのプレミアム保護を利用できます。"
+msgstr ""
+"DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示"
+"などのプレミアム保護を利用できます。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr ""
+"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3240,20 +3357,28 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
+"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
+"にまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
+"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
+msgstr ""
+"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
+"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
+"ロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3339,7 +3464,8 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr ""
+"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3360,16 +3486,19 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
-"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
-"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
+"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
+"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
+"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr ""
+"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
+"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3378,8 +3507,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
-"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
+"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3748,7 +3878,8 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr ""
+"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3877,10 +4008,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai "
-""
-"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
-"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
+"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
+"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
+"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
+"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -3935,14 +4067,18 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
+"チャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
+msgstr ""
+"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
+"イベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4022,7 +4158,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr "チャットはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr ""
+"チャットはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されま"
+"す。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4030,7 +4168,10 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
+msgstr ""
+"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
+"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
+"削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4041,7 +4182,12 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
+"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
+"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
+"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4063,14 +4209,19 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
+msgstr ""
+"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
+"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
+"バイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
+msgstr ""
+"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
+"レージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4129,7 +4280,8 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr ""
+"この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4194,7 +4346,8 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr ""
+"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4225,7 +4378,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr "VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サイトをブロックできます。"
+msgstr ""
+"VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サ"
+"イトをブロックできます。"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4423,8 +4578,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
-"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
+"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
+"と自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4433,7 +4589,10 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
+msgstr ""
+"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
+"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
+"ります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4441,7 +4600,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
+msgstr ""
+"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
+"ストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4449,7 +4610,11 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
+msgstr ""
+"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
+"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
+"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
+"きます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4490,7 +4655,9 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
+msgstr ""
+"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
+"ださい"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4501,12 +4668,15 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr ""
+"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
+msgstr ""
+"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
+"い"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4520,7 +4690,9 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr ""
+"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
+"右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4549,7 +4721,8 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr ""
+"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4585,7 +4758,8 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr ""
+"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4610,7 +4784,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
+msgstr ""
+"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
+"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
+"リックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4620,7 +4797,10 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
+msgstr ""
+"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
+"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
+"ない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4688,14 +4868,18 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr ""
+"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
+"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
+msgstr ""
+"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
+"能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4895,7 +5079,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
+msgstr ""
+"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
+"を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5166,7 +5352,9 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
+msgstr ""
+"最近のチャットはここから再開できます。または、Fire Buttonで削除することもでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5296,7 +5484,8 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr ""
+"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5349,8 +5538,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › Sync & Backup › "
-"別のデバイスと同期%2$sに移動して、もう一度お試しください。"
+"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › "
+"Sync & Backup › 別のデバイスと同期%2$sに移動して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5408,7 +5597,9 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
+msgstr ""
+"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5514,7 +5705,9 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧・保存できるようになります。"
+msgstr ""
+"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲"
+"覧・保存できるようになります。"
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5522,7 +5715,9 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
+msgstr ""
+"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧"
+"できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5767,7 +5962,8 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr ""
+"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6049,7 +6245,8 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr ""
+"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6083,7 +6280,9 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr "リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
+msgstr ""
+"リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分"
+"のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6179,7 +6378,9 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6196,7 +6397,9 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
+msgstr ""
+"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
+"aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6326,6 +6529,12 @@ msgid "Dislike source"
 msgstr "情報源が気に入らない"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "無視する"
@@ -6436,6 +6645,12 @@ msgid "Djibouti"
 msgstr "ジブチ"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6483,13 +6698,15 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr ""
+"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr ""
+"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6520,7 +6737,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
+"れず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6528,7 +6747,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr ""
+"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
+"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6643,7 +6864,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
+"す。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6651,7 +6874,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
+msgstr ""
+"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
+"は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6671,7 +6896,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
+msgstr ""
+"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
+"作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6679,7 +6906,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
+msgstr ""
+"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
+"くつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6813,7 +7042,8 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
+"きにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6822,7 +7052,10 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
+msgstr ""
+"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
+"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6830,13 +7063,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr ""
+"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6845,7 +7081,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr ""
+"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
+"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6859,7 +7097,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
+msgstr ""
+"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
+"「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6873,14 +7113,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
+"を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
+msgstr ""
+"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6893,7 +7137,10 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
+msgstr ""
+"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
+"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
+"きます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6904,9 +7151,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
-"に直接アクセスすることでDuck.aiを利用できます。"
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
+"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
+"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
+"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6920,7 +7168,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
+msgstr ""
+"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
+"できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -6933,7 +7183,8 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr ""
+"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -6957,7 +7208,8 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr ""
+"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -6967,8 +7219,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo "
-"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
+"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
+"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6996,9 +7249,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
-"UIを完全に削除）、オンデマンド（[アシスト] "
-"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
+"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
+"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
+"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
+"は、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7007,9 +7262,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
-"AI Chat%2$sもご利用いただけます。"
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
+"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
+"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7018,8 +7273,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
+"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -7032,9 +7287,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
-"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
-"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
+"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
+"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
+"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
+"注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7048,15 +7305,22 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
-"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
+"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
+"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
+"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
+"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
+"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
+"要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
+msgstr ""
+"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
+"れません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7064,7 +7328,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
+"行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7073,8 +7339,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7083,8 +7349,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
+"いるプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7092,7 +7358,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
+msgstr ""
+"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
+"可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7100,7 +7368,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
+"「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7108,13 +7378,17 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
+"してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
+msgstr ""
+"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7263,14 +7537,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
+msgstr ""
+"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
+"に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
+"同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7278,7 +7556,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
+msgstr ""
+"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
+"意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7286,7 +7566,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
+msgstr ""
+"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
+"追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7298,8 +7580,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
-"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
+"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
+"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
+"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
+"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
+"こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7318,7 +7604,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr ""
+"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
+"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7409,7 +7697,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr ""
+"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
+"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
+"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7485,7 +7776,8 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr ""
+"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7622,7 +7914,9 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
+"でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7664,7 +7958,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr ""
+"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
+"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7688,7 +7984,8 @@ msgstr "暗号化モデル"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted. Not even DuckDuckGo can read your chat."
-msgstr "暗号化されています。DuckDuckGoでさえ、チャットの内容を読むことはできません。"
+msgstr ""
+"暗号化されています。DuckDuckGoでさえ、チャットの内容を読むことはできません。"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -7796,7 +8093,8 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr ""
+"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -7839,7 +8137,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
+msgstr ""
+"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
+"さい。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7864,7 +8164,9 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
+msgstr ""
+"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
+"リアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8204,6 +8506,12 @@ msgid "Fast"
 msgstr "速い"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8247,7 +8555,9 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
+msgstr ""
+"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8255,14 +8565,19 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
+msgstr ""
+"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
+"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
+"で参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
+msgstr ""
+"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
+"ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8385,7 +8700,8 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8397,7 +8713,9 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
+msgstr ""
+"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
+"す"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8434,7 +8752,9 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
+msgstr ""
+"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8497,7 +8817,9 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr ""
+"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
+"プションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8515,6 +8837,12 @@ msgstr "フォローアップの質問"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "フォローアップは非公開のままとなります。"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8650,7 +8978,9 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
+msgstr ""
+"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
+"ん。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -8731,8 +9061,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
-"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
+"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
+"strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9018,14 +9349,16 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
-"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削"
+"除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
+"能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9090,7 +9423,9 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
+msgstr ""
+"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
+"か。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9111,8 +9446,9 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal Information "
-"Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal "
+"Information Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の"
+"復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9120,7 +9456,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft "
+"Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9128,7 +9466,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr ""
+"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
+"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9138,7 +9478,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr ""
+"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
+"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9181,7 +9523,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプション）、その他のプレミアム保護機能を利用できます。"
+msgstr ""
+"ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプ"
+"ション）、その他のプレミアム保護機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9190,20 +9534,25 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
-"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個"
+"人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr ""
+"ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難"
+"後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
+msgstr ""
+"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
+"ド："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9239,7 +9588,9 @@ msgstr "アプリをダウンロード"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
+msgstr ""
+"DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょ"
+"う。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9298,8 +9649,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
+"ピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9308,8 +9660,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9319,8 +9671,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
+"コードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9330,8 +9683,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
-"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
+"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
+"たは、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9339,13 +9693,16 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr "%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します。"
+msgstr ""
+"%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに"
+"移動します。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr ""
+"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9354,8 +9711,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
-"がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
+"し、[位置情報サービス] がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9364,8 +9721,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
-"まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
+"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9432,6 +9789,12 @@ msgstr "優れたデザイン"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "プライバシーポリシーが良い"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10053,7 +10416,8 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr ""
+"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10080,8 +10444,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s "
-"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
+"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10094,7 +10458,9 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
+msgstr ""
+"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
+"シーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10143,7 +10509,9 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
+msgstr ""
+"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
+"プロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10411,7 +10779,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
+msgstr ""
+"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
+"どんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10446,8 +10816,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
-"の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
+"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10457,8 +10827,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
-"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
+"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
+"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10472,7 +10843,9 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
+msgstr ""
+"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
+"加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10481,8 +10854,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット "
-"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
+"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10490,13 +10863,18 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
+msgstr ""
+"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
+"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
+msgstr ""
+"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
+"さい%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10505,14 +10883,18 @@ msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDu
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
+msgstr ""
+"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
+"ご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
+msgstr ""
+"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10550,6 +10932,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "画像プロンプトはDuck.aiの%1$sに準拠する必要があります。"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10652,7 +11040,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr ""
+"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
+"クトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10662,7 +11052,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
+msgstr ""
+"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
+"期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10676,7 +11068,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
+msgstr ""
+"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
+"保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10686,7 +11080,8 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr ""
+"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11012,7 +11407,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr ""
+"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11080,7 +11476,11 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
+msgstr ""
+"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
+"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
+"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
+"取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11088,7 +11488,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
+msgstr ""
+"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
+"と安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11160,7 +11562,9 @@ msgstr "両方のデバイスでSync & Backupを開いたままにします。"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確保できます。"
+msgstr ""
+"一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確"
+"保できます。"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11578,7 +11982,8 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
+msgstr ""
+"検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12352,7 +12757,9 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
+msgstr ""
+"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
+"ください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13135,7 +13542,11 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
+msgstr ""
+"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
+"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
+"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
+"ンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13457,7 +13868,8 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr ""
+"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -13969,7 +14381,9 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
+msgstr ""
+"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
+"に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13977,7 +14391,9 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr "別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します"
+msgstr ""
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
+"スと同期%4$sに移動します"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13986,8 +14402,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
-"別のデバイスと同期%4$sに移動して、このコードをスキャンします："
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
+"スと同期%4$sに移動して、このコードをスキャンします："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13996,8 +14412,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
-"別のデバイスと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
+"スと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14024,7 +14440,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
+msgstr ""
+"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
+"アップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14050,7 +14468,8 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr ""
+"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14064,7 +14483,9 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
+"てからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14394,7 +14815,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
+msgstr ""
+"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
+"す。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14407,21 +14830,27 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミアム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
+msgstr ""
+"ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミア"
+"ム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
+msgstr ""
+"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
+"せん。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr ""
+"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
+"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14673,7 +15102,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr ""
+"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
+"報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14829,8 +15260,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information "
-"Removalは、お客様の個人情報を売買しているデータブローカーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向けて対応します。"
+"Personal Information Removalは、お客様の個人情報を売買しているデータブロー"
+"カーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向け"
+"て対応します。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14900,7 +15332,10 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
+"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
+"索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14909,8 +15344,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
-"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
+"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
+"設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14919,7 +15355,10 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
+"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
+"定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14951,7 +15390,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14959,7 +15399,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr ""
+"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -14967,7 +15408,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
+msgstr ""
+"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
+"の保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15067,7 +15510,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
+"を完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15075,7 +15520,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
+msgstr ""
+"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
+"してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15107,7 +15554,9 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
+msgstr ""
+"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
+"ます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15115,7 +15564,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
+"は違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15123,7 +15574,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
+msgstr ""
+"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
+"は有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15334,10 +15787,18 @@ msgid "Poor formatting"
 msgstr "フォーマットが不十分"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
+msgstr ""
+"人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャット"
+"は匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15846,7 +16307,9 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
+msgstr ""
+"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
+"ます。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15894,7 +16357,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
+msgstr ""
+"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
+"自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16178,7 +16643,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16186,7 +16653,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
+msgstr ""
+"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
+"バイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16195,7 +16664,10 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr ""
+"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
+"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
+"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16336,7 +16808,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
+msgstr ""
+"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
+"を縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16477,8 +16951,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
-"ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
+"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16585,14 +17059,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
+msgstr ""
+"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
+"します。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16655,14 +17133,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr ""
+"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
+"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
+"人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16670,7 +17152,10 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
+msgstr ""
+"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
+"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
+"特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16761,7 +17246,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
+"です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16769,7 +17257,10 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
+msgstr ""
+"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
+"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
+"になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16779,9 +17270,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
-"Assistには、当社の%1$s利用規約%2$sが適用されます。"
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
+"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
+"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
+"には、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17205,7 +17697,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
+msgstr ""
+"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
+"を使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17218,7 +17712,9 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
+msgstr ""
+"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
+"う。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17377,7 +17873,9 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr ""
+"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17386,8 +17884,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
-"をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
+"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17411,7 +17909,9 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
+msgstr ""
+"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17473,17 +17973,20 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search "
-""
-"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
-"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
+"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
+"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
+"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
+"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
+msgstr ""
+"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
+"ができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17492,8 +17995,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search "
-"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
+"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
+"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
+"報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17613,7 +18117,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
+msgstr ""
+"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
+"Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17631,7 +18137,10 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
+msgstr ""
+"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
+"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
+"できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17650,8 +18159,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
-"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
+"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
+"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
+"ブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17753,7 +18264,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17761,7 +18274,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17769,7 +18284,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr ""
+"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
+"すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17777,7 +18294,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
+"てのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17791,7 +18310,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr ""
+"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
+"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17941,35 +18462,41 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr ""
+"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr ""
+"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr ""
+"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -17981,7 +18508,9 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
+msgstr ""
+"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
+"してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -17992,7 +18521,8 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr ""
+"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18005,7 +18535,9 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
+msgstr ""
+"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
+"メニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18013,8 +18545,8 @@ msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
-"オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
+"は、%3$sOpera > オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18033,7 +18565,8 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr ""
+"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18078,13 +18611,17 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
+msgstr ""
+"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
+"プションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr ""
+"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
+"します"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18156,7 +18693,9 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18199,7 +18738,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
+msgstr ""
+"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
+"の指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18321,7 +18862,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
+msgstr ""
+"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
+"Sync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18427,7 +18970,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr ""
+"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
+"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18528,7 +19073,9 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
+msgstr ""
+"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
+"象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18576,7 +19123,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単で、オン/オフの切り替えがいつでも可能です。"
+msgstr ""
+"ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単"
+"で、オン/オフの切り替えがいつでも可能です。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18702,7 +19251,9 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
+msgstr ""
+"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
+"す。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -18885,7 +19436,8 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
+msgstr ""
+"Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -18939,14 +19491,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
+"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr ""
+"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
+"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -18983,7 +19539,8 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr ""
+"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19004,7 +19561,9 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
+msgstr ""
+"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
+"示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19255,7 +19814,8 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr ""
+"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19285,7 +19845,8 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr ""
+"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19323,7 +19884,9 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
+msgstr ""
+"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
+"は形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19331,13 +19894,17 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
+msgstr ""
+"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
+"たことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
+msgstr ""
+"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
+"に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19345,13 +19912,17 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
+msgstr ""
+"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
+"るには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
+msgstr ""
+"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
+"らもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19405,7 +19976,9 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
+msgstr ""
+"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
+"お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19610,7 +20183,8 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr ""
+"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -19754,7 +20328,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -19822,7 +20398,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr ""
+"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20158,7 +20735,8 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr ""
+"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20220,7 +20798,8 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backupは、より多くのチャットを保存し、すべてのデバイス間で同期します。"
+msgstr ""
+"Sync & Backupは、より多くのチャットを保存し、すべてのデバイス間で同期します。"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20269,21 +20848,25 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-""
-""
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
+"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
+"期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
+"す。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
+"す\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
+"けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
+"れ、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20421,7 +21004,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
+msgstr ""
+"Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、"
+"無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20429,7 +21014,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
+msgstr ""
+"Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこから"
+"でも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20452,7 +21039,8 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr ""
+"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -20672,7 +21260,10 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
+msgstr ""
+"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
+"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
+"や支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20680,7 +21271,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
+msgstr ""
+"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
+"保存できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -20688,7 +21281,9 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr "Duck.aiトグルを使用すると、プライベート検索とDuckDuckGoによって匿名化されたAIチャットをすばやく切り替えることができます。"
+msgstr ""
+"Duck.aiトグルを使用すると、プライベート検索とDuckDuckGoによって匿名化されたAI"
+"チャットをすばやく切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20717,14 +21312,18 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
+msgstr ""
+"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
+"人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
+msgstr ""
+"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -20738,7 +21337,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr ""
+"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20796,7 +21396,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr ""
+"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
+"認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20810,7 +21412,9 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
+msgstr ""
+"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20828,7 +21432,10 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
+msgstr ""
+"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
+"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
+"デフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20865,7 +21472,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
+msgstr ""
+"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20873,7 +21482,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
+msgstr ""
+"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
+"トを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -20911,7 +21522,10 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+msgstr ""
+"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
+"は%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20920,7 +21534,10 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
+msgstr ""
+"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
+"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
+"は%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20928,7 +21545,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr ""
+"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
+"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20938,8 +21557,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
-"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
+"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
+"については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -20955,7 +21575,9 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr "このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s件のチャットはローカルストレージで引き続き利用可能です。"
+msgstr ""
+"このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s"
+"件のチャットはローカルストレージで引き続き利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -20987,7 +21609,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -20995,7 +21618,8 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr ""
+"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21026,14 +21650,18 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
+msgstr ""
+"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
+"さい。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21060,7 +21688,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
+msgstr ""
+"これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択する"
+"と、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21068,7 +21698,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
+msgstr ""
+"これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してくださ"
+"い！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21088,7 +21720,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
+"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21096,7 +21730,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr ""
+"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
+"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21132,7 +21768,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
+msgstr ""
+"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
+"でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21140,7 +21778,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
+msgstr ""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21150,15 +21790,17 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
-"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
+"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
+"答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "この共有チャットを開くことができませんでした。リンクが不完全な可能性があります。"
+msgstr ""
+"この共有チャットを開くことができませんでした。リンクが不完全な可能性がありま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21187,13 +21829,16 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
+msgstr ""
+"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
+"す。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr ""
+"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21203,8 +21848,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
-"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
+"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
+"ウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21212,7 +21858,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
+msgstr ""
+"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
+"の操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21349,7 +21997,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
+msgstr ""
+"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
+"刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21358,7 +22008,10 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
+msgstr ""
+"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
+"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
+"存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21366,14 +22019,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
+msgstr ""
+"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
+"プデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
+msgstr ""
+"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
+"うに設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21395,13 +22052,17 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "トグルを切り替えてプライベートAIチャットにするか、%1$s設定で無効にする%2$sこともできます。"
+msgstr ""
+"トグルを切り替えてプライベートAIチャットにするか、%1$s設定で無効にする%2$sこ"
+"ともできます。"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
+msgstr ""
+"トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にで"
+"きます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21462,6 +22123,12 @@ msgstr "この情報源からの結果が多すぎる"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "遅すぎる"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21574,7 +22241,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
+msgstr ""
+"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
+"ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21621,7 +22290,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
+"行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21629,7 +22300,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
+msgstr ""
+"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
+"ばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21737,7 +22410,8 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr ""
+"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -21747,7 +22421,9 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
+msgstr ""
+"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
+"を！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -21876,13 +22552,16 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
+msgstr ""
+"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
+"ださい。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr ""
+"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -21896,6 +22575,12 @@ msgstr "各モデルを試してみてください。それぞれ異なる応答
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "キーワードの数を減らしてみてください。"
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22015,7 +22700,8 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr ""
+"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22073,7 +22759,8 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr ""
+"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22267,7 +22954,8 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr ""
+"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22311,14 +22999,17 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr ""
+"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr ""
+"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
+"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22447,14 +23138,18 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
+msgstr ""
+"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
+"ページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
+msgstr ""
+"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
+"入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22464,7 +23159,8 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr ""
+"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22474,13 +23170,17 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
+msgstr ""
+"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
+"を選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
+msgstr ""
+"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
+"ます"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -22569,7 +23269,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
+msgstr ""
+"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
+"限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22629,7 +23331,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
+msgstr ""
+"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
+"う。%1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -22726,7 +23430,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
+msgstr ""
+"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
+"モデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22850,7 +23556,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
+msgstr ""
+"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
+"を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -22951,7 +23659,10 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
+msgstr ""
+"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
+"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
+"要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -22963,7 +23674,8 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr ""
+"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23005,14 +23717,18 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
+msgstr ""
+"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
+"切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
+msgstr ""
+"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
+"復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23136,8 +23852,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.aiから共有された会話を表示 — "
-"DuckDuckGoによる無料のプライベートAIチャット。自分のチャットに保存して、プライバシーを保護しながら会話を続けましょう。"
+"Duck.aiから共有された会話を表示 — DuckDuckGoによる無料のプライベートAIチャッ"
+"ト。自分のチャットに保存して、プライバシーを保護しながら会話を続けましょう。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23171,7 +23887,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
+"Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23179,7 +23897,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
+msgstr ""
+"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
+"TripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23187,7 +23907,9 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr "広告表示機能のプライバシーはDuckDuckGoで保護されます。広告のクリックはYelpの広告ネットワークで管理されています。"
+msgstr ""
+"広告表示機能のプライバシーはDuckDuckGoで保護されます。広告のクリックはYelpの"
+"広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23198,7 +23920,9 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
+"スしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23206,7 +23930,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
+msgstr ""
+"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
+"クセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23214,7 +23940,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
+msgstr ""
+"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23229,8 +23957,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
-"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
+"い。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23239,7 +23968,10 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr ""
+"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
+"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
+"たは、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23249,8 +23981,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
+"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
+"択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23259,7 +23992,10 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr ""
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
+"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
+"す。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23311,7 +24047,9 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23399,7 +24137,8 @@ msgstr "壁紙"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "新しいタブページからプライベートなAIチャットに簡単にアクセスしたいですか？"
+msgstr ""
+"新しいタブページからプライベートなAIチャットに簡単にアクセスしたいですか？"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -23461,8 +24200,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
-"のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
+"YouTube のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23481,7 +24220,11 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
+msgstr ""
+"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
+"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
+"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
+"いません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23493,7 +24236,8 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr ""
+"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23504,7 +24248,10 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
+"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
+"てください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23515,7 +24262,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr ""
+"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
+"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23528,7 +24277,9 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
+msgstr ""
+"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
+"きません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23555,7 +24306,9 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
+msgstr ""
+"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
+"します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23568,7 +24321,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
+"理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23576,7 +24331,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
+msgstr ""
+"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
+"思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23615,18 +24372,23 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
+msgstr ""
+"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
+"なたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
+msgstr ""
+"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
+"せん。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr ""
+"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23640,7 +24402,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr "データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご利用いただけます。"
+msgstr ""
+"データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご"
+"利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23648,7 +24412,8 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr ""
+"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23672,7 +24437,9 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
+msgstr ""
+"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
+"広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23680,7 +24447,9 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
+msgstr ""
+"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
+"す。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23688,13 +24457,17 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr "当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、使いやすいダッシュボードで進捗状況を共有します。"
+msgstr ""
+"当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、"
+"使いやすいダッシュボードで進捗状況を共有します。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
+msgstr ""
+"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
+"でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23714,7 +24487,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr ""
+"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
+"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23727,7 +24502,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr "データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所などを探し、見つかった個人情報の削除に向けて対応します。"
+msgstr ""
+"データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所など"
+"を探し、見つかった個人情報の削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23735,7 +24512,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
+"ラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23743,7 +24522,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr ""
+"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
+"ザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23757,7 +24538,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
+msgstr ""
+"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23765,7 +24548,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
+msgstr ""
+"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23886,7 +24671,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
+"レーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23894,7 +24681,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
+"AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23904,14 +24693,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI "
-"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
+"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
+"トレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
+msgstr ""
+"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
+"ました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -23978,7 +24770,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
+msgstr ""
+"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
+"みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -23992,7 +24786,9 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
+msgstr ""
+"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
+"すか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24012,7 +24808,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
+msgstr ""
+"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
+"う言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24036,7 +24834,12 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
+msgstr ""
+"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
+"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
+"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
+"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
+"誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24271,7 +25074,9 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
+msgstr ""
+"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
+"の違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24371,7 +25176,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
+msgstr ""
+"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
+"か？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24571,7 +25378,9 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
+msgstr ""
+"Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはあ"
+"りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24579,14 +25388,17 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr "チャット履歴をオンにすると、最新のチャットを最大%1$s件このデバイスに保存します。"
+msgstr ""
+"チャット履歴をオンにすると、最新のチャットを最大%1$s件このデバイスに保存しま"
+"す。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr "チャット履歴をオンにすると、最新のチャットがこのデバイスに保存されます。"
+msgstr ""
+"チャット履歴をオンにすると、最新のチャットがこのデバイスに保存されます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -24600,7 +25412,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr "お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名前、住所などの個人情報を削除します。"
+msgstr ""
+"お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名"
+"前、住所などの個人情報を削除します。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24867,7 +25681,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
+"があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24875,7 +25691,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
+msgstr ""
+"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
+"索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24888,7 +25706,8 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr ""
+"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -24896,17 +25715,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr ""
+"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
+"す。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
+msgstr ""
+"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
+"こともできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -24919,7 +25743,9 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
+msgstr ""
+"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
+"きます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24939,7 +25765,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
+msgstr ""
+"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
+"意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -24968,7 +25796,8 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr ""
+"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25031,7 +25860,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
+msgstr ""
+"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
+"ブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25094,7 +25925,8 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr ""
+"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25102,7 +25934,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr ""
+"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
+"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25123,7 +25957,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
+"サーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25132,7 +25969,10 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
+msgstr ""
+"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
+"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
+"れたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25145,7 +25985,8 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr ""
+"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25159,7 +26000,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
+"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
+"り、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25171,7 +26015,9 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
+msgstr ""
+"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
+"もっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25220,7 +26066,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr ""
+"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25233,12 +26080,14 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr ""
+"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25247,8 +26096,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
+"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
+"たチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25258,8 +26108,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & "
-"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
+"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
+"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
+"されたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25272,7 +26123,9 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
+msgstr ""
+"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
+"されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25293,7 +26146,8 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25331,7 +26185,9 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25340,7 +26196,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
+"に保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25349,7 +26208,10 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
+msgstr ""
+"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
+"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
+"レージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25373,14 +26235,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
+msgstr ""
+"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
+"がこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr ""
+"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
+"DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25388,7 +26254,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
+msgstr ""
+"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
+"れる場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25400,41 +26268,50 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
+"りません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr ""
+"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr ""
+"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
+msgstr ""
+"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
+"されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25448,7 +26325,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr ""
+"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
+"せん。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25456,7 +26335,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr ""
+"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -25487,7 +26367,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr ""
+"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
+"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25530,10 +26412,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
-""
-"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
-"がお客様のパスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
+"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
+"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
+"パスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25547,7 +26429,10 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
+msgstr ""
+"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
+"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
+"きません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25560,7 +26445,9 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
+msgstr ""
+"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
+"ます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -25592,8 +26479,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
-"AI%2$s拡張機能を有効にしてください。"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
+"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25602,8 +26489,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
-"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
+"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
+"い。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25630,7 +26518,10 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
+msgstr ""
+"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
+"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
+"ストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25638,7 +26529,9 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
+msgstr ""
+"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
+"ください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25646,7 +26539,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
+"続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25654,7 +26549,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
+msgstr ""
+"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
+"します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25668,13 +26565,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr ""
+"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr ""
+"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -25757,7 +26656,9 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
+msgstr ""
+"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
+"います。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -25976,7 +26877,9 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
+msgstr ""
+"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
+"たものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ja_JP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ja_JP/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,10 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,10 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoの"
-"サブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替え"
-"てください。"
+msgstr "%1$sはProでのみ利用可能です。チャットを続けるには、このブラウザでDuckDuckGoのサブスクリプションを再度アップグレードするか、Plusまたは無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,10 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるに"
-"は、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替え"
-"てください。"
+msgstr "%1$sはDuckDuckGoのサブスクリプションでのみ利用可能です。チャットを続けるには、このブラウザでサブスクリプションを再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,9 +221,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直し"
-"てください。"
+msgstr "%1$sは一時的に利用できません。 別のモデルに切り替えるか、後でもう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -335,9 +324,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$sはTrusted Execution Environmentで動作します。つまり、モデルプロバイダーで"
-"さえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサー"
-"バーに保存することもできません。"
+"%1$sはTrusted Execution "
+"Environmentで動作します。つまり、モデルプロバイダーでさえあなたのプロンプトやモデルの応答を見ることができず、このチャットをサーバーに保存することもできません。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -422,9 +410,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替え"
-"てこのチャットを続けることができます。"
+msgstr "%1$sは%2$s日後（%3$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -434,9 +420,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えて"
-"このチャットを続けることができます。"
+msgstr "%1$sは1日後（%2$s）にDuck.aiで利用不可になります。その後、モデルを切り替えてこのチャットを続けることができます。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -448,9 +432,7 @@ msgstr "%1$s単語"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$s"
-"をクリックしてください"
+msgstr "%1$s%2$s追加ボタンをクリックして%3$s%4$s許可%5$sにチェックを入れ、 %6$sOK%7$sをクリックしてください"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -458,8 +440,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$s"
-"ボックスをオンにしてから %8$sOK%9$sをクリックしてください"
+"%1$s%2$s許可%3$sにチェックを入れて、%4$s追加%5$sをクリックし、%6$s許可%7$sボックスをオンにしてから "
+"%8$sOK%9$sをクリックしてください"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -469,8 +451,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sインストールを続行%3$sをクリックして %4$s追加ボタン%5$sを押し、%6$s許"
-"可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
+"%1$s%2$sインストールを続行%3$sをクリックして "
+"%4$s追加ボタン%5$sを押し、%6$s許可%7$sにチェックを入れたら%8$sOK%9$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -478,9 +460,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう"
-"一度試します。"
+msgstr "この検索の結果について再読み込みする場合は、%1$sこちらをクリック%2$sしてもう一度試します。"
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -498,8 +478,7 @@ msgstr "%1$sさらに詳しく%2$s"
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
+msgstr "%1$sDuckDuckGoが位置情報を保護する方法については、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -513,9 +492,7 @@ msgstr "%1$s詳細情報%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこち"
-"ら%2$sをご覧ください。"
+msgstr "DuckDuckGoのサーバー上でチャットが非公開で保存される仕組みについては%1$sこちら%2$sをご覧ください。"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -533,8 +510,7 @@ msgstr "ホーム画面でDuckDuckGoのアプリアイコンを%1$s長押し%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
+msgstr "%1$s%2$s%3$s問題が発生しました。%4$s更新%5$sして、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -892,8 +868,7 @@ msgstr "6時間の使用制限に達しました。このチャットは%1$s以�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
+msgstr "6時間の使用制限に達しました。1日の制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -946,27 +921,21 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"ネットワークの問題により、Search Assistは回答を生成できません。接続を確認し"
-"て、もう一度試してください。"
+msgstr "ネットワークの問題により、Search Assistは回答を生成できません。接続を確認して、もう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "AI Chatの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてくださ"
-"い。"
+msgstr "Duck.aiの新バージョンが登場！続行するには、このページを再読み込みしてください。"
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1010,9 +979,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフ"
-"にすると、DuckDuckGo SearchのAI Chat機能は非表示になりますが、%1$sduckduckgo."
-"com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
+"AI Chatでは、サードパーティのAIチャットモデルと匿名で会話できます。設定をオフにすると、DuckDuckGo SearchのAI "
+"Chat機能は非表示になりますが、%1$sduckduckgo.com/aichat%2$sにアクセスすると、AI Chatをご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1072,11 +1040,7 @@ msgid ""
 "However, we also offer and often link to %sDuck.ai%s for follow-up "
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
-msgstr ""
-"AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただ"
-"し、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供して"
-"います。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活"
-"用したプライベートチャットサービスです。"
+msgstr "AI支援による回答は現在、フォローアップの質問を直接サポートしていません。ただし、フォローアップの質問のために%1$sDuck.ai%2$sも（リンク経由を含め）提供しています。Duck.aiは、OpenAIやAnthropicなどのチャットモデルをサポートするAIを活用したプライベートチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1272,9 +1236,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切"
-"り替えてください。"
+msgstr "チャットを続けるには、このブラウザで %1$s を再度有効にするか、無料プランに切り替えてください。"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1309,18 +1271,14 @@ msgstr "広告"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファ"
-"イリングには使用されません。"
+msgstr "広告クリックは%1$sの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロ"
-"ファイリングには使用されません。"
+msgstr "広告クリックはMicrosoftの広告ネットワークによって管理されており、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1390,9 +1348,7 @@ msgstr "DuckDuckGo拡張機能を追加"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加でき"
-"ます："
+msgstr "DuckDuckGo Privacy Essentialsは一度のダウンロードで、ブラウザに無料で追加できます："
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1668,9 +1624,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1678,9 +1632,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性がありま"
-"す。%1$s"
+msgstr "高度なモデルは、他のモデルよりも2～5倍早く使用制限に達する可能性があります。%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1716,16 +1668,13 @@ msgstr "アフリカーンス語"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
+msgstr "ダウンロード後、ファイルを開いたら%1$sインストール%2$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールして"
-"ください"
+msgstr "ダウンロード後は拡張ファイルの場所に行き、ダブルクリックしてインストールしてください"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1860,9 +1809,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供"
-"元が学習内容をチャットモデルの学習に利用することはありません"
+msgstr "すべてのチャットはDuckDuckGoによって匿名化されます。DuckDuckGoやモデルの提供元が学習内容をチャットモデルの学習に利用することはありません"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1900,9 +1847,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されてい"
-"ます。"
+msgstr "すべてのモデルプロバイダーは、会話内容に基づくAIのトレーニングを禁止されています。"
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1916,9 +1861,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスな"
-"ど）が削除されます。"
+msgstr "AIプロバイダーにチャットを送信する前に、すべての個人メタデータ（IPアドレスなど）が削除されます。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1956,9 +1899,7 @@ msgstr "許可"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可"
-"してください。"
+msgstr "ボイスチャットを使用するには、システム設定でDuckDuckGoのマイクアクセスを許可してください。"
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1989,19 +1930,14 @@ msgid ""
 "Allows %s to search the web to improve responses to relevant prompts. Only "
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
-msgstr ""
-"%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。"
-"AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$s"
-"のプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
+msgstr "%1$sがウェブを検索して、関連するプロンプトへの応答を改善できるようにします。AIが生成したクエリのみをデータ保持が制限された検索エンジンに送信します。%2$sのプロンプトや応答は依然としてプロバイダーに%3$s一切表示されません%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する"
-"場合に必須)"
+msgstr "デバイス上で Cloud Save キーのローカル保存を許可します (Cloud Save を利用する場合に必須)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2138,9 +2074,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2148,9 +2082,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアク"
-"セスできます。"
+msgstr "%1$s、%2$sに加え、オープンソースの%3$sや%4$sなど、人気のAIモデルに匿名でアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2163,9 +2095,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選"
-"択するか、完全に無効にすることができます。"
+msgstr "ウェブコンテンツに基づいて、検索クエリの回答を匿名で生成します。表示頻度を選択するか、完全に無効にすることができます。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2211,9 +2141,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教"
-"えてください"
+msgstr "Duck.aiが従うべき追加の指示はありますか。例えばいつもアヒルについての事実を教えてください"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2339,9 +2267,7 @@ msgctxt "Body text for disable chat history confirmation modal"
 msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
-msgstr ""
-"履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むす"
-"べてのチャットが削除されます。"
+msgstr "履歴を無効にしてもよろしいですか？これにより、ピン留めされたチャットを含むすべてのチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2349,9 +2275,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている"
-"最近のチャットも削除されます。"
+msgstr "最近のチャットを無効にしてもよろしいですか？無効にすると、現在保存されている最近のチャットも削除されます。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2388,9 +2312,7 @@ msgstr "最終更新："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"私達はプライバシーポリシーに従って、個人情報を収集または共有することはありま"
-"せん。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
+msgstr "私達はプライバシーポリシーに従って、個人情報を収集または共有することはありません。これらのプライバシー保護機能はすべてあなたのデバイスで実行されます。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2532,12 +2454,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿"
-"名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist UIを完全に"
-"削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回"
-"答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻"
-"繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できま"
-"す。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
+""
+"Assistは、関連するWebコンテンツを要約して、一部の検索に対してAI支援の回答を匿名で生成できます。Assistの表示頻度は、「なし」（検索結果からAssist "
+"UIを完全に削除）、「オンデマンド」（Assistボタンをクリックした場合にのみAI支援による回答を表示）、「時々」（関連性の高い場合にのみAI支援による回答を表示）、「頻繁」（より広範な検索でより頻繁にAIアシストによる回答を表示）から選択できます。現時点では、AI支援の回答は米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2548,12 +2467,7 @@ msgid ""
 "generate a brief answer based on relevant information found. It’s important "
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
-msgstr ""
-"Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプ"
-"ション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活"
-"用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答"
-"は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されるこ"
-"とを覚えておくことが重要です。"
+msgstr "Assistは、検索クエリに対するAI支援の回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AIを活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2578,9 +2492,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非"
-"表示にして保護します。"
+msgstr "DuckDuckGo VPNは、カフェ、空港、ホテルでのWi-Fi接続を暗号化し、IPアドレスを非表示にして保護します。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2654,8 +2566,7 @@ msgstr "チャット終了後、音声は当社または OpenAI によって保�
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
+msgstr "チャットの文字起こし後、音声データは当社またはOpenAIによって保存されません。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2696,24 +2607,18 @@ msgstr "自動応答"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があ"
-"ります。"
+msgstr "リストされたソースに基づいて自動生成されます。不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる"
-"場合があります。"
+msgstr "リストされたソースに基づいて自動生成されます。回答には不正確な情報が含まれる場合があります。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"ソースに基づき自動生成されています。内容に不正確な部分を含む可能性がありま"
-"す。"
+msgstr "ソースに基づき自動生成されています。内容に不正確な部分を含む可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2732,10 +2637,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して"
-"情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能で"
-"す。"
+msgstr "関連する検索にAssistを自動表示します。Assistを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、Assistは英語圏でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2744,16 +2646,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"関連する検索に DuckAssist を自動表示します。このツールを使用すると、一部の検"
-"索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ"
-"利用可能です。"
+"関連する検索に DuckAssist "
+"を自動表示します。このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。現時点では、イングランド地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
+msgstr "動画の結果にカーソルを合わせると、プレビューが短時間無音で自動再生されます。"
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2952,9 +2852,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータ"
-"などのPIIを削除することで、会話を匿名化します。"
+msgstr "このレポートを保存する前に、DuckDuckGoは名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2966,7 +2864,7 @@ msgid ""
 "Before storing this report, DuckDuckGo will remove uploaded files and "
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "このレポートを保存する前に、DuckDuckGoはアップロードされたファイルと生成された画像を削除し、名前、メールアドレス、識別メタデータなどのPIIを削除することで、会話を匿名化します。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3095,15 +2993,12 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示"
-"などのプレミアム保護を利用できます。"
+msgstr "DuckDuckGoのサブスクリプションなら、有害サイトのブロックやIPアドレスの非表示などのプレミアム保護を利用できます。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
+msgstr "ブロックリストは完全ではなく、不正確な情報が含まれている可能性があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3357,28 +3252,20 @@ msgstr "ファイルを参照"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索"
-"エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$s"
-"にまとめました。"
+msgstr "DuckDuckGoなら普段どおりに閲覧しながら、プライバシー保護を強化できます。検索エンジン、トラッカーブロック、高度な暗号化機能をひとつの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、"
-"高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。検索エンジン、トラッカーブロック、高度な暗号化機能を1つの%1$s%2$s拡張機能%3$sにまとめました。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロッ"
-"ク、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウン"
-"ロードしましょう。"
+msgstr "いつも通り閲覧して、あとは当社におまかせ。プライベート検索、トラッカーブロック、サイトの暗号化機能を1つにまとめた%1$s主要なブラウザ%2$s向けツールをダウンロードしましょう。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3464,8 +3351,7 @@ msgstr "「%1$s」をクリックすると、当社の%2$sに同意したこと�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
+msgstr "「%1$s」をクリックすると、Duck.aiの%2$sと%3$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3486,19 +3372,16 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に"
-"保存されます。匿名の Cloud Save 機能を利用すると、設定情報を (クラウド上のリ"
-"モートサーバーに) より長期的に保存できます。個人を特定できる情報がクラウドに"
-"保存されたり、パスフレーズがブラウザ上に残ることもありません。"
+"初期状態では、設定情報は秘匿されないブラウザのCookieファイル (ブラウザ内) に保存されます。匿名の Cloud Save "
+"機能を利用すると、設定情報を (クラウド上のリモートサーバーに) "
+"より長期的に保存できます。個人を特定できる情報がクラウドに保存されたり、パスフレーズがブラウザ上に残ることもありません。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信される"
-"ことに同意したことになります。開始する間に当社の%1$sを確認してください。"
+msgstr "音声入力を有効にすると、この機能の使用のために音声データがOpenAIに送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3507,9 +3390,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI に送信"
-"されることに同意したことになります。開始する間に当社の%1$sを確認してくださ"
-"い。"
+"ボイスチャットを有効にすると、この機能の使用のために音声データがOpenAI "
+"に送信されることに同意したことになります。開始する間に当社の%1$sを確認してください。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3878,8 +3760,7 @@ msgstr "サイト全体の背景色を変更する"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
+msgstr "マウスオーバー、モジュール、ドロップダウンメニューでの検索結果の背景色を変更"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4008,11 +3889,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"チャット（Duck.ai サービス経由）を通じて、OpenAI、Anthropicなどのサードパー"
-"ティのAIチャットモデルと匿名で会話することができます。この設定をオフにする"
-"と、DuckDuckGo Searchのチャットボタンとリンクが非表示になります。ただし、この"
-"設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用"
-"できます。"
+"チャット（Duck.ai "
+""
+"サービス経由）を通じて、OpenAI、AnthropicなどのサードパーティのAIチャットモデルと匿名で会話することができます。この設定をオフにすると、DuckDuckGo "
+"Searchのチャットボタンとリンクが非表示になります。ただし、この設定がオフの場合でも、%1$shttps://duck.ai%2$sにアクセスして直接チャットを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4067,18 +3947,14 @@ msgstr "プライベートチャット"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートに"
-"チャットできます。"
+msgstr "無料ブラウザに内蔵されたDuck.aiがあれば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプラ"
-"イベートにチャットできます。"
+msgstr "無料のDuckDuckGoブラウザのDuck.aiサイドバーを使えば、どのウェブサイトでもプライベートにチャットできます。"
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4158,9 +4034,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
-"チャットはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されま"
-"す。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "チャットはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4168,10 +4042,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスに"
-"ローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが"
-"削除されます。"
+msgstr "チャットは、DuckDuckGoサーバーやリモートサーバーでなく、お使いのデバイスにローカルで保存されます。チャット履歴を無効にすると、ピン留めされたチャットが削除されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4182,12 +4053,7 @@ msgid ""
 "help recover a chat if you lose your internet connection. Disabling chat "
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
-msgstr ""
-"チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗"
-"号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インター"
-"ネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にする"
-"と、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効"
-"になります。"
+msgstr "チャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4209,19 +4075,14 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップ"
-"ロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロ"
-"バイダーによって匿名でレビューされます。"
+msgstr "%1$sとのチャットではプロバイダーの可視性がゼロになりますが、Duck.aiにアップロードされたすべてのファイルは、%2$sを目的としてコンテンツモデレーションプロバイダーによって匿名でレビューされます。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはスト"
-"レージを解放してください。"
+msgstr "添付ファイル付きのチャットが同期されなくなりました。同期を再開するにはストレージを解放してください。"
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4280,8 +4141,7 @@ msgstr "この障害に関する最新情報は、DuckDuckGoのサブレディ�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"この停止に関する最新情報については、ステータスページを確認してください。"
+msgstr "この停止に関する最新情報については、ステータスページを確認してください。"
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4346,8 +4206,7 @@ msgstr "%1$sや%2$sを含むAIモデルの選択"
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
+msgstr "%1$s初期設定の検索エンジンを保持%2$sを選び、プライバシーを保護しましょう。"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4378,9 +4237,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サ"
-"イトをブロックできます。"
+msgstr "VPNサーバーは世界中に40以上あり、都合の良い場所を選択して、有害サイトや詐欺サイトをブロックできます。"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4578,9 +4435,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最"
-"近のチャットが無期限に保存される場合、またはAI Chatの未使用期間が7日を超える"
-"と自動的に削除される場合があります。"
+"ブラウザのデータを消去すると、チャットも消去されます。一部のブラウザでは、最近のチャットが無期限に保存される場合、またはAI "
+"Chatの未使用期間が7日を超えると自動的に削除される場合があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4589,10 +4445,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは"
-"無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあ"
-"ります。ブラウザによって異なります。"
+msgstr "ブラウザのデータを消去すると、最近のチャットが削除されます。最近のチャットは無期限に保存されるか、Duck.aiを使用しない場合、7日後に自動削除されることがあります。ブラウザによって異なります。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4600,9 +4453,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリ"
-"ストを当社の無料ブラウザに"
+msgstr "ブラウザデータを消去すると、ブロックしたサイトがリセットされます。ブロックリストを当社の無料ブラウザに"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4610,11 +4461,7 @@ msgid ""
 "Click \"More\" to go deeper on a topic, and ask follow-up questions via "
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
-msgstr ""
-"「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。ま"
-"た、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなど"
-"のチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用で"
-"きます。"
+msgstr "「詳細」をクリックすると、トピックについてさらに詳しい情報が表示されます。また、フォローアップの質問をするために、%1$sDuck.ai%2$s（OpenAIやAnthropicなどのチャットモデルをサポートする当社のプライベートAIチャットサービス）も使用できます。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4655,9 +4502,7 @@ msgstr "一覧から%1$s検索設定の変更%2$sをクリックしてくださ�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてく"
-"ださい"
+msgstr "%1$s編集 > 設定%2$s (Windows) %3$sSeaMonkey > 設定%4$s (Mac) をクリックしてください"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4668,15 +4513,12 @@ msgstr "%1$sここ%2$sをクリックして検索エンジンとして追加し�
 # smartling.placeholder_format=C
 #. Link to add the DuckDuckGo browser extension to Safari.
 msgid "Click %sHere%s to download the DuckDuckGo extension"
-msgstr ""
-"%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
+msgstr "%1$sここ%2$sをクリックしてDuckDuckGoの拡張機能をダウンロードしてください"
 
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてくださ"
-"い"
+msgstr "%1$s開く%2$sをクリックしてDuckDuckGoのSafari拡張設定をダウンロードしてください"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4690,9 +4532,7 @@ msgstr "左側のサイドバーにある%1$sプライバシーとサービス%2
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、"
-"右上の%3$s歯車アイコン%4$sをクリックしてください)"
+msgstr "%1$sSafari%2$sをトップメニューからクリックしてください(またはWindowsの場合、右上の%3$s歯車アイコン%4$sをクリックしてください)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4721,8 +4561,7 @@ msgstr "%1$sはい%2$sをクリックしてください"
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
+msgstr "Chromeのツールバーで「%1$ssettings/hamburger icon %2$s」をクリックします。"
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4758,8 +4597,7 @@ msgstr "下のほうの %1$sデフォルトに設定%2$s をクリックしま�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
+msgstr "アドオンタイプセクションの下にある%1$s検索エンジン%2$sボタンを押してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4784,10 +4622,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作"
-"によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がク"
-"リックまたはタップされるまでブラウザに残ります。"
+msgstr "「%1$s自分のデータを削除%2$s」をクリックまたはタップします。データはこの操作によりクラウドから削除されますが、「%3$sすべての検索設定をリセット%4$s」がクリックまたはタップされるまでブラウザに残ります。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4797,10 +4632,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはク"
-"ラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップし"
-"ない限り、お使いのブラウザに保存されたままとなります。"
+msgstr "%1$s自分のデータを削除%2$sをクリックまたはタップします。この操作でデータはクラウド上から削除されますが、%3$sすべての設定をリセット%4$sをクリック/タップしない限り、お使いのブラウザに保存されたままとなります。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4868,18 +4700,14 @@ msgstr "検索ボックスの選択項目をクリック"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューを"
-"クリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
+msgstr "%1$s「アドレスバーで使用する検索エンジン」の横にあるドロップダウンメニューをクリック%2$sして、%3$sDuckDuckGo%4$s を選択します。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機"
-"能のアイコンはブラウザの右上隅に表示されています。"
+msgstr "広告ブロッカー拡張機能のアイコンをクリックします。通常、広告ブロッカー拡張機能のアイコンはブラウザの右上隅に表示されています。"
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5079,9 +4907,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能"
-"を使うかどうかはあなた次第。強制ではありません。"
+msgstr "パスワードを入力すれば、Cloud Saveで自分の設定をずっと保存できます。この機能を使うかどうかはあなた次第。強制ではありません。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5352,9 +5178,7 @@ msgstr "広告ブロックを継続"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"最近のチャットはここから再開できます。または、Fire Buttonで削除することもでき"
-"ます。"
+msgstr "最近のチャットはここから再開できます。または、Fire Buttonで削除することもできます。"
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5484,8 +5308,7 @@ msgstr "コピー"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
+msgstr "「%1$sabout:preferences#search%2$s」をアドレスバーにコピー＆ペーストします"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5538,8 +5361,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › "
-"Sync & Backup › 別のデバイスと同期%2$sに移動して、もう一度お試しください。"
+"別のデバイスからコードをコピーしてください。%1$sDuck.ai設定 › チャット › Sync & Backup › "
+"別のデバイスと同期%2$sに移動して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5597,9 +5420,7 @@ msgstr "コスタリカ"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しくださ"
-"い。"
+msgstr "リカバリーコードを読み込めませんでした。これを閉じて、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5705,9 +5526,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr ""
-"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲"
-"覧・保存できるようになります。"
+msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧・保存できるようになります。"
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5715,9 +5534,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧"
-"できるようになります。"
+msgstr "リンクを作成するとチャットのコピーが作成され、リンクを開いた人なら誰でも閲覧できるようになります。"
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5962,8 +5779,7 @@ msgstr "1日の使用制限に達しました。このチャットは%1$s以降�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
+msgstr "1日の使用制限に達しました。週間制限時間を使ってチャットを続行できます。"
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6245,8 +6061,7 @@ msgstr "ストレージを解放するために最も古いチャットを削除
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
+msgstr "保存容量を空けるために添付ファイル付きの最も古いチャットを削除しますか？"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6280,9 +6095,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分"
-"のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
+msgstr "リンクを削除すると、そのリンクは機能しなくなります。 リンクを開いて会話を自分のチャットに追加したユーザーは、各自のコピーをそのまま保持します。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6378,9 +6191,7 @@ msgstr "Duck.aiの音声入力"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されま"
-"せん。"
+msgstr "音声入力は当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6397,9 +6208,7 @@ msgstr "音声入力は一時的に利用できません"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck."
-"aiチャットができます。"
+msgstr "音声入力はOpenAIのモデルを使って音声をテキストに変換し、タイピングせずにDuck.aiチャットができます。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6532,7 +6341,7 @@ msgstr "情報源が気に入らない"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "ビジュアルスタイルが気に入らない"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6648,7 +6457,7 @@ msgstr "ジブチ"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "指示に従っていない"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6698,15 +6507,13 @@ msgstr "DuckDuckGoがリストにありませんか？"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
+msgstr "表示されませんか？ %1$s%2$s%3$s再度ダウンロードするにはここをクリック%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
+msgstr "チェックボックスが表示されない場合は、%1$s以下の手順に従ってください%2$s。"
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -6737,9 +6544,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供さ"
-"れず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、AI機能は提供されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6747,9 +6552,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能"
-"は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
+msgstr "AIが不要な場合は、%1$snoai.duckduckgo.com%2$sにアクセスすると、検索時にAI機能は使用されず、AI画像は除外されます。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6864,9 +6667,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成しま"
-"す。内容は、簡潔かつ詳細に入力してください。"
+msgstr "シーリングファンの修理サービスの見積もりを依頼するベンダーにメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6874,9 +6675,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容"
-"は、簡潔かつ詳細に入力してください。"
+msgstr "家庭用冷蔵庫の修理サービスの見積もりを依頼する業者にメールを作成します。内容は、簡潔かつ詳細に入力してください。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6896,9 +6695,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか"
-"作成してください。"
+msgstr "今後のパーティーに人々を招待するソーシャルメディア投稿のオプションをいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6906,9 +6703,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をい"
-"くつか作成してください。"
+msgstr "チームコラボレーションを強化するための戦略について書いた投稿のタイトル案をいくつか作成してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7042,8 +6837,7 @@ msgid ""
 msgstr ""
 "Duck.aiは、現在表示しているページに関する質問に回答できるようになりました。\n"
 "\n"
-"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したと"
-"きにのみ含まれます。"
+"設定でページを自動添付することを選択しない限り、ページコンテンツは添付したときにのみ含まれます。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7052,10 +6846,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。"
-"ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しくださ"
-"い。"
+msgstr "Duck.aiはローカルストレージにアクセスできないため、チャットを保存できません。ブラウザの設定を確認するか、拡張機能を無効にしてから、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7063,16 +6854,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してくだ"
-"さい。"
+msgstr "Duck.aiの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
+msgstr "Duck.aiのパワーはプライベートな無料ブラウザDuckDuckGoで最も発揮されます！"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7081,9 +6869,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻"
-"したいユーザーのためにオンライン保護に取り組む独立系企業です。"
+msgstr "Duck.aiのクリエイターであるDuckDuckGoは、自分の個人情報に対する主導権を取り戻したいユーザーのためにオンライン保護に取り組む独立系企業です。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7097,9 +6883,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが"
-"「https://duck.ai」と覚えやすくなります"
+msgstr "Duck.aiは引き続きDuckDuckGoの製品ですが、今後はウェブ上のホームページが「https://duck.ai」と覚えやすくなります"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7113,18 +6897,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」"
-"を%2$s宛てにメールで送信してください"
+msgstr "Duck.aiは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してくださ"
-"い。"
+msgstr "Duck.aiは一時的に利用できません。ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7137,10 +6917,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiの"
-"ボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスで"
-"きます。"
+msgstr "Duck.aiでは、人気のAIモデルと非公開でチャットできます。無効にするとDuck.aiのボタンやリンクは非表示になりますが、%1$sduck.ai%2$sには引き続き直接アクセスできます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7151,10 +6928,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデル"
-"と匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタ"
-"ンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://"
-"duck.ai%2$s に直接アクセスすることでDuck.aiを利用できます。"
+""
+"Duck.aiを使用すると、OpenAIやAnthropicなどのサードパーティのAIチャットモデルと匿名で会話できます。この設定をオフにすると、DuckDuckGo検索上のDuck.aiのボタンやリンクが非表示になります。ただし、この設定がオフの状態でも、%1$shttps://duck.ai%2$s "
+"に直接アクセスすることでDuck.aiを利用できます。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7168,9 +6944,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用"
-"できます。"
+msgstr "Duck.aiの最近のチャットが失われた可能性があります。Duck.aiはいつも通りに使用できます。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7183,8 +6957,7 @@ msgstr "Duck.aiでPDFを読み、解析できるようになりました。ぜ�
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
+msgstr "Duck.aiの回答は特定の情報源に基づいておらず、正確性も確認されていません。"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7208,8 +6981,7 @@ msgstr "Duck.aiがアップグレードしました！"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
+msgstr "Duck.aiと最も相性の良いDuckDuckGoは、プライバシーを重視した無料のアプリです。"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7219,9 +6991,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、プライベートAIチャットボット、無料AIチャット、匿名AI"
-"チャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オー"
-"プンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
+"Duck.ai、DuckDuckGo "
+"AI、プライベートAIチャットボット、無料AIチャット、匿名AIチャット、サインアップ不要AIチャット、OpenAI、Anthropic、Llama、Mistral、オープンソースAIモデル、プライバシー重視AI、アカウント不要AIチャット"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7249,11 +7020,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。"
-"DuckAssistの表示頻度は、なし（検索結果からDuckAssist UIを完全に削除）、オンデ"
-"マンド（[アシスト] ボタンをクリックした場合にのみ表示）、時々（関連性の高い場"
-"合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点で"
-"は、米国（英語）地域でのみ利用可能です。"
+"このツールを使用すると、一部の検索に対して情報を匿名で調べ、要約できます。DuckAssistの表示頻度は、なし（検索結果からDuckAssist "
+"UIを完全に削除）、オンデマンド（[アシスト] "
+"ボタンをクリックした場合にのみ表示）、時々（関連性の高い場合にのみ表示）、頻繁（広範な検索でより頻繁に表示）から選択できます。現時点では、米国（英語）地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7262,9 +7031,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他か"
-"らチャットモデルをサポートするプライベートAI搭載チャットサービ"
-"ス、%1$sDuckDuckGo AI Chat%2$sもご利用いただけます。"
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAI、Anthropic、その他からチャットモデルをサポートするプライベートAI搭載チャットサービス、%1$sDuckDuckGo "
+"AI Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7273,8 +7042,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャット"
-"モデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
+""
+"DuckAssistは追加の質問には回答できません。ただし、OpenAIとAnthropicのチャットモデルをサポートするプライベートAI搭載チャットサービス、DuckDuckGo%1$sAI "
 "Chat%2$sもご利用いただけます。"
 
 # smartling.placeholder_format=C
@@ -7287,11 +7056,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 こ"
-"れを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、"
-"AIを活用した自然言語技術を使用して情報の要約を生成します。 現時点での回答は"
-"Wikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご"
-"注意ください。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる新しい検索機能です。 "
+"これを実現するために、Wikipediaや関連サイトをスキャンして関連コンテンツを探し、AIを活用した自然言語技術を使用して情報の要約を生成します。 "
+"現時点での回答はWikipediaおよび関連コンテンツに基づいており、正確性は確認されていないことにご注意ください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7305,22 +7072,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション"
-"機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI を活用した"
-"自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssist"
-"の回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのた"
-"め、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成さ"
-"れ、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重"
-"要です。"
+"DuckAssistは、検索クエリに対する回答を匿名で生成できる、検索結果のオプション機能です。この機能は、ウェブをスキャンして関連コンテンツを探し、AI "
+"を活用した自然言語技術で見つかった関連情報に基づき、簡単な回答を生成します。DuckAssistの回答は、常に1つか2つの情報源に直接リンクして回答元を引用しています。そのため、より詳細な情報を簡単に取得することができます。回答は引用元から自動生成され、%1$sウェブのクロール%2$sに基づいて自動生成されることを覚えておくことが重要です。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認さ"
-"れません。"
+msgstr "DuckAssistの回答は記載されている情報源に基づいて自動生成され、正確性は確認されません。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7328,9 +7088,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続"
-"行してください。"
+msgstr "DuckDuckGo AI Chatの1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7339,8 +7097,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7349,8 +7107,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートして"
-"いるプライベートAI搭載のチャットサービスです。"
+"DuckDuckGo AI "
+"Chatは、現在%1$sの%2$sと%3$sの%4$sチャットモデルをサポートしているプライベートAI搭載のチャットサービスです。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7358,9 +7116,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される"
-"可能性があります。"
+msgstr "DuckDuckGo AI Chatはベータ版であるため、不正確な情報や不快な情報が表示される可能性があります。"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7368,9 +7124,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード"
-"「%1$s」を%2$s宛てにメールで送信してください"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。この問題が続く場合は、匿名コード「%1$s」を%2$s宛てにメールで送信してください"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7378,17 +7132,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直"
-"してください。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 ページを更新して、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しくださ"
-"い。"
+msgstr "DuckDuckGo AI Chatは一時的に利用できません。 時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7537,18 +7287,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的"
-"に削除することで、これらのレポートを匿名化します。"
+msgstr "DuckDuckGoは、名前、メールアドレス、電話番号、識別メタデータなどのPIIを自動的に削除することで、これらのレポートを匿名化します。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに"
-"同意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、Duck.aiの%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7556,9 +7302,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同"
-"意したことになります。"
+msgstr "DuckDuckGoはチャットを匿名化します。「%1$s」をクリックすると、当社の%2$sに同意したことになります。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7566,9 +7310,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による"
-"追跡行為を阻止することができます。"
+msgstr "DuckDuckGoでは、アクセスするウェブサイト上でGoogleやFacebookなどの企業による追跡行為を阻止することができます。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7580,12 +7322,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する"
-"場合、ローカルデバイスだけに保存されます。DuckDuckGo は検索時にユーザーのデバ"
-"イスから送信される位置情報を検索結果を向上するために使用します。位置情報は使"
-"用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様の"
-"プライバシーを保護するため、当社がどのようにこの技術を設計したかについては、"
-"こちらをご覧ください%2$s。"
+"DuckDuckGo はプライバシーを保護するように設計されています。位置情報を使用する場合、ローカルデバイスだけに保存されます。DuckDuckGo "
+"は検索時にユーザーのデバイスから送信される位置情報を検索結果を向上するために使用します。位置情報は使用後にすぐ消去されるため、ユーザーは匿名性を保つことができます。%1$sお客様のプライバシーを保護するため、当社がどのようにこの技術を設計したかについては、こちらをご覧ください%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7604,9 +7342,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を"
-"表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
+msgstr "DuckDuckGo はおおよその位置情報のみを使用します。精度の高いローカル検索結果を表示するのに充分な情報です。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7697,10 +7433,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載"
-"されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～"
-"20字のパスフレーズ候補として4、5個の単語が選ばれます。"
+msgstr "パスフレーズ候補を生成する度、DuckDuckGoサーバーからランダムな単語が多数記載されたリストを取得します。その後お使いのブラウザ内で、そのリストから最低18～20字のパスフレーズ候補として4、5個の単語が選ばれます。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7776,8 +7509,7 @@ msgstr "画像を編集中..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
+msgstr "メッセージを編集すると、以下の応答が削除され、新しい応答が生成されます。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7914,9 +7646,7 @@ msgstr "ウェブ検索を有効にする"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後"
-"でいつでも変更できます。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を有効にしてください。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7958,9 +7688,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索"
-"データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
+msgstr "「匿名の位置情報」機能を有効にすると、より正確な検索結果が得られるうえ、検索データと正確な位置情報もDuckDuckGoに対して非公開のままとなります。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7984,8 +7712,7 @@ msgstr "暗号化モデル"
 #. Explains that the shared chat is encrypted so DuckDuckGo cannot read its contents.
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted. Not even DuckDuckGo can read your chat."
-msgstr ""
-"暗号化されています。DuckDuckGoでさえ、チャットの内容を読むことはできません。"
+msgstr "暗号化されています。DuckDuckGoでさえ、チャットの内容を読むことはできません。"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8093,8 +7820,7 @@ msgstr "位置情報へのアクセスは必ず %1$s許可%2$s にします。"
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
+msgstr "ブラウザによる%1$s位置情報へのアクセス%2$sが許可されていることを確認します"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8137,9 +7863,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてくだ"
-"さい。データが新しいパスフレーズで保存されます。"
+msgstr "新しいパスフレーズを入力し、%1$s設定を保存%2$sをクリックまたはタップしてください。データが新しいパスフレーズで保存されます。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8164,9 +7888,7 @@ msgstr "テキストを入力"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイ"
-"リアス%6$s: d%7$s"
+msgstr "以下の詳細を入力してください: %1$s名前%2$s: DuckDuckGo%3$s URL%4$s: %5$s エイリアス%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8509,7 +8231,7 @@ msgstr "速い"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "高速な画像生成"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8555,9 +8277,7 @@ msgstr "フィードバックが送信されました"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきま"
-"す。"
+msgstr "お寄せくださったフィードバックを私たちの製品の更新と改善に直接活用していきます。"
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8565,19 +8285,14 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用さ"
-"せていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組ん"
-"で参ります。"
+msgstr "お客様からいただいたフィードバックは、当社の製品のアップデートと改善に活用させていただきます。また、ご指摘についても真摯に受け止め、誠意を持って取り組んで参ります。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆"
-"ペーストしてください。"
+msgstr "以下から自由に設定できます。設定後のコードをあなたのウェブサイトにコピー＆ペーストしてください。"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8700,8 +8415,7 @@ msgstr "金融アドバイザー"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを検索し、%3$sデフォルトに設定 %4$sをクリックしてください"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8713,9 +8427,7 @@ msgstr "ダウンロードフォルダで<b>%1$s</b>を表示"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックしま"
-"す"
+msgstr "表示されたリストからDuckDuckGoを探し、%1$sデフォルトに設定%2$sをクリックします"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8752,9 +8464,7 @@ msgstr "あなたにとって最も的確な結果を見つけます。"
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されま"
-"す。"
+msgstr "お近くの結果を検索します。%1$s位置情報は非公開、安全、匿名のまま保持されます。"
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8817,9 +8527,7 @@ msgstr "霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオ"
-"プションを選択したり、ボタンをクリックする必要がある場合があります。"
+msgstr "DuckDuckGoの広告ブロッカーをオフにする手順に沿ってお進みください。メニューオプションを選択したり、ボタンをクリックする必要がある場合があります。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8842,7 +8550,7 @@ msgstr "フォローアップは非公開のままとなります。"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "指示に従った"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8978,9 +8686,7 @@ msgstr "営利目的で共有、使用が可能"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されませ"
-"ん。"
+msgstr "チャットを削除して容量を空けましょう。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9061,9 +8767,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; <strong>[アッ"
-"プデートを確認...]</strong>、次に<strong>[アップデートをインストール]</"
-"strong> を選択します。"
+"Macのアプリメニューバーから <strong>[DuckDuckGo]</strong> &gt; "
+"<strong>[アップデートを確認...]</strong>、次に<strong>[アップデートをインストール]</strong> を選択します。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9349,16 +9054,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削"
-"除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
+"DuckDuckGo VPN、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機"
-"能を利用できます。"
+msgstr "DuckDuckGo VPN、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9423,9 +9126,7 @@ msgstr "開始"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがです"
-"か。"
+msgstr "VPN1件と追加の保護対策2つを組み合わせた手軽なサブスクリプションはいかがですか。"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9446,9 +9147,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal "
-"Information Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の"
-"復旧）機能を利用できます。"
+"ノーログ型高速VPNに加え、高度なAIチャット（オプション）、Personal Information "
+"Removal（個人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9456,9 +9156,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft "
-"Restoration（ID盗難後の復旧）機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIチャット（オプション）Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9466,9 +9164,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これに"
-"は、VPNやその他のプレミアムなプライバシー保護も含まれています。"
+msgstr "DuckDuckGoに加入すると、Duck.aiで高度なAIモデルをご利用いただけます。これには、VPNやその他のプレミアムなプライバシー保護も含まれています。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9478,9 +9174,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。"
-"VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
+msgstr "DuckDuckGoのサブスクリプションでDuck.aiの高度なAIモデルにアクセスできます。VPNやその他のプレミアムなプライバシー保護機能も含まれています。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9523,9 +9217,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプ"
-"ション）、その他のプレミアム保護機能を利用できます。"
+msgstr "ノーログ型高速VPNに加え、高度なAIモデルへのアクセス（コール上限数拡大付きオプション）、その他のプレミアム保護機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9534,25 +9226,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個"
-"人情報の削除）、Identity Theft Restoration（ID盗難後の復旧）機能を利用できま"
-"す。"
+"ノーログ型の安全なVPNに加え、高度なDuck.ai、Personal Information Removal（個人情報の削除）、Identity "
+"Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難"
-"後の復旧）機能を利用できます。"
+msgstr "ノーログ型安全なVPNに加え、高度なDuck.ai、Identity Theft Restoration（ID盗難後の復旧）機能を利用できます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロー"
-"ド："
+msgstr "ブラウザの個人情報をシームレスに保護する無料ツールをワンクリックでダウンロード："
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9588,9 +9275,7 @@ msgstr "アプリをダウンロード"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょ"
-"う。%2$s"
+msgstr "DuckDuckGoブラウザを無料で入手して、%1$sYouTubeの広告をブロックしましょう。%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9649,9 +9334,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」 › 「テキストコードをコ"
-"ピー」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」 › 「テキストコードをコピー」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9660,8 +9344,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9671,9 +9355,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックして、次の"
-"コードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックして、次のコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9683,9 +9366,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャッ"
-"ト」 › 「Sync & Backup」 › 「別のデバイスと同期」%4$sの順にクリックします。ま"
-"たは、リカバリーPDFのQRコードをスキャンします。"
+"他のブラウザまたはDuckDuckGoアプリで%1$sDuck.ai設定%2$sに移動し、%3$s「チャット」 › 「Sync & Backup」 › "
+"「別のデバイスと同期」%4$sの順にクリックします。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9693,16 +9375,13 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに"
-"移動します。"
+msgstr "%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
+msgstr "%1$s[プライバシーとセキュリティ] > [位置情報サービス]%2$sの順に移動します"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9711,8 +9390,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動"
-"し、[位置情報サービス] がオンになっていることを確認します。"
+"%1$s [設定] > [プライバシーとセキュリティ] > [位置情報サービス] %2$sに移動し、[位置情報サービス] "
+"がオンになっていることを確認します。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9721,8 +9400,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、"
-"[DuckDuckGo] まで下にスクロールします。%3$s%4$s"
+"%1$s[設定] > [プライバシー] > [権限マネージャ] > [位置情報]%2$s に移動し、[DuckDuckGo] "
+"まで下にスクロールします。%3$s%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9794,7 +9473,7 @@ msgstr "プライバシーポリシーが良い"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "優れたビジュアルスタイル"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10416,8 +10095,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
+msgstr "Search Assistの回答で重要な事実を強調表示し、重要な情報を見つけやすくします。"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10444,8 +10122,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"キーボードの %1$s戻る%2$s キーを押して、%3$sDuckDuckGoをリストに保存しま"
-"す。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
+"キーボードの %1$s戻る%2$s "
+"キーを押して、%3$sDuckDuckGoをリストに保存します。%4$sそして、%5$sデフォルトに設定%6$sをクリックします"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10458,9 +10136,7 @@ msgstr "ミャオ語"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバ"
-"シーが保護されなくなります。"
+msgstr "ご注意ください！元の設定に戻すとDuckDuckGoの拡張機能が無効になり、プライバシーが保護されなくなります。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10509,9 +10185,7 @@ msgstr "猛暑"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様の"
-"プロファイリングには使用されません。"
+msgstr "ホテルの広告クリックはTripadvisorの広告ネットワークによって管理され、お客様のプロファイリングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10779,9 +10453,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズは"
-"どんなものですか、またその理由は何ですか？"
+msgstr "私は「風の名前」という本が好きです。 これに最も似ている他の良い本やシリーズはどんなものですか、またその理由は何ですか？"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10816,8 +10488,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセッ"
-"ト] > [位置情報とプライバシー設定をリセット]%2$s の順に移動します。"
+"それでもブラウザの位置情報を利用できない場合は、%1$s[設定] > [一般] > [リセット] > [位置情報とプライバシー設定をリセット]%2$s "
+"の順に移動します。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10827,9 +10499,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク "
-"> [メニュー] > [設定] > [サイト設定] > [位置情報]%2$s の順に移動し、"
-"DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
+"それでもブラウザの位置情報を使用できない場合は、ブラウザで、%1$s「⋮」マーク > [メニュー] > [設定] > [サイト設定] > "
+"[位置情報]%2$s の順に移動し、DuckDuckGo に位置情報へのアクセスを許可しているか確認します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10843,9 +10514,7 @@ msgstr "このエラーが続く場合は、%1$sに連絡してください。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追"
-"加する必要があります"
+msgstr "%1$sDuckDuckGo が表示されない場合、%2$s %3$sほかの検索エンジン%4$s リストに追加する必要があります"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10854,8 +10523,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"チャット プロバイダーまたは特定のチャット応答についてご不明な点がある場合"
-"は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
+"チャット "
+"プロバイダーまたは特定のチャット応答についてご不明な点がある場合は、%1$sおよび%2$sサポートページに直接お問い合わせいただくこともできます。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10863,18 +10532,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこの"
-"コードが必要になります。このコードはテキストファイルとしてデバイスに保存でき"
-"ます。"
+msgstr "デバイスにアクセスできなくなった場合、保存されたチャットを回復するためにこのコードが必要になります。このコードはテキストファイルとしてデバイスに保存できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力くだ"
-"さい%2$s"
+msgstr "もし、私たちをもっとサポートして頂けるなら、%1$sDuckDuckGoの普及にご協力ください%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10883,18 +10547,14 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンを"
-"ご利用ください。"
+msgstr "Javascript 無しで DuckDuckGo をご利用の場合は、 %1$s、または%2$s バージョンをご利用ください。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択して"
-"ください。"
+msgstr "ご希望であれば、新しいウィンドウと新しいタブの隣に開くホームページを選択してください。"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10937,7 +10597,7 @@ msgstr "画像プロンプトはDuck.aiの%1$sに準拠する必要がありま�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "画質"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11040,9 +10700,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレ"
-"クトする必要があります。%1$sさらに詳しく%2$s。"
+msgstr "古いブラウザの一部では、検索漏れを防ぐため、当社のサーバーを経由してリダイレクトする必要があります。%1$sさらに詳しく%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -11052,9 +10710,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同"
-"期」を選択します。"
+msgstr "DuckDuckGoブラウザで、「設定」＞「Sync & Backup」に移動し、「別のデバイスと同期」を選択します。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11068,9 +10724,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に"
-"保存されている情報を正確に知ることができます。"
+msgstr "情報透明性の観点から、このデータは暗号化されていません。つまり、DuckDuckGo に保存されている情報を正確に知ることができます。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11080,8 +10734,7 @@ msgstr "上部のメニューから%1$sツール%2$s > %3$s設定%4$sを選択"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
+msgstr "ポップアップ画面の、%1$s既定の検索エンジンに設定%2$s ボックスをオンにします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11407,8 +11060,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
+msgstr "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。"
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11476,11 +11128,7 @@ msgid ""
 "Items are ranked based on relevance to your search terms and are delivered "
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
-msgstr ""
-"アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告"
-"ネットワークを通じて配信されます。クリック後はマーチャントのランディングペー"
-"ジに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け"
-"取ることはありません。"
+msgstr "アイテムは検索キーワードとの関連性に基づいてランク付けされ、Microsoftの広告ネットワークを通じて配信されます。クリック後はマーチャントのランディングページに移動し、広告とは異なり、DuckDuckGoがクリックされた結果に対して報酬を受け取ることはありません。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11488,9 +11136,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっ"
-"と安全です。"
+msgstr "ランダムな文字や数字を10個覚えるよりは、単語を4～5つ覚える方が簡単な上、ずっと安全です。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11562,9 +11208,7 @@ msgstr "両方のデバイスでSync & Backupを開いたままにします。"
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確"
-"保できます。"
+msgstr "一度に最大5台のデバイスで、すべてのアプリとオンラインの活動のプライバシーを確保できます。"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11982,8 +11626,7 @@ msgstr "DuckDuckGo を使って匿名で検索しましょう"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
+msgstr "検索クエリの送信とDuck.aiへのプロンプトの送信を切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12757,9 +12400,7 @@ msgstr "ミクロネシア"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試し"
-"ください。"
+msgstr "マイクへのアクセスが拒否されました。マイクアクセスを許可して、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13542,11 +13183,7 @@ msgid ""
 "DuckDuckGo server after being sent, to help recover a chat if you lose your "
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
-msgstr ""
-"新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的"
-"に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立"
-"ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロ"
-"ンプトと応答の一時的な保存が無効になります。"
+msgstr "新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。チャット履歴を無効にすると、固定されたチャットが削除され、新しいプロンプトと応答の一時的な保存が無効になります。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13868,8 +13505,7 @@ msgstr "結果が見つかりません。"
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
+msgstr "音声が検出されませんでした。再試行時には、マイクに向かって話してください。"
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14381,9 +14017,7 @@ msgstr "オンデマンド"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順"
-"に%5$sクリックしてください"
+msgstr "Macでは%1$sMaxthon > 環境設定%2$s、Windowsでは%3$s アイコン > 設定%4$sの順に%5$sクリックしてください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14391,9 +14025,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動します"
+msgstr "別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイスと同期%4$sに移動します"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14402,8 +14034,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動して、このコードをスキャンします："
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動して、このコードをスキャンします："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14412,8 +14044,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › 別のデバイ"
-"スと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
+"別のデバイスで%1$sDuck.ai設定%2$s › %3$sチャット › Sync & Backup › "
+"別のデバイスと同期%4$sに移動します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14440,9 +14072,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルを"
-"アップロードしてください。"
+msgstr "添付ファイルの1点がサポートページ数を超えています。%1$sページ以下のファイルをアップロードしてください。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14468,8 +14098,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
+msgstr "変更した設定のみ。これらの詳細は %1$sURLパラメータ%2$s のページにあります。"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14483,9 +14112,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおい"
-"てからもう一度試してください。"
+msgstr "おっと！このテキストの翻訳中に予期しないエラーが発生しました。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14815,9 +14442,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡していま"
-"す。私たちは追跡しません。"
+msgstr "他社の検索エンジンはあなたの検索をプライベートブラウジングでも追跡しています。私たちは追跡しません。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14830,27 +14455,21 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミア"
-"ム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
+msgstr "ノーログ型の高速VPNに加え、上級AIチャット（利用上限数拡大）、その他のプレミアム保護機能を利用できます。全機能を1つにまとめたサブスクリプションです。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しま"
-"せん。"
+msgstr "私たちのプライバシーポリシーはシンプルです。ユーザーの個人情報は一切収集しません。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、"
-"強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
+msgstr "当社のモバイル用プライベートブラウザには、検索エンジン、トラッカーブロック、強制暗号化機能などが備わっています。%1$siOSとAndroid%2$sに対応。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15102,9 +14721,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情"
-"報をファイルに関連付けないため、パスフレーズを復元できません。"
+msgstr "当社は、お客様のIPアドレスやブラウザ上の個人を特定できる情報、その他一切の情報をファイルに関連付けないため、パスフレーズを復元できません。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15260,9 +14877,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removalは、お客様の個人情報を売買しているデータブロー"
-"カーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向け"
-"て対応します。"
+"Personal Information "
+"Removalは、お客様の個人情報を売買しているデータブローカーサイトから、その情報を見つけ出します。そして、お客様に代わって削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15332,10 +14948,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能"
-"性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検"
-"索設定%2$sにアクセスしてください。"
+msgstr "検索を質問として完全な文章で表現すると、AI支援の回答が自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$s検索設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15344,9 +14957,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精"
-"度が高くなります。 この機能の動作を調整したり、オフにするには、%1$sDuckAssist"
-"設定%2$sにアクセスしてください。"
+"検索を質問として完全な文章で表現すると、DuckAssistが表示される可能性と回答精度が高くなります。 "
+"この機能の動作を調整したり、オフにするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15355,10 +14967,7 @@ msgid ""
 "DuckAssist more likely to appear automatically and often yields better "
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
-msgstr ""
-"検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精"
-"度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設"
-"定%2$sにアクセスしてください。"
+msgstr "検索を完全な質問文で表現すると、DuckAssistが自動的に表示される可能性と回答精度が高くなります。オフにしてAssistボタンを非表示にするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15390,8 +14999,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15399,8 +15007,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
+msgstr "GPT-5 mini、Claude Haiku 4.5、Mistralなど人気のAIからチャット相手を選びます。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15408,9 +15015,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGo"
-"の保護が付属しません。"
+msgstr "目的地までの経路案内に使用するサービスを選択します。外部アプリにはDuckDuckGoの保護が付属しません。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15510,9 +15115,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"このプロンプトがボットにより行われていないことを確認するため、次のチャレンジ"
-"を完了してください。"
+msgstr "このプロンプトがボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15520,9 +15123,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"この検索がボットにより行われていないことを確認するため、次のチャレンジを完了"
-"してください。"
+msgstr "この検索がボットにより行われていないことを確認するため、次のチャレンジを完了してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15554,9 +15155,7 @@ msgctxt "Modal disclaimer text"
 msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
-msgstr ""
-"注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除され"
-"ます。"
+msgstr "注：モデルとの新しいチャットを開始すると、現在のチャットセッションが削除されます。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15564,9 +15163,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害また"
-"は違法である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが有害または違法である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15574,9 +15171,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法また"
-"は有害である理由を説明してください。"
+msgstr "プロンプトと問題のある出力（個人情報は削除）を貼り付け、コンテンツが違法または有害である理由を説明してください。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15790,15 +15385,13 @@ msgstr "フォーマットが不十分"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "画質が悪い"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャット"
-"は匿名化されます。"
+msgstr "人気のAIモデルが利用可能です。アカウントは必要ありません。当社によりチャットは匿名化されます。"
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16307,9 +15900,7 @@ msgstr "確認する"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示し"
-"ます。"
+msgstr "ローカル検索で利用する、おおよその位置情報の使用を許可するプロンプトを表示します。"
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16357,9 +15948,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独"
-"自のテキストを挿入します。]"
+msgstr "次のテキストをより簡潔にするための提案をいくつか提供してください。 [ここに独自のテキストを挿入します。]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16643,9 +16232,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16653,9 +16240,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデ"
-"バイスにローカルで保存されます。"
+msgstr "最近のチャットは、DuckDuckGoサーバーなどのリモートサーバーでなく、お使いのデバイスにローカルで保存されます。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16664,10 +16249,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポン"
-"スは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、イ"
-"ンターネット接続が途切れた場合のチャット復旧に役立ちます。"
+msgstr "最近のチャットはデバイスのローカルに保存されます。新しいプロンプトやレスポンスは暗号化され、送信後はDuckDuckGoサーバーに一時的に保存されます。これは、インターネット接続が途切れた場合のチャット復旧に役立ちます。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16808,9 +16390,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズ"
-"を縮小します"
+msgstr "結果の内部と周辺にある余分なスペースを減らし、結果のタイトルテキストのサイズを縮小します"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16951,8 +16531,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッ"
-"シュ）]、または [Reload（再読み込み）] ボタンをクリックします。"
+"指示に従ってDuckDuckGoを再度読み込みするか、ブラウザの [Refresh（リフレッシュ）]、または [Reload（再読み込み）] "
+"ボタンをクリックします。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17059,18 +16639,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「質問」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるように"
-"します。キャッシュされた回答は常に自動的に表示されます。"
+msgstr "「生成」ボタンを削除して、関連する検索に対して回答が自動的に表示されるようにします。キャッシュされた回答は常に自動的に表示されます。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17133,18 +16709,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の"
-"匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
+msgstr "レポートは匿名で、検索サービスの向上目的でDuckDuckGoに送信されます。お客様の匿名でのフィードバックはサービス改善に役立てるために%1$sとも共有されます。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個"
-"人を特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信される報告内容は、匿名です。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17152,10 +16724,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべ"
-"てのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を"
-"特定できる情報を含めないようお願いいたします。"
+msgstr "DuckDuckGoに送信されるレポートは、このページの読み込み中に翻訳を希望したすべてのテキストを含み、匿名になっています。フィードバックには、個人情報や個人を特定できる情報を含めないようお願いいたします。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17246,10 +16815,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象"
-"です。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。AI支援回答は、当社の%1$s利用規約%2$sの対象です。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17257,10 +16823,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバ"
-"イスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象"
-"になります。"
+msgstr "回答は教育的な目的のみであり、医療、法律、金融、投資、その他の専門的なアドバイスを意図したものではありません。DuckAssistは、当社の%1$s利用規約%2$sの対象になります。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17270,10 +16833,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なア"
-"ドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて"
-"生成されているため、不正確な情報が含まれている可能性があります。Search Assist"
-"には、当社の%1$s利用規約%2$sが適用されます。"
+""
+"回答は教育的な目的でのみ提供され、医療、法律、金融、投資、その他の専門的なアドバイスの提供を意図したものではありません。回答はウェブコンテンツに基づいて生成されているため、不正確な情報が含まれている可能性があります。Search "
+"Assistには、当社の%1$s利用規約%2$sが適用されます。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17697,9 +17259,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージ"
-"を使用すれば、さらに多くのチャットを保存できます。"
+msgstr "最新のチャットを最大30件デバイス上にローカルに保存できます。暗号化ストレージを使用すれば、さらに多くのチャットを保存できます。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17712,9 +17272,7 @@ msgstr "最新のチャットを最大30件デバイスにローカルで保存�
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょ"
-"う。"
+msgstr "エンドツーエンド暗号化を使用して、デバイス間でDuck.aiのチャットを保存しましょう。"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17873,9 +17431,7 @@ msgstr "下方向にスクロールし、%1$s詳細設定を表示%2$s をクリ
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします"
+msgstr "%1$sアドレスバーで検索%2$sが見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) をクリックします"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17884,8 +17440,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変"
-"更%4$s (または %5$s新たに追加%6$s) をクリックします。"
+"%1$sアドレスバーで検索%2$s が見つかるまで下方向にスクロールします。%3$s変更%4$s (または %5$s新たに追加%6$s) "
+"をクリックします。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17909,9 +17465,7 @@ msgstr "%1$sDuckDuckGo%2$sまで下にスクロールし、位置情報の使用
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s "
-"をクリックします。"
+msgstr "%1$sサービス%2$s セクションまで下方向にスクロールして、%3$sアドレスバー%4$s をクリックします。"
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17973,20 +17527,17 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コン"
-"テンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻"
-"度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々"
-"（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。"
-"Search Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
+"Search "
+""
+"Assistは検索クエリに対する回答を匿名で生成します。そのために、関連コンテンツをウェブでスキャンしてから、AIを使用して簡潔な回答を生成します。表示頻度は、「表示しない」、「要求時（Assistがクリックされたときのみ）」、「時々（関連性が高いとき）」、「頻繁（検索範囲が広いとき）」から選択できます。Search "
+"Assistは現時点で、英語圏の一部の地域でのみ利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけること"
-"ができませんでした。別の検索をお試しください。"
+msgstr "Search Assistはこの質問の回答を生成するのに十分な信頼できる情報を見つけることができませんでした。別の検索をお試しください。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17995,9 +17546,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。こ"
-"れを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情"
-"報に基づいてAIを使って簡潔な回答を生成します。"
+"Search "
+"Assistは、検索クエリに対する回答を匿名で生成するオプション機能です。これを行うには、%1$sウェブをスキャンして%2$s関連コンテンツを探し、見つかった情報に基づいてAIを使って簡潔な回答を生成します。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18117,9 +17667,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、"
-"Wikipediaで「ducks」を直接検索します。"
+msgstr "%1$sのショートカットで他のサイトを検索します：「!w ducks」を検索すると、Wikipediaで「ducks」を直接検索します。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18137,10 +17685,7 @@ msgstr "プライベートに検索し、トラッカーをブロック"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りの"
-"ブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索"
-"できます。"
+msgstr "検索時のプライバシーが心配なあなたにぴったりのアプリ・拡張機能。お気に入りのブラウザにプライベート検索機能を追加するか、%1$sduckduckgo.com%2$sで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18159,10 +17704,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されます"
-"が、設定をクラウド上のリモートサーバーに匿名で保存できるCloud Saveもご利用い"
-"ただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズが"
-"ブラウザの外に送信されることもありません。"
+"検索設定は、非個人用のブラウザCookieおよびローカルストレージに保存されますが、設定をクラウド上のリモートサーバーに匿名で保存できるCloud "
+"Saveもご利用いただけます。クラウドには個人を特定できる情報は一切保存されず、パスフレーズがブラウザの外に送信されることもありません。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18264,9 +17807,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18274,9 +17815,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべてのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべてのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18284,9 +17823,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、"
-"すべての同期済みのデバイスから簡単にアクセスできます。"
+msgstr "エンドツーエンド暗号化で、ほぼ無制限のチャットを当社サーバーに安全に保存し、すべての同期済みのデバイスから簡単にアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18294,9 +17831,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべ"
-"てのデバイスからアクセスできます。"
+msgstr "チャットはエンドツーエンド暗号化を使用して当社サーバーに安全に保存され、すべてのデバイスからアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18310,9 +17845,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。"
-"DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
+msgstr "データはDuckDuckGoのサーバー上にエンドツーエンド暗号化で安全に保存されます。DuckDuckGoを含めて、本人以外のユーザーは閲覧できません。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18462,41 +17995,35 @@ msgstr "Safariメニューの%1$s「このウェブサイトの設定...」%2$s 
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
+msgstr "%1$sカスタム%2$s を選択して、入力欄に %3$shttps://duckduckgo.com%4$s と入力"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトとして追加%4$sをクリックします。"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$sをクリックしてください"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
+msgstr "%1$sDuckDuckGo%2$sを選択し、%3$sデフォルトに設定%4$s をクリックします。"
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
+msgstr "%1$sDuckDuckGo%2$sをデフォルトの検索エンジン選択メニューから選んでください"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
+msgstr "リストで%1$sDuckDuckGo%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18508,9 +18035,7 @@ msgstr "検索エンジンから%1$sDuckDuckGo%2$sを選択してください"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択"
-"してください"
+msgstr "%1$sデフォルトの検索エンジン%2$sセクションの中にある%3$sDuckDuckGo%4$sを選択してください"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18521,8 +18046,7 @@ msgstr "選ぶなら%1$sDuckDuckGo%2$s！"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
+msgstr "ドロップダウンの中にある%1$s検索エンジンを編集...%2$sボタンを選択してください"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18535,9 +18059,7 @@ msgstr "ドロップダウンメニューの%1$sアドオン管理%2$sを選択�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$s"
-"メニュー > 設定%4$sの順に選択してください"
+msgstr "Macの場合、%1$sOpera > 設定%2$sの順に選択してください。Windowsの場合は、%3$sメニュー > 設定%4$sの順に選択してください"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18545,8 +18067,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合"
-"は、%3$sOpera > オプション%4$sの順に選択してください"
+"Macの場合、%1$sOpera > 環境設定%2$sの順に選択してください。Windowsの場合は、%3$sOpera > "
+"オプション%4$sの順に選択してください"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18565,8 +18087,7 @@ msgstr "%1$s検索エンジン%2$s を選択"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
+msgstr "%1$s検索エンジン%2$sを選択してから、%3$sその他...%4$sをクリックします。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18611,17 +18132,13 @@ msgstr "%1$s設定%2$sを選択し、%3$s検索エンジン%4$sを選択して�
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオ"
-"プションをどれか一つどうぞ)"
+msgstr "%1$sこのページをホームページに設定%2$sを選択してください(または他のお好みのオプションをどれか一つどうぞ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$s"
-"します"
+msgstr "リストで%1$sお使いのブラウザ%2$sを選択し、位置情報へのアクセスを%3$s許可%4$sします"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18693,9 +18210,7 @@ msgstr "選択テキストの参照元：%1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しくだ"
-"さい。"
+msgstr "選択したテキストが長すぎます。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18738,9 +18253,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これら"
-"の指示は、今後のすべての会話に適用されます。"
+msgstr "AIモデルに、メッセージに応答する方法を指示したプロンプトを送信します。これらの指示は、今後のすべての会話に適用されます。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18862,9 +18375,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるように"
-"Sync & Backupを設定します。"
+msgstr "チャット履歴をオンにしてから、チャットがデバイス間で継続的に同期されるようにSync & Backupを設定します。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18970,9 +18481,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お"
-"客様の正確な位置情報を当社や AI モデルに決して公開しません。"
+msgstr "都市レベルの位置情報をAIモデルと共有して関連性を向上させます。Duck.ai は、お客様の正確な位置情報を当社や AI モデルに決して公開しません。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19073,9 +18582,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事"
-"象の報告には必須）"
+msgstr "プロンプトとチャットの回答をDuckDuckGoと共有してください（違法および有害な事象の報告には必須）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19123,9 +18630,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単"
-"で、オン/オフの切り替えがいつでも可能です。"
+msgstr "ノーログ型の高速VPNを使って、オンライン活動を保護できます。セットアップは簡単で、オン/オフの切り替えがいつでも可能です。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19251,9 +18756,7 @@ msgstr "DuckAssist<sup>ベータ版</sup>を表示"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできま"
-"す。）"
+msgstr "DuckAssistをより頻繁に表示します。（完全に%1$sオフにする%2$sこともできます。）"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19436,8 +18939,7 @@ msgstr "サイドバーを表示する"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
+msgstr "Duck.aiを最大限に活用するためのステップバイステップのヒントを表示します。"
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19491,18 +18993,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオ"
-"フにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
+msgstr "DuckDuckGoでの検索が常に非公開であることのリマインダーを表示します。これをオフにすると、リマインダーが非表示になり、検索のプライバシーには影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これを"
-"オフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
+msgstr "DuckDuckGoでの検索が常に保護されていることのリマインダーを表示します。これをオフにするとリマインダーが非表示になりますが、検索の保護には影響しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19539,8 +19037,7 @@ msgstr "DuckDuckGoを端末に追加するリマインダーを随時表示"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
+msgstr "DuckDuckGoのプライバシーニュースレターへの登録に関する通知をときどき表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19561,9 +19058,7 @@ msgstr "入力に応じて検索ボックスの下に検索候補を表示"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表"
-"示"
+msgstr "ホームページでDuckDuckGoを利用することで生まれるプライバシー上のメリットを表示"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19814,8 +19309,7 @@ msgstr "サーバーへの保存が失敗しました。再度お試しくださ
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
+msgstr "Sync & Backupを有効にしている際に問題が発生しました。もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19845,8 +19339,7 @@ msgstr "時々表示する"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
+msgstr "申し訳ありませんが、お力になれません。別の方法で画像を説明してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19884,9 +19377,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像また"
-"は形式を試してください。"
+msgstr "申し訳ありませんが、アップロードした画像を処理できませんでした。別の画像または形式を試してください。"
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19894,17 +19385,13 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされ"
-"たことを確認してください。"
+msgstr "申し訳ありません。このコードは無効です。正しいコードが入力またはスキャンされたことを確認してください。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
-msgstr ""
-"申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai "
-"に聞いてみてください。"
+msgstr "申し訳ありませんが、これ以上豊富な回答を出すことはできませんでした。Duck.ai に聞いてみてください。"
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19912,17 +19399,13 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行す"
-"るには、%1$sこちらをクリック%2$sしてください。"
+msgstr "申し訳ありませんが、これらの結果を表示する際にエラーが発生しました。再試行するには、%1$sこちらをクリック%2$sしてください。"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてか"
-"らもう一度試してください。"
+msgstr "申し訳ありませんが、フィードバックを送信できませんでした。少し時間をおいてからもう一度試してください。"
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19976,9 +19459,7 @@ msgstr "ソーステキストが消去されました"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度"
-"お試しください。"
+msgstr "ソーステキストが長すぎて要約できません。ソーステキストを一部選択し、もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20183,8 +19664,7 @@ msgstr "DuckDuckGoを使用し続ける"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
+msgstr "プライバシーニュースレターで、データを常時守り、最新情報を入手しましょう。"
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20328,9 +19808,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "Duck.aiの制限を引き上げるにはDuckDuckGoに登録するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20398,8 +19876,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
+msgstr "手術したばかりの人宛てのお見舞いのカードに書くフレーズを提案してください。"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20735,8 +20212,7 @@ msgstr "%1$sに切り替えました"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
+msgstr "切り替えると、チャットはプロバイダーの可視性がゼロのモデルに送信されます"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20798,8 +20274,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backupは、より多くのチャットを保存し、すべてのデバイス間で同期します。"
+msgstr "Sync & Backupは、より多くのチャットを保存し、すべてのデバイス間で同期します。"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20848,25 +20323,21 @@ msgid ""
 msgstr ""
 "同期リカバリーコード\n"
 "\n"
-"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複"
-"数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同"
-"期済みのデータを回復できます。\n"
+""
+""
+"リカバリーコードを使用すると、パスワード、自動入力データ、Duck.aiチャットが複数のデバイスで同期されるようになり、デバイスにアクセスできなくなった場合に同期済みのデータを回復できます。\n"
 "\n"
 "この情報は安全に保管してください。\n"
-"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできま"
-"す。\n"
+"このコードにアクセス可能なユーザーは誰でも同期済みデータにアクセスできます。\n"
 "\n"
 "%1$s\n"
 "\n"
 "このコードの仕組みは？\n"
 "1. ブラウザでDuck.aiにアクセスし、Duck.aiの設定を開きます。\n"
-"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択しま"
-"す\n"
-"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付"
-"けます\n"
+"2. 「Sync & Backupをオンにする」、「同期されたデータを復元」の順に選択します\n"
+"3. リカバリーコードをコピーし、「ここにコードを貼り付けてください」欄に貼り付けます\n"
 "\n"
-"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除さ"
-"れ、復元できなくなります。"
+"DuckDuckGoブラウザの未使用期間が18か月を超えると、データはサーバーから削除され、復元できなくなります。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -21004,9 +20475,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、"
-"無料アプリに組み込めます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。どこにいても素早くアクセスできるよう、無料アプリに組み込めます。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21014,9 +20483,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこから"
-"でも素早くアクセスできます。"
+msgstr "Duck.aiをどこへでも連れて行きましょう。無料ブラウザに組み込むことで、どこからでも素早くアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21039,8 +20506,7 @@ msgstr "個人データを自己管理しましょう！"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
+msgstr "この匿名アンケートに回答して、Duck.aiを改善するためのご意見をお寄せください。"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21260,10 +20726,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情"
-"報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワード"
-"や支払い情報がこうした情報に含まれる場合もあります。"
+msgstr "つまり、お使いのデバイスとこのリンクに接続するウェブページの間で送信される情報はサードパーティに傍受されるリスクが高いことになります。まれに、パスワードや支払い情報がこうした情報に含まれる場合もあります。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21271,9 +20734,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動"
-"保存できます。"
+msgstr "Cloud Save ブックマークレットを使用すると、設定上の変更をすべてクラウドに自動保存できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21281,9 +20742,7 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr ""
-"Duck.aiトグルを使用すると、プライベート検索とDuckDuckGoによって匿名化されたAI"
-"チャットをすばやく切り替えることができます。"
+msgstr "Duck.aiトグルを使用すると、プライベート検索とDuckDuckGoによって匿名化されたAIチャットをすばやく切り替えることができます。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21312,18 +20771,14 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本"
-"人だけです。"
+msgstr "暗号化キーはブラウザのローカルストレージにのみ保存され、アクセスできるのは本人だけです。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除しま"
-"す。"
+msgstr "モデルプロバイダーはこのチャットに関連するすべてのデータを30日以内に削除します。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21337,8 +20792,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
+msgstr "モデルプロバイダーは、このチャットや関連データをサーバーに保存しません。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21396,9 +20850,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確"
-"認し、ローカルデータの保存が有効になっていることをご確認ください。"
+msgstr "このチャットをローカルに保存する際にエラーが発生しました。ブラウザの設定を確認し、ローカルデータの保存が有効になっていることをご確認ください。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21412,9 +20864,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してくださ"
-"い。"
+msgstr "検索結果の表示中にまたエラーが発生しました。数分待ってから再試行してください。"
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21432,10 +20882,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加す"
-"るために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoを"
-"デフォルトの検索エンジンにするために使用されます。"
+msgstr "これらのブラウザのアクセス許可は、訪問したWebサイトにプライバシー保護を追加するために隠れたトラッカーをブロックし、接続を可能な限り暗号化し、DuckDuckGoをデフォルトの検索エンジンにするために使用されます。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21472,9 +20919,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみ"
-"てください。"
+msgstr "このAIモデルは使用できなくなりました。別のモデルで新しいチャットを開始してみてください。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21482,9 +20927,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャッ"
-"トを開始してください。"
+msgstr "このAIモデル版はサポートされなくなりました。このモデルの最新版で新しいチャットを開始してください。"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21522,10 +20965,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な情報が表示される場合があります（詳細について"
-"は%4$sを参照してください）。"
+msgstr "この会話は、%2$sの%3$sモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21534,10 +20974,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AI"
-"チャットでは不正確な情報や不快な内容が表示される場合があります（詳細について"
-"は%2$sを参照してください）。"
+msgstr "この会話は、複数のチャットモデルを使用してDuck.ai（%1$s）で生成されました。AIチャットでは不正確な情報や不快な内容が表示される場合があります（詳細については%2$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21545,9 +20982,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な"
-"情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
+msgstr "この会話はDuck.aiボイスチャット(%1$s)で生成されました。AIは不正確または不快な情報を提供する可能性があります。（詳細は%2$sを参照してください。）"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21557,9 +20992,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI Chat（%1$s）で生成されま"
-"した。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細"
-"については%4$sを参照してください）。"
+"この会話は、%2$sの%3$sモデルを使用してDuckDuckGo AI "
+"Chat（%1$s）で生成されました。AIチャットでは不正確な情報や不快な情報が表示される場合があります（詳細については%4$sを参照してください）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21575,9 +21009,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s"
-"件のチャットはローカルストレージで引き続き利用可能です。"
+msgstr "このデバイスは、他のデバイスの同期データにアクセスできなくなります。直近%1$s件のチャットはローカルストレージで引き続き利用可能です。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21609,8 +21041,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21618,8 +21049,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
+msgstr "このファイル形式はサポートされていません。%1$sまたは%2$sを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21650,18 +21080,14 @@ msgstr "この画像は作成できませんでした。"
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してくだ"
-"さい。"
+msgstr "この画像形式はサポートされていません。JPG、PNG、WebP、またはGIFを添付してください。"
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21688,9 +21114,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択する"
-"と、チャットの先頭に固定できます！"
+msgstr "これはサンプルチャットです。メニュー（3つの点）を開き、「ピン留め」を選択すると、チャットの先頭に固定できます！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21698,9 +21122,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してくださ"
-"い！"
+msgstr "これはサンプルチャットです。サイドメニューのFire Buttonを使って削除してください！"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21720,9 +21142,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除しま"
-"す。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
+msgstr "このモデルプロバイダーは、このチャットに関連するデータを30日以内に削除します。他のモデルプロバイダーは、データを一切保持しないモデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21730,9 +21150,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"このモデルプロバイダーはこのチャットに関連するデータを保存していません。他の"
-"モデルプロバイダーは限定的なデータ保持モデルを採用しています。"
+msgstr "このモデルプロバイダーはこのチャットに関連するデータを保存していません。他のモデルプロバイダーは限定的なデータ保持モデルを採用しています。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21768,9 +21186,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後"
-"でどのブラウザからでもアクセスできます。"
+msgstr "チャットはエンドツーエンドの暗号化でDuckDuckGoの安全なサーバーに保存され、後でどのブラウザからでもアクセスできます。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21778,9 +21194,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。"
+msgstr "この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21790,17 +21204,15 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除"
-"すると、AI支援の回答が再表示されることがあります。ただし、%1$s にはAI支援の回"
-"答が一切表示されないスタートページもご用意しています。"
+""
+"この設定はブラウザに保存されているため、duckduckgo.comのブラウザデータを削除すると、AI支援の回答が再表示されることがあります。ただし、%1$s "
+"にはAI支援の回答が一切表示されないスタートページもご用意しています。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"この共有チャットを開くことができませんでした。リンクが不完全な可能性がありま"
-"す。"
+msgstr "この共有チャットを開くことができませんでした。リンクが不完全な可能性があります。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21829,16 +21241,13 @@ msgstr "この翻訳は正しくありません"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能で"
-"す。"
+msgstr "この動画はまだここで視聴することはできません。この動画は %1$s 上で視聴可能です。"
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
+msgstr "このウェブページでは「暗号化された安全な接続(HTTPS)」を利用できません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21848,9 +21257,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除さ"
-"れ、Sync & Backupとの接続は解除されます。Sync & Backupに接続している他のブラ"
-"ウザでは、引き続きチャットにアクセスできます。"
+"このオプションを選択すると、Duck.aiのチャットがこのブラウザからすべて削除され、Sync & Backupとの接続は解除されます。Sync & "
+"Backupに接続している他のブラウザでは、引き続きチャットにアクセスできます。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21858,9 +21266,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。こ"
-"の操作は取り消せません。"
+msgstr "これにより、ピン留めされていない限り、最近のチャットがすべて削除されます。この操作は取り消せません。"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21997,9 +21403,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印"
-"刷アイコンをクリックします。%4$s"
+msgstr "ルートの印刷手順：%1$s地図に戻ります。%2$s印刷するルートを選択します。%3$s印刷アイコンをクリックします。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22008,10 +21412,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"同期したデータを復元するには、同期を初めて設定したときに保存したリカバリー"
-"コードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保"
-"存されている可能性があります。"
+msgstr "同期したデータを復元するには、同期を初めて設定したときに保存したリカバリーコードが必要です。このコードは、同期設定に最初に使用したデバイスにPDFとして保存されている可能性があります。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22019,18 +21420,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアッ"
-"プデートし、再度お試しください。"
+msgstr "チャット履歴をDuck.aiに転送するには、DuckDuckGoブラウザを最新バージョンにアップデートし、再度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるよ"
-"うに設定してください。"
+msgstr "音声入力機能を使用するには、システム設定でブラウザがマイクにアクセスできるように設定してください。"
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -22052,17 +21449,13 @@ msgstr "今日"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"トグルを切り替えてプライベートAIチャットにするか、%1$s設定で無効にする%2$sこ"
-"ともできます。"
+msgstr "トグルを切り替えてプライベートAIチャットにするか、%1$s設定で無効にする%2$sこともできます。"
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にで"
-"きます。%3$s"
+msgstr "トグルを切り替えてプライベートAIチャットを試すか、%1$s%2$sメニューで無効にできます。%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22128,7 +21521,7 @@ msgstr "遅すぎる"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "生成が遅すぎる"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22241,9 +21634,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、"
-"ブロック件数が表示されるようになります。"
+msgstr "DuckDuckGoが追跡試行をブロックすると、こちらに表示されます。閲覧を続けると、ブロック件数が表示されるようになります。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22290,9 +21681,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって"
-"行けばいいですか？」"
+msgstr "この英語の文章をフランス語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22300,9 +21689,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行け"
-"ばいいですか？」"
+msgstr "この日本語の文章を英語に翻訳してください。「最寄りの映画館へはどうやって行けばいいですか？」"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22410,8 +21797,7 @@ msgstr "%1$sを試す"
 # smartling.placeholder_format=C
 #. Prompt for the user to start using our homepage that doesn't show promotional messages. The placeholder is a homepage url (e.g., 'start.duckduckgo.com')
 msgid "Try %s to stop seeing messages like this."
-msgstr ""
-"このようなメッセージが表示されないようにするには、%1$sをお試しください。"
+msgstr "このようなメッセージが表示されないようにするには、%1$sをお試しください。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
@@ -22421,9 +21807,7 @@ msgstr "プロバイダーの可視性がゼロの最初のモデル%1$sをお�
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試し"
-"を！"
+msgstr "%1$sDuck.ai%2$sは、個人情報保護に配慮したAIチャットサービスです。ぜひ、お試しを！"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22552,16 +21936,13 @@ msgstr "別のキーワードを試してみてください。"
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しく"
-"ださい。"
+msgstr "より多くの結果を表示するには、DuckDuckGoで広告ブロッカーを無効にしてお試しください。"
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
+msgstr "検索結果の精度を高めるには、匿名の位置情報を使用する設定にしてみてください。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22580,7 +21961,7 @@ msgstr "キーワードの数を減らしてみてください。"
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "無料で試す"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22700,8 +22081,7 @@ msgstr "位置情報を手動で設定してみてください。"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
+msgstr "%1$sDuckDuckGoブラウザ%2$sをお試しください。スピーディで無料、プライベート。"
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22759,8 +22139,7 @@ msgstr "最近追加されたオープンソースのLlama 3.1とMixtralをお�
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
+msgstr "まずはこれらのプロンプトを試すか、以下に独自のプロンプトを入力してください。"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22954,8 +22333,7 @@ msgstr "より正確な結果を得るには、「正確な位置情報」をオ
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
+msgstr "より正確な結果を得るには、「正確な位置情報を使用」をオンにしてください。"
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -22999,17 +22377,14 @@ msgstr "「%1$sDuckDuckGo%2$s」と %3$s フォームの最初のフィールド
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Type %sduckduckgo.com%s in the %ssecond form field"
-msgstr ""
-"「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
+msgstr "「%1$sduckduckgo.com%2$s」と%3$s フォームの2番目のフィールドに入力します"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索して"
-"から回答が表示されるまでに、多少タイムラグが生じる場合があります。"
+msgstr "DuckAssist が生成した回答を入力します。このオプションをオフにすると、検索してから回答が表示されるまでに、多少タイムラグが生じる場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23138,18 +22513,14 @@ msgstr "長所と短所を明らかにする"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$s"
-"ページがセレクト%6$s クリックします。"
+msgstr "%1$sスタートの時%2$s の下、%3$sとあるページを開く%4$s をクリックして、%5$sページがセレクト%6$s クリックします。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと"
-"入力してください"
+msgstr "%1$sOn startup%2$sの中から%3$sHomepage%4$sを選択してhttps://duckduckgo.comと入力してください"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23159,8 +22530,7 @@ msgstr "%1$s開く%2$s の中から %3$s特定のページを開く%4$s を選�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
+msgstr "%1$s起動時 > ホームページ%2$sの中で https://duckduckgo.com と入力してください"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23170,17 +22540,13 @@ msgstr "%1$s検索設定%2$sで、%3$sDuckDuckGo%4$sを選択します"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$s"
-"を選択します"
+msgstr "%1$sアドレスバーでの検索時に使う検索プロバイダー%2$sの下の%3$s新たに追加%4$sを選択します"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックし"
-"ます"
+msgstr "%1$s検索%2$sセクションの下にある「%3$s検索エンジンの管理...%4$s」をクリックします"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23269,9 +22635,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上"
-"限がPlusプランの2倍になります。"
+msgstr "Proにアップグレードすると、%1$sのロックが解除され、AI推論能力が向上し、使用上限がPlusプランの2倍になります。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23331,9 +22695,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょ"
-"う。%1$s"
+msgstr "DuckDuckGoのサブスクリプションで、より高性能なAIモデルをアンロックしましょう。%1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23430,9 +22792,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度な"
-"モデルにアクセスしよう"
+msgstr "DuckDuckGo ブラウザを更新して、Duck.ai でサブスクリプションを有効にし、高度なモデルにアクセスしよう"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23556,9 +22916,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像"
-"を作成してください。"
+msgstr "ProにアップグレードしてPlusの2倍の制限を活用するか、後で戻ってきてさらに画像を作成してください。"
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23659,10 +23017,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、"
-"詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必"
-"要ありません。"
+msgstr "ChatGPT、Claude、その他のAIをプライベートに使いましょう。チャットをハッカー、詐欺師、企業から守りましょう。情報の機密を保ちましょう。無料。アカウントは必要ありません。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23674,8 +23029,7 @@ msgstr "DuckDuckGo Private Searchを使う"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
+msgstr "あなたのiPad、iPhoneまたはAndroidで、DuckDuckGoのプライベート検索を使おう！"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23717,18 +23071,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大"
-"切に保管してください。"
+msgstr "デバイスにアクセスできない場合は、このコードを使用してデータを復元します。大切に保管してください。"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを"
-"復元してください。"
+msgstr "デバイスへのアクセスを失った場合に、このコードを使用して保存済みのチャットを復元してください。"
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23852,8 +23202,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.aiから共有された会話を表示 — DuckDuckGoによる無料のプライベートAIチャッ"
-"ト。自分のチャットに保存して、プライバシーを保護しながら会話を続けましょう。"
+"Duck.aiから共有された会話を表示 — "
+"DuckDuckGoによる無料のプライベートAIチャット。自分のチャットに保存して、プライバシーを保護しながら会話を続けましょう。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23887,9 +23237,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは "
-"Microsoft の広告ネットワークで管理されています"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは Microsoft の広告ネットワークで管理されています"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23897,9 +23245,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックは"
-"TripAdvisorの広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーは DuckDuckGo で保護されます。広告のクリックはTripAdvisorの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23907,9 +23253,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
-"広告表示機能のプライバシーはDuckDuckGoで保護されます。広告のクリックはYelpの"
-"広告ネットワークで管理されています。"
+msgstr "広告表示機能のプライバシーはDuckDuckGoで保護されます。広告のクリックはYelpの広告ネットワークで管理されています。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23920,9 +23264,7 @@ msgstr "ヴァージン諸島"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセ"
-"スしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23930,9 +23272,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにア"
-"クセスしてください。"
+msgstr "この機能の動作を調整したり、オフにしたりするには、%1$sDuckAssist設定%2$sにアクセスしてください。"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23940,9 +23280,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従って"
-"ください。"
+msgstr "タブレットまたは携帯電話で%1$sDuckDuckGo.com%2$sにアクセスして、案内に従ってください。"
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23957,9 +23295,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してくださ"
-"い。"
+"他のブラウザでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s "
+"に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23968,10 +23305,7 @@ msgid ""
 "Visit Duck.ai in your other browser and open Duck.ai Settings. Select “Turn "
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
-msgstr ""
-"別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆"
-"Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。ま"
-"たは、リカバリーPDFのQRコードをスキャンしてください。"
+msgstr "別のブラウザでDuck.aiにアクセスし、Duck.aiの設定を開いてください。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択してください。または、リカバリーPDFのQRコードをスキャンしてください。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23981,9 +23315,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s "
-"> %3$sSync & Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選"
-"択してください。"
+"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、%1$sDuck.ai設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s に進み、%7$s別のデバイスと同期%8$sを選択してください。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23992,10 +23325,7 @@ msgid ""
 "Visit Duck.ai in your other browser or the DuckDuckGo app and open Duck.ai "
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
-msgstr ""
-"他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開き"
-"ます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択しま"
-"す。または、リカバリーPDFのQRコードをスキャンします。"
+msgstr "他のブラウザまたはDuckDuckGoアプリでDuck.aiにアクセスし、Duck.aiの設定を開きます。Sync＆Backupで「オンにする」を選択し、「別のデバイスと同期」を選択します。または、リカバリーPDFのQRコードをスキャンします。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24047,9 +23377,7 @@ msgstr "ボイスチャットは終了しました"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用"
-"されません。"
+msgstr "ボイスチャットは当社によって匿名化されており、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24137,8 +23465,7 @@ msgstr "壁紙"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"新しいタブページからプライベートなAIチャットに簡単にアクセスしたいですか？"
+msgstr "新しいタブページからプライベートなAIチャットに簡単にアクセスしたいですか？"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24200,8 +23527,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、"
-"YouTube のおすすめに影響されずに動画を視聴できます。"
+"Duck Player で視聴すると、YouTube でパーソナライズ広告がブロックされるため、YouTube "
+"のおすすめに影響されずに動画を視聴できます。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24220,11 +23547,7 @@ msgid ""
 "because we have to stream the content from there. DuckDuckGo is an "
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
-msgstr ""
-"このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテン"
-"ツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGo"
-"は独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ござ"
-"いません。"
+msgstr "このプラットフォームで動画を視聴する場合、ホストするウェブサイトからコンテンツが流されるため、そのウェブサイトは視聴者の追跡が可能になります。DuckDuckGoは独立した会社であり、ほとんどの動画がホストされているYouTubeとは一切関係ございません。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24236,8 +23559,7 @@ msgstr "匿名化に対応"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
+msgstr "%1$s位置情報%2$sを匿名化して、より正確な結果が表示されるようにできます。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24248,10 +23570,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報する"
-"には、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してし"
-"てください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な回答を通報するには、DuckDuckGoが問題を調査し、対処できるように、この会話を当社と共有してしてください。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24262,9 +23581,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する"
-"場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
+msgstr "当社が修正できるのは、目に見えるものだけです。有害または違法な応答を報告する場合は、問題を調査し対処するために、プロンプトと応答内容をお知らせください。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -24277,9 +23594,7 @@ msgstr "匿名の%1$s位置情報%2$sを使用すると、おおよその結果�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることがで"
-"きません。"
+msgstr "添付ファイルのうち少なくとも1つが暗号化されているため、内容を読み取ることができません。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24306,9 +23621,7 @@ msgstr "私たちはあなたの個人情報を保存しません。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束"
-"します。"
+msgstr "個人情報を保存しません。広告で追い回しません。閲覧状況を追跡しません。お約束します。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24321,9 +23634,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った"
-"理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「もう一度DuckDuckGoを使おうと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24331,9 +23642,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと"
-"思った理由」を教えてください。"
+msgstr "私たちはあなたを追跡しません。ですから、「あなたがDuckDuckGoを使ってみようと思った理由」を教えてください。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24372,23 +23681,18 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であ"
-"なたを追跡して、それを広告主に販売することはありません。"
+msgstr "私たちは、あなたの検索履歴を保存しません。したがって、インターネット経由であなたを追跡して、それを広告主に販売することはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しま"
-"せん。"
+msgstr "私たちは、プライベートブラウジングモードでも、それ以外でも、あなたを追跡しません。"
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
+msgstr "私たちはあなたを追跡しません。これが私たちのプライバシーポリシーの概要です。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24402,9 +23706,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご"
-"利用いただけます。"
+msgstr "データブローカーサイトから個人情報を探して削除します。さらにVPNなどの機能もご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24412,8 +23714,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
+msgstr "チャットがAIの学習に使用されない旨の契約をAIプロバイダーと結んでいます。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24437,9 +23738,7 @@ msgstr "接続が失われました。メッセージの送信をもう一度お
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索"
-"広告%2$sから収益を得ています。"
+msgstr "私たちは、あなたのデータを悪用するのではなく、%1$sプライバシーを尊重する検索広告%2$sから収益を得ています。"
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24447,9 +23746,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されま"
-"す。この設定は後でいつでも変更できます。"
+msgstr "匿名の位置情報は、表示される結果を比較的近くに絞り込む目的でのみ使用されます。この設定は後でいつでも変更できます。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24457,17 +23754,13 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、"
-"使いやすいダッシュボードで進捗状況を共有します。"
+msgstr "当社はデータブローカーサイトを定期的にスキャンしてお客様の個人情報を検索し、使いやすいダッシュボードで進捗状況を共有します。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名"
-"でのフィードバックを頼りにしています。"
+msgstr "DuckDuckGoを誰にとってもより良いものにするために、私たちはみなさまからの匿名でのフィードバックを頼りにしています。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24487,9 +23780,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご"
-"提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
+msgstr "このようなフィードバックをDuckDuckGoの向上に活用します。%1$sは独自の判断でご提案を採用します。訂正内容は結果にすぐ表示されない場合があります。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24502,9 +23793,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所など"
-"を探し、見つかった個人情報の削除に向けて対応します。"
+msgstr "データブローカーサイトをスキャンして、お客様のメールアドレス、名前、住所などを探し、見つかった個人情報の削除に向けて対応します。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24512,9 +23801,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエ"
-"ラーが続く場合は、%1$sに連絡してください。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。このエラーが続く場合は、%1$sに連絡してください。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24522,9 +23809,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウ"
-"ザのキャッシュをクリアすると解決に役立つ場合があります。"
+msgstr "当社はこの問題について認識しており、現在解決に向けて取り組んでいます。ブラウザのキャッシュをクリアすると解決に役立つ場合があります。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24538,9 +23823,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力していま"
-"す。"
+msgstr "ご不便をおかけして申し訳ありません。体験の改善のために一生懸命努力しています。"
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24548,9 +23831,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要"
-"があります。"
+msgstr "Duck.aiサービスを更新しました。変更を有効にするには、ページをリロードする必要があります。"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24671,9 +23952,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのト"
-"レーニングには使用されません。"
+msgstr "Duck.aiへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24681,9 +23960,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、"
-"AIモデルのトレーニングには使用されません。"
+msgstr "DuckDuckGo AI Chatへようこそ！ここでのチャットはすべて非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24693,17 +23970,14 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chatへようこそ！このチャットセッションは%1$sの%2$sを使用してい"
-"ます。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルの"
-"トレーニングに使用されたりすることはありません。"
+"DuckDuckGo AI "
+"Chatへようこそ！このチャットセッションは%1$sの%2$sを使用しています。ここでのチャットはすべて非公開で、DuckDuckGoに保存されたり、AIモデルのトレーニングに使用されたりすることはありません。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになり"
-"ました。"
+msgstr "新しいDuck.aiへようこそ！ダウンロードしたチャットをインポートできるようになりました。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24770,9 +24044,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込"
-"みしてみてください。"
+msgstr "申し訳ありませんが、Duck.aiの読み込みに問題があったようです。ページを再読み込みしてみてください。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24786,9 +24058,7 @@ msgctxt "Full sentence for improving arguments"
 msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
-msgstr ""
-"プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありま"
-"すか？"
+msgstr "プラントベースの食事の概念に対する議論、反論、反駁にはどのようなものがありますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24808,9 +24078,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をど"
-"う言い換えられますか？"
+msgstr "「私たちは本当にもっとうまくやる必要がある」という文脈で「もっとうまく」をどう言い換えられますか？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24834,12 +24102,7 @@ msgid ""
 "ai integrations, and privacy protections. Keep it quite short, simple, and "
 "easy to understand for people with or without much AI, or technical, "
 "experience."
-msgstr ""
-"Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメ"
-"リットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回"
-"答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に"
-"重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、"
-"誰でも簡単に理解できるように回答します。"
+msgstr "Duck.aiの利用に興味があるユーザーが、DuckDuckGoブラウザをダウンロードするメリットとは何でしょうか。まず、DuckDuckGoの公式ソースのみ参照します。また、回答はタイトル付きの明確なセクションに分かれ、Duck.aiの統合とプライバシー保護に重点が置かれます。簡潔かつシンプルで、AIや技術に関する経験の有無に関わらず、誰でも簡単に理解できるように回答します。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25074,9 +24337,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットと"
-"の違いは？"
+msgstr "Cloud Saveブックマークレットとは何ですか？URLパラメータ・ブックマークレットとの違いは？"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25176,9 +24437,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何です"
-"か？"
+msgstr "初心者向けのエレキギターを購入する場合、考慮すべきトップ製品ブランドは何ですか？"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25378,9 +24637,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはあ"
-"りません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
+msgstr "Duck.aiでは、チャットは匿名化されており、AIのトレーニングに使用されることはありません。「%1$s」メニューでいつでもオン/オフを切り替えられます。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25388,17 +24645,14 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
-"チャット履歴をオンにすると、最新のチャットを最大%1$s件このデバイスに保存しま"
-"す。"
+msgstr "チャット履歴をオンにすると、最新のチャットを最大%1$s件このデバイスに保存します。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
-"チャット履歴をオンにすると、最新のチャットがこのデバイスに保存されます。"
+msgstr "チャット履歴をオンにすると、最新のチャットがこのデバイスに保存されます。"
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25412,9 +24666,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名"
-"前、住所などの個人情報を削除します。"
+msgstr "お使いのデバイス上で直接動作し、データブローカーサイトからメールアドレス、名前、住所などの個人情報を削除します。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25681,9 +24933,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合"
-"があります。"
+msgstr "%1$sとチャット中です。 AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25691,9 +24941,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検"
-"索できます。"
+msgstr "%1$sか、%2$s検索ショートカットを使用してDuckDuckGoや他の検索エンジンで直接検索できます。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25706,8 +24954,7 @@ msgstr "DuckDuckGo AI Chatには%1$sから直接アクセスできます。"
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
+msgstr "%1$sの動作を調整したり、%2$s検索設定%3$sでいつでも無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25715,22 +24962,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
+msgstr "Assistは、動作を調整したり、%1$s検索設定%2$sでいつでもオフにしたりできます。"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできま"
-"す。"
+msgstr "%1$sDuck.ai%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりする"
-"こともできます。"
+msgstr "%1$s DuckDuckGo AI Chat%2$sを使用して質問に答えたり、テキストを要約したりすることもできます。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25743,9 +24985,7 @@ msgstr "添付するテキストは最大%1$sまで選択できます。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりで"
-"きます。"
+msgstr "Search Assistは、%1$s検索設定%2$sで表示頻度を変更したり、完全に無効にしたりできます。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25765,9 +25005,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任"
-"意で削除できます。"
+msgstr "設定を別のパスフレーズで保存してください。それまで使っていたパスフレーズも任意で削除できます。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25796,8 +25034,7 @@ msgstr "月間制限時間を使ってチャットを続行できます。"
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
+msgstr "このデバイスでは最大100件のチャットを保存できます。チャットを開始しましょう！"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25860,9 +25097,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトの"
-"ブロックを解除する必要があります。"
+msgstr "最大%1$sサイトまでブロックできます。%2$sをブロックするには、まず別のサイトのブロックを解除する必要があります。"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25925,8 +25160,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
+msgstr "これで%1$s、より高いAI推論、Plusの2倍の使用制限が利用可能になりました。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25934,9 +25168,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスク"
-"リプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
+msgstr "高度なAIモデルへのアクセスが可能になりました。VPNやその他のDuckDuckGoサブスクリプション保護機能は、DuckDuckGoブラウザ内でご利用いただけます。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25957,10 +25189,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。これにより、暗号化された"
-"サーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。これにより、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25969,10 +25198,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件の"
-"チャットはローカルストレージで引き続き利用可能です。この操作により、暗号化さ"
-"れたサーバーからチャットデータが削除されることはありません。"
+msgstr "このブラウザからは、保存済みのチャットにアクセスできなくなります。直近30件のチャットはローカルストレージで引き続き利用可能です。この操作により、暗号化されたサーバーからチャットデータが削除されることはありません。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25985,8 +25211,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
+msgstr "最新バージョンを入手すると、DuckDuckGoアプリの自動アップデートが届きます。"
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -26000,10 +25225,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを"
-"使ってもプライベートに閲覧できます。このアプリはすでにインストールされてお"
-"り、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社アプリを使ってもプライベートに閲覧できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -26015,9 +25237,7 @@ msgstr "あなたは今、匿名で検索しています！"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡を"
-"もっと減らすヒントを学びましょう。"
+msgstr "今あなたはプライバシーが保護された状態で検索しています。%1$sあなたの痕跡をもっと減らすヒントを学びましょう。"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26066,8 +25286,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
+msgstr "現在、メッセージ数の上限に達しています。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26080,14 +25299,12 @@ msgstr "1回のセッションの最大ボイスチャット時間に達しま�
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
+msgstr "本日のボイスチャットの回数制限に達しました。明日もう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ディクテーションの利用上限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26096,9 +25313,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"添付ファイル付きのDuck.aiチャットのSync & Backup用ストレージ容量が不足してい"
-"ます。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされ"
-"たチャットは削除されません。"
+"添付ファイル付きのDuck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。%1$s件の最も古いチャットを削除して同期を再開してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26108,9 +25324,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.aiチャットのSync & Backup用ストレージ容量が不足しています。同期を再開す"
-"るには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留め"
-"されたチャットは削除されません。"
+"Duck.aiチャットのSync & "
+"Backup用ストレージ容量が不足しています。同期を再開するには、添付ファイル付きの最も古いチャットを%1$s件削除してください。ピン留めされたチャットは削除されません。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26123,9 +25338,7 @@ msgstr "ストレージの容量がいっぱいです"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録"
-"されています。"
+msgstr "YouTube(Google社)に匿名性はありません。ここで見るビデオはGoogle社によって記録されています。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26146,8 +25359,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
+msgstr "最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26185,9 +25397,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26196,10 +25406,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージ"
-"に保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット%1$s件は、次のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26208,10 +25415,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの"
-"同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルスト"
-"レージに保存されます。"
+msgstr "バックアップデータはDuckDuckGoのサーバーから削除されます。すべてのデバイスの同期が解除されます。最新のチャット履歴100件は、以下のブラウザのローカルストレージに保存されます。"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26235,18 +25439,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGo"
-"がこのデータにアクセスすることはありません。"
+msgstr "お使いのブラウザでは訪問回数が特に多いサイトリストが作成されます。DuckDuckGoがこのデータにアクセスすることはありません。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、"
-"DuckDuckGoはこのデータにアクセスすることはできません。"
+msgstr "ブラウザには、あなたがよくアクセスするサイトの一覧のデータがありますが、DuckDuckGoはこのデータにアクセスすることはできません。"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26254,9 +25454,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示さ"
-"れる場合があります。"
+msgstr "%1$sとのチャットは非公開です。AIチャットでは不正確な情報や不快な情報が表示される場合があります。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26268,50 +25466,41 @@ msgstr "チャットが保存されるようになりました。"
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
-msgstr ""
-"チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはあ"
-"りません。"
+msgstr "チャットは非公開で、保存されたり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
+msgstr "チャットは非公開であり、AIモデルのトレーニングに使用されることはありません。"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
+msgstr "チャットは非公開で、匿名化され、AIモデルのトレーニングには使用されません。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用"
-"されません。"
+msgstr "チャットは非公開で、当社が保存することはなく、AIモデルのトレーニングにも使用されません。"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26325,9 +25514,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されま"
-"せん。チャット履歴を保持するには、以下の手順に従ってください。"
+msgstr "チャットは引き続き非公開で、匿名化され、AIモデルのトレーニングには使用されません。チャット履歴を保持するには、以下の手順に従ってください。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26335,8 +25522,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
+msgstr "チャットがインポートされました。Duck.aiで中断したところから続けましょう。"
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26367,9 +25553,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検"
-"索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
+msgstr "あなたの電子メールアドレスが他人に共有されることはありませし、%1$s匿名での検索に紐づけられることもありません。(%2$s例文のサンプル%3$s)"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26412,10 +25596,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) を使用した512ビットの"
-"キーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残りま"
-"す。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo がお客様の"
-"パスフレーズを知ることはありません。"
+"パスフレーズは、Secure Hash Algorithm (%1$sSHA-2%2$s) "
+""
+"を使用した512ビットのキーを生成します。ブラウザには、このキーと関連する設定ファイルのみが残ります。この設定ファイルは、キーを名前に用いて保存されます。DuckDuckGo "
+"がお客様のパスフレーズを知ることはありません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26429,10 +25613,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータ"
-"が取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはで"
-"きません。"
+msgstr "プロンプトはDuckDuckGoのサーバーを介して中継され、個人を特定できるメタデータが取り除かれるため、モデルプロバイダーが会話を特定の個人に結びつけることはできません。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26445,9 +25626,7 @@ msgctxt "Popover text for recent chats onboarding"
 msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
-msgstr ""
-"最近のチャットはここにあります！チャットはいつでも参照したり、消去したりでき"
-"ます。"
+msgstr "最近のチャットはここにあります！チャットはいつでも参照したり、消去したりできます。"
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26479,8 +25658,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能を有効にしてください。"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能を有効にしてください。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26489,9 +25668,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に"
-"保存するには、%1$sDuckDuckGo No AI%2$s拡張機能をインストールしてくださ"
-"い。%3$s詳細情報%4$s"
+"設定は保存されていますが、Cookieを消去するとリセットされます。設定を永続的に保存するには、%1$sDuckDuckGo No "
+"AI%2$s拡張機能をインストールしてください。%3$s詳細情報%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26518,10 +25696,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウ"
-"ザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにイン"
-"ストールされており、以下が可能になります。"
+msgstr "現在、Chromeのプライベート検索を使用しています。Chromeの代わりに当社のブラウザをご使用になると、さらにセキュリティを強化できます。このアプリはすでにインストールされており、以下が可能になります。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26529,9 +25704,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直して"
-"ください。"
+msgstr "メッセージの最大サイズを超えました。 メッセージを短くして、もう一度やり直してください。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26539,9 +25712,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして"
-"続行します。"
+msgstr "この会話のチャットの最大時間に達しました。 この会話をFire Buttonでクリアして続行します。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26549,9 +25720,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始"
-"します。"
+msgstr "この会話のチャットの最大時間に達しました。続行するには、新しいチャットを開始します。"
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26565,15 +25734,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
+msgstr "1日のメッセージ数の上限に達しました。このチャットは明日続行してください。"
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
+msgstr "ボイスチャットの回数制限に達しました。時間を置いてもう一度お試しください。"
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26656,9 +25823,7 @@ msgstr "（%1$s）"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されて"
-"います。"
+msgstr "DuckDuckGoが提供するオンライン保護は、毎日何百万人ものユーザーから信頼されています。"
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26877,9 +26042,7 @@ msgstr "公式ウェブサイト"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードし"
-"たものです)"
+msgstr "あるいはカラーコードを指定してください。例：%1$s (%2$s は %3$s をエンコードしたものです)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ka_GE/LC_MESSAGES/duckduckgo.po
+++ b/locales/ka_GE/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6759,6 +6780,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7012,6 +7038,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7759,6 +7790,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8679,6 +8715,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12613,6 +12654,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17654,6 +17700,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18012,6 +18063,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
+++ b/locales/kab_DZ/LC_MESSAGES/duckduckgo.po
@@ -2374,6 +2374,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5226,6 +5237,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Agi"
@@ -5315,6 +5331,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6772,6 +6793,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7029,6 +7055,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7776,6 +7807,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8702,6 +8738,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12643,6 +12684,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17704,6 +17750,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18063,6 +18114,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Ɛreḍ kra n wawalen tisura."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/kn_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/kn_IN/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5216,6 +5227,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5305,6 +5321,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6764,6 +6785,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7019,6 +7045,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7766,6 +7797,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8687,6 +8723,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12621,6 +12662,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17664,6 +17710,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18022,6 +18073,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
-"이용하거나, Plus 또는 무료 모델로 전환하세요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
+"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
-"무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
+"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -227,7 +229,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
+msgstr ""
+"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -330,8 +334,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
-"채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
+"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -378,7 +382,8 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
+msgstr ""
+"%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -416,7 +421,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
+"서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -426,7 +433,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
+msgstr ""
+"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
+"팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -438,7 +447,9 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
+msgstr ""
+"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
+"니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -446,8 +457,8 @@ msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
-"클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
+"표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -457,8 +468,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
-"%8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
+"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -466,7 +477,9 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
+msgstr ""
+"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
+"시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -484,7 +497,8 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr ""
+"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -498,7 +512,8 @@ msgstr "%1$s자세히 알아보기%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr ""
+"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -516,7 +531,8 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr ""
+"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -867,14 +883,17 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -927,14 +946,17 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
+msgstr ""
+"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
+"확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr ""
+"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -985,9 +1007,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
-"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
-"이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
+"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
+"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1048,9 +1070,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
-"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
-"기반 채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
+"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
+"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
+"채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1246,7 +1269,9 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+msgstr ""
+"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
+"환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1281,14 +1306,18 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
+"용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
+"데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1358,7 +1387,9 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
+msgstr ""
+"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
+"요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1634,7 +1665,9 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr "고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. %1$s"
+msgstr ""
+"고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1642,7 +1675,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
+msgstr ""
+"고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1684,7 +1718,8 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr ""
+"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1820,8 +1855,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
-"않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
+"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1859,7 +1894,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr ""
+"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1873,7 +1909,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
+msgstr ""
+"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1911,7 +1949,8 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr ""
+"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1943,15 +1982,17 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
-"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
+"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
+"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr ""
+"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2088,7 +2129,8 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2096,7 +2138,8 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr ""
+"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2109,7 +2152,9 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
+msgstr ""
+"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
+"하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2155,7 +2200,9 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
+msgstr ""
+"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
+"를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2327,8 +2374,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
-"사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
+"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2470,10 +2517,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
-"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
-"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
-"지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
+"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
+"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
+"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
+"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2485,9 +2533,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
-"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
-"자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
+"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
+"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
+"링%2$s을 기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2512,7 +2561,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에서 IP 주소를 감출 수 있습니다."
+msgstr ""
+"카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에"
+"서 IP 주소를 감출 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2627,13 +2678,17 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
+msgstr ""
+"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2658,8 +2713,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
+"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
+"지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2668,14 +2724,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
-"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
+"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
+"는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr ""
+"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2875,8 +2933,20 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
-"내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
+"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3005,7 +3075,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이용하세요."
+msgstr ""
+"구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이"
+"용하세요."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3265,16 +3337,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
+"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
-"암호화 보호 강화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
+"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3282,8 +3356,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
-"차단, 사이트 암호화 기능을 이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
+"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3390,9 +3465,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
-"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
-"않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
+"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
+"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
+"호 또한 서버에 저장되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3400,8 +3476,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
-"페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3410,8 +3486,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
-"%1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
+"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3446,7 +3522,8 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr ""
+"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3780,7 +3857,9 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
+msgstr ""
+"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
+"합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3909,8 +3988,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
-"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
+"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
+"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -3966,14 +4046,18 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
+msgstr ""
+"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
+"개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4053,7 +4137,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr "채팅이 DuckDuckGo 서버에 안전하게 저장되고 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr ""
+"채팅이 DuckDuckGo 서버에 안전하게 저장되고 종단간 암호화가 적용됩니다. 회원님"
+"의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4061,7 +4147,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr ""
+"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
+"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4073,9 +4161,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
-"저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
+"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
+"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
+"운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4098,15 +4187,17 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
-"검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
+"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
+msgstr ""
+"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
+"를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4159,7 +4250,8 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr ""
+"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4261,7 +4353,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr "전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세요."
+msgstr ""
+"전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세"
+"요."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4459,8 +4553,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
-"않으면 자동으로 삭제할 수 있습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
+"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4470,8 +4565,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
-"사용하지 않으면 자동으로 삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
+"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
+"삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4479,7 +4575,9 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
+msgstr ""
+"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
+"DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4488,8 +4586,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
-"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
+"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
+"후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4530,7 +4629,9 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
+msgstr ""
+"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
+"경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4546,7 +4647,9 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
+msgstr ""
+"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
+"요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4560,7 +4663,9 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr ""
+"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
+"기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4589,7 +4694,8 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr ""
+"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4651,8 +4757,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
-"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
+"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
+"정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4663,8 +4770,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
-"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
+"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
+"라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4732,14 +4840,18 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
+msgstr ""
+"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
+"%3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
+msgstr ""
+"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
+"에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -4939,7 +5051,9 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr ""
+"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
+"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5210,7 +5324,8 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
+msgstr ""
+"최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5340,7 +5455,8 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr ""
+"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5393,8 +5509,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & Backup › Sync With "
-"Another Device%2$s로 들어가서 다시 시도해 보세요."
+"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & "
+"Backup › Sync With Another Device%2$s로 들어가서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5566,7 +5682,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
+msgstr ""
+"링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5804,14 +5921,17 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
+msgstr ""
+"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6128,8 +6248,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 "
-"계속 보유할 수 있습니다."
+"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대"
+"화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 계속 보유할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6225,7 +6346,8 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6242,7 +6364,9 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr ""
+"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
+"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6372,6 +6496,12 @@ msgid "Dislike source"
 msgstr "소스가 싫습니다"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "닫기"
@@ -6482,6 +6612,12 @@ msgid "Djibouti"
 msgstr "지부티"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6529,7 +6665,9 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
+msgstr ""
+"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
+"%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6567,8 +6705,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
+"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6577,8 +6715,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
-"%3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
+"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6693,7 +6831,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
+"세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6701,7 +6841,9 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
+msgstr ""
+"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
+"작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6721,7 +6863,9 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
+msgstr ""
+"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6729,7 +6873,9 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
+msgstr ""
+"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6861,8 +7007,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
-"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
+"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
+"자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6872,8 +7019,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
-"시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
+"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6881,13 +7028,16 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr ""
+"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
+"니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -6896,7 +7046,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr ""
+"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
+"람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6910,7 +7062,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
+msgstr ""
+"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
+"억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6924,14 +7078,18 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
+"를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -6945,8 +7103,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
-"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
+"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
+"용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6957,9 +7116,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
-"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
-"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
+"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
+"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
+"속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6973,7 +7133,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
+msgstr ""
+"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
+"실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7010,7 +7172,8 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr ""
+"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7020,8 +7183,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
-"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
+"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
+"버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7049,9 +7213,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
-"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
-"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
+"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
+"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
+"어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7060,8 +7226,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7070,8 +7237,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
+"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
+"다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7083,9 +7251,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
-"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
-"답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
+"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
+"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
+"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7099,17 +7268,21 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
-"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
-"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
-"기반으로 자동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
+"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
+"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
+"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
+"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
+"동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
+msgstr ""
+"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7117,7 +7290,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
+"팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7126,8 +7301,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7136,8 +7311,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
-"서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
+"개 AI 기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7145,7 +7320,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
+msgstr ""
+"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7153,7 +7330,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
+"코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7161,13 +7340,16 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
+"시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr ""
+"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7317,15 +7499,17 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
-"익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
+"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
+"의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7333,7 +7517,9 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
+msgstr ""
+"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
+"에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7342,8 +7528,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
-"Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
+"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7355,10 +7541,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
-"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
-"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
+"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
+"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
+"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
+"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7378,8 +7565,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
-"알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
+"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7471,8 +7658,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
-"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
+"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
+"선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7685,7 +7873,9 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
+"경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7727,7 +7917,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr ""
+"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
+"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7902,7 +8094,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
+msgstr ""
+"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
+"터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7927,7 +8121,9 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
+msgstr ""
+"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
+"임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8027,7 +8223,9 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
+msgstr ""
+"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8267,6 +8465,12 @@ msgid "Fast"
 msgstr "빠른"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8310,7 +8514,8 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8318,7 +8523,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr ""
+"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
+"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8413,13 +8620,16 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr ""
+"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
+msgstr ""
+"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
+"요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8460,7 +8670,8 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr ""
+"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8497,7 +8708,8 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr ""
+"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8560,7 +8772,9 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
+msgstr ""
+"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
+"클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8578,6 +8792,12 @@ msgstr "후속 질문"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "후속 질문은 비공개로 유지됩니다."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8683,7 +8903,8 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr ""
+"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8794,8 +9015,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
-"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
+"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9088,7 +9309,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+msgstr ""
+"DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9174,8 +9396,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, Identity Theft "
-"Restoration을 이용해 보세요."
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, "
+"Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9183,7 +9405,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration을 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration"
+"을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9191,7 +9415,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9201,7 +9427,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr ""
+"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
+"Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9244,7 +9472,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 다양한 프리미엄 보호 기능을 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 "
+"다양한 프리미엄 보호 기능을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9253,20 +9483,24 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information Removal 및 Identity "
-"Theft Restoration을 이용해 보세요."
+"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information "
+"Removal 및 Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 보세요."
+msgstr ""
+"안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 "
+"보세요."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
+msgstr ""
+"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9302,7 +9536,8 @@ msgstr "앱 받기"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
+msgstr ""
+"무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9361,8 +9596,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9371,8 +9606,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9382,8 +9617,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9393,8 +9628,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
-"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
+"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
+"을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9418,7 +9654,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
+msgstr ""
+"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
+"스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9426,7 +9664,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
+msgstr ""
+"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
+"%3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9493,6 +9733,12 @@ msgstr "훌륭한 디자인"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "바람직한 개인정보 보호정책"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10114,7 +10360,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
+msgstr ""
+"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
+"강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10141,8 +10389,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
-"설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
+"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10155,7 +10403,9 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
+msgstr ""
+"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
+"보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10204,7 +10454,9 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
+msgstr ""
+"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
+"집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10472,7 +10724,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
+msgstr ""
+"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
+"며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10506,7 +10760,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr ""
+"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
+"및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10516,8 +10772,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
-"DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
+"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10531,7 +10787,9 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
+msgstr ""
+"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
+"해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10539,7 +10797,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
+msgstr ""
+"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
+"지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10547,13 +10807,17 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr ""
+"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
+"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
+msgstr ""
+"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
+"세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10562,7 +10826,8 @@ msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr ""
+"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10607,6 +10872,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "이미지 프롬프트는 Duck.ai %1$s을 준수해야 합니다."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10710,8 +10981,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
-"%1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
+"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10721,7 +10992,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
+msgstr ""
+"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
+"기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10735,7 +11008,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
+msgstr ""
+"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
+"됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11140,8 +11415,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
-"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
+"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
+"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11149,7 +11425,8 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr ""
+"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11221,7 +11498,8 @@ msgstr "두 기기 모두에서 Sync & Backup을 열어둘 수 있습니다."
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
+msgstr ""
+"한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -12413,7 +12691,8 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr ""
+"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13197,8 +13476,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
-"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
+"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
+"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
+"다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13520,7 +13801,8 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr ""
+"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14032,7 +14314,9 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
+msgstr ""
+"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
+"콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14041,8 +14325,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
-"Another Device%4$s로 들어가세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14051,8 +14335,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
-"Another Device%4$s로 들어가서 코드 스캔:"
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14061,8 +14345,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
-"Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14089,7 +14373,9 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
+msgstr ""
+"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
+"파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14115,7 +14401,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
+msgstr ""
+"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
+"를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14129,7 +14417,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr ""
+"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14459,7 +14748,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
+msgstr ""
+"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
+"추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14472,14 +14763,18 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미엄 보호 기능을 올인원 구독으로 이용해 보세요."
+msgstr ""
+"빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미"
+"엄 보호 기능을 올인원 구독으로 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
+msgstr ""
+"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
+"유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14487,8 +14782,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
-"및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
+"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14740,7 +15035,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
+msgstr ""
+"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
+"않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14896,8 +15193,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용자의 정보를 찾아내서 정보 삭제를 "
-"도와드립니다."
+"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용"
+"자의 정보를 찾아내서 정보 삭제를 도와드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14968,8 +15265,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
-"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
+"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
+"색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14978,8 +15276,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
-"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
+"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
+"나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14989,8 +15288,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
-"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
+"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
+"%1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15022,7 +15322,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15030,7 +15332,9 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
+msgstr ""
+"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
+"보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15038,7 +15342,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
+msgstr ""
+"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
+"호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15186,7 +15492,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
+"하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15194,7 +15502,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
+msgstr ""
+"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
+"이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15346,7 +15656,9 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15405,10 +15717,18 @@ msgid "Poor formatting"
 msgstr "형식이 조악함"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
+msgstr ""
+"인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo"
+"가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -15845,7 +16165,8 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr ""
+"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -15917,7 +16238,9 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
+msgstr ""
+"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
+"다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -15935,7 +16258,8 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr ""
+"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -15965,7 +16289,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
+msgstr ""
+"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
+"력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16194,7 +16520,8 @@ msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
+msgstr ""
+"추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16249,7 +16576,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16257,7 +16586,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
+msgstr ""
+"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
+"됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16267,8 +16598,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
-"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
+"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
+"DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16549,7 +16881,9 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
+msgstr ""
+"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
+"DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16656,14 +16990,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
+"항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
+msgstr ""
+"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
+"이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16727,15 +17065,18 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
-"사에도 서비스 개선을 위해 제공됩니다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
+"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+msgstr ""
+"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
+"기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16744,8 +17085,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
-"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
+"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
+"인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16837,8 +17179,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
-"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
+"이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16847,8 +17190,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
-"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
+"적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16858,8 +17202,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
-"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
+"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
+"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
+"관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17283,7 +17629,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
+msgstr ""
+"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
+"이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17338,7 +17686,8 @@ msgstr "안녕하세요, Duck.ai입니다!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
+msgstr ""
+"DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17455,7 +17804,9 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
+"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17463,7 +17814,9 @@ msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
+"%5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17487,7 +17840,9 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
+msgstr ""
+"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
+"릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17549,10 +17904,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
-"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
-"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
-"사용하는 일부 지역에만 제공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
+"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
+"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
+"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
+"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
+"공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17560,8 +17917,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
-"보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
+"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17570,8 +17927,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
-"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
+"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
+"기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17692,8 +18050,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
-"검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
+"위키피디아에서 바로 'ducks'를 바로 검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17712,15 +18070,18 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
-"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
+"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
+"로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
+msgstr ""
+"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
+"합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -17732,9 +18093,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
-"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
-"유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
+"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
+"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
+"며, 암호가 브라우저 밖으로 유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17836,7 +18198,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17844,7 +18208,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17852,7 +18218,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
+"고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17860,7 +18228,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
+msgstr ""
+"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
+"기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17874,7 +18244,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr ""
+"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
+"이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18024,7 +18396,9 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
+msgstr ""
+"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
+"력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18088,14 +18462,18 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
+"정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
+msgstr ""
+"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
+"션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18159,7 +18537,8 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr ""
+"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18280,7 +18659,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr ""
+"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
+"으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18402,7 +18783,9 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
+msgstr ""
+"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
+"하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18482,7 +18865,9 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
+msgstr ""
+"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
+"요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18509,8 +18894,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
-"절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
+"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18611,7 +18996,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr ""
+"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18659,7 +19045,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언제든 쉽게 켜고 끌 수 있어요."
+msgstr ""
+"로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언"
+"제든 쉽게 켜고 끌 수 있어요."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19023,15 +19411,17 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
-"않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
+"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr ""
+"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
+"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19176,7 +19566,8 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr ""
+"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19408,7 +19799,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr ""
+"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19416,7 +19808,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
+msgstr ""
+"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
+"지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19430,7 +19824,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
+msgstr ""
+"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
+"기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19490,7 +19886,8 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr ""
+"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -19839,7 +20236,9 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
+"이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20305,7 +20704,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup을 사용하면 더 많은 채팅을 저장하고 모든 기기에서 동기화할 수 있습니다."
+msgstr ""
+"Sync & Backup을 사용하면 더 많은 채팅을 저장하고 모든 기기에서 동기화할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20354,11 +20755,13 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
-"경우 동기화된 데이터를 복구할 수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
+"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
+"수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
+"다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -20367,8 +20770,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
-"복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
+"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20506,7 +20909,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
+msgstr ""
+"어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱"
+"에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20514,7 +20919,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
+msgstr ""
+"어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있"
+"도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20758,8 +21165,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
-"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
+"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
+"보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20767,7 +21175,9 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
+msgstr ""
+"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
+"로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -20775,7 +21185,9 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr "Duck.ai 전환 기능을 사용하면 DuckDuckGo를 통해 익명화되는 비공개 검색과 AI 채팅 사이를 간편하게 오갈 수 있습니다."
+msgstr ""
+"Duck.ai 전환 기능을 사용하면 DuckDuckGo를 통해 익명화되는 비공개 검색과 AI 채"
+"팅 사이를 간편하게 오갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20804,7 +21216,8 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr ""
+"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -20883,7 +21296,9 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr ""
+"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
+"성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20897,7 +21312,8 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr ""
+"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -20916,8 +21332,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
-"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
+"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
+"강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20954,7 +21371,9 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
+"요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -20962,7 +21381,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
+msgstr ""
+"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
+"을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21001,8 +21422,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
-"수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21012,8 +21433,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
-"있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
+"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21022,8 +21443,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
-"%2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
+"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21033,8 +21454,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
-"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
+"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
+"은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21050,7 +21472,9 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr "이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 채팅 %1$s개는 로컬 저장소에 남습니다."
+msgstr ""
+"이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 "
+"채팅 %1$s개는 로컬 저장소에 남습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21121,14 +21545,16 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr ""
+"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21155,7 +21581,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
+msgstr ""
+"샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계"
+"속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21163,7 +21591,8 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
+msgstr ""
+"샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21183,7 +21612,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
+"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21191,7 +21622,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr ""
+"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
+"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21227,7 +21660,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
+msgstr ""
+"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
+"모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21235,7 +21670,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr ""
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21245,8 +21682,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
-"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
+"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
+"지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21281,13 +21719,17 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
+msgstr ""
+"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
+msgstr ""
+"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
+"사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21297,8 +21739,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
-"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
+"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21306,7 +21749,9 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr ""
+"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
+"릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21398,7 +21843,9 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
+msgstr ""
+"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
+"다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21443,7 +21890,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
+msgstr ""
+"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
+"쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21453,8 +21902,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
-"기기에 PDF로 저장되었을 수 있습니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
+"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21462,14 +21912,18 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
+msgstr ""
+"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
+"하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
+msgstr ""
+"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
+"용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21497,7 +21951,9 @@ msgstr "전환하여 비공개 AI 채팅을 사용하거나 %1$s설정에서 비
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
+msgstr ""
+"전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21558,6 +22014,12 @@ msgstr "이 출처의 결과가 너무 많음"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "너무 느림"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21670,7 +22132,9 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
+msgstr ""
+"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
+"었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21717,7 +22181,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21725,7 +22191,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
+msgstr ""
+"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
+"주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21994,6 +22462,12 @@ msgid "Try fewer keywords."
 msgstr "더 짧은 검색어를 사용해 보세요."
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22111,7 +22585,9 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
+msgstr ""
+"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
+"보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22203,8 +22679,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
+"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22213,8 +22689,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
-"있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
+"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22414,7 +22890,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr ""
+"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
+"시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22543,24 +23021,30 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
+msgstr ""
+"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
+"지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
+"을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr ""
+"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr ""
+"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -22570,7 +23054,8 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr ""
+"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -22582,7 +23067,8 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr ""
+"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -22665,7 +23151,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
+msgstr ""
+"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
+"용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22822,7 +23310,9 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
+msgstr ""
+"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
+"이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -22946,7 +23436,9 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
+msgstr ""
+"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
+"더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23048,8 +23540,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
-"무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
+"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23103,14 +23595,17 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
+"보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr ""
+"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23234,8 +23729,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"DuckDuckGo가 제공하는 비공개 무료 AI 채팅 Duck.ai에서 공유된 대화를 열람하세요. 내 채팅에 저장하고 비공개로 대화를 "
-"이어갈 수 있습니다."
+"DuckDuckGo가 제공하는 비공개 무료 AI 채팅 Duck.ai에서 공유된 대화를 열람하세"
+"요. 내 채팅에 저장하고 비공개로 대화를 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23269,7 +23764,9 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
+"프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23277,7 +23774,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
+"TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23285,7 +23784,9 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 Yelp의 광고 네트워크에서 관리합니다."
+msgstr ""
+"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 Yelp의 광"
+"고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23312,7 +23813,9 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
+msgstr ""
+"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
+"을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23327,8 +23830,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
-"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23338,8 +23841,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
-"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
+"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
+"에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23349,8 +23853,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
+"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
+"택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23360,8 +23865,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
-"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
+"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
+"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23413,7 +23919,8 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr ""
+"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23562,7 +24069,9 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
+msgstr ""
+"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
+"YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23582,8 +24091,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
-"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
+"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
+"스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23595,7 +24105,9 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
+msgstr ""
+"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23607,8 +24119,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
-"DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
+"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23620,8 +24132,9 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
-"프롬프트와 응답 내용을 보내서 신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
+"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
+"신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23662,8 +24175,9 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
-"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
+"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
+"절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23676,7 +24190,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
+"알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23684,7 +24200,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
+"려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23695,7 +24213,9 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -23724,19 +24244,24 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
-"정보도 보유하고 있지 않습니다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
+"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
+"다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
+msgstr ""
+"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
+msgstr ""
+"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
+"니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -23750,7 +24275,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr "데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 함께 이용하세요."
+msgstr ""
+"데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 "
+"함께 이용하세요."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23758,7 +24285,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
+msgstr ""
+"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
+"도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23782,7 +24311,9 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
+msgstr ""
+"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
+"를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -23790,7 +24321,9 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
+msgstr ""
+"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
+"지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23798,18 +24331,24 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr "데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
+msgstr ""
+"데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하"
+"기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
+msgstr ""
+"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
+"좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
+msgstr ""
+"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
+"포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -23825,8 +24364,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
-"바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
+"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23839,7 +24378,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr "데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정보가 삭제되도록 도와드립니다."
+msgstr ""
+"데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정"
+"보가 삭제되도록 도와드립니다."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23847,7 +24388,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
+"의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23855,7 +24398,9 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
+msgstr ""
+"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
+"가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23869,7 +24414,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
+msgstr ""
+"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
+"력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -23877,7 +24424,9 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
+msgstr ""
+"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
+"세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -23985,7 +24534,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr ""
+"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23999,8 +24549,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
-"사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
+"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24009,8 +24559,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
-"저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
+"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24020,8 +24570,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
-"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
+"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
+"장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24094,7 +24645,9 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
+msgstr ""
+"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
+"고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24128,7 +24681,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
+msgstr ""
+"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
+"개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24153,9 +24708,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
-"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
-"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
+"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
+"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
+"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24390,7 +24946,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr ""
+"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24465,7 +25022,8 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr ""
+"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -24490,7 +25048,9 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
+msgstr ""
+"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
+"요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24691,8 +25251,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
-"있습니다."
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. "
+"'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24721,7 +25281,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr "사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, 이름, 주소 등의 정보를 삭제해 드립니다."
+msgstr ""
+"사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, "
+"이름, 주소 등의 정보를 삭제해 드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24988,7 +25550,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -24996,7 +25560,9 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
+msgstr ""
+"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
+"검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25009,7 +25575,8 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25017,17 +25584,22 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
+"다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr ""
+"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25040,7 +25612,9 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
+msgstr ""
+"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25060,7 +25634,9 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
+msgstr ""
+"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
+"를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25089,7 +25665,8 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr ""
+"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25152,7 +25729,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
+msgstr ""
+"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
+"트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25215,7 +25794,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
+msgstr ""
+"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
+"니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25224,8 +25805,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
-"수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
+"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25247,8 +25828,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25258,8 +25840,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
-"채팅이 삭제되지는 않습니다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
+"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25287,8 +25870,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
-"다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
+"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25300,7 +25883,9 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
+msgstr ""
+"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
+"팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25376,8 +25961,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
-"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
+"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25387,8 +25973,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
-"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
+"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25402,8 +25989,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
-"YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
+"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25462,7 +26049,8 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr "백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
+msgstr ""
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25472,8 +26060,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
-"저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25483,8 +26071,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
-"저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
+"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25508,14 +26096,18 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
+msgstr ""
+"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
+"는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
+msgstr ""
+"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
+"에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25523,7 +26115,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
+msgstr ""
+"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
+"시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25548,28 +26142,36 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
+"습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
+msgstr ""
+"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
+"지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -25584,8 +26186,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
-"다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
+"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25624,7 +26226,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
+msgstr ""
+"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
+"[%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25667,9 +26271,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
-"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
-"없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
+"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
+"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
+"암호를 절대 알 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25684,8 +26289,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
-"특정 사용자에 연결할 수 없습니다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
+"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
+"다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25730,8 +26336,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
-"사용 설정하세요."
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
+"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25740,8 +26346,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
-"설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
+"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25769,8 +26375,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
-"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
+"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
+"며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25786,7 +26393,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
+"러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -25794,7 +26403,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr ""
+"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -25808,7 +26418,9 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
+msgstr ""
+"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
+"요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26116,7 +26728,9 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
+msgstr ""
+"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
+"문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ko_KR/LC_MESSAGES/duckduckgo.po
+++ b/locales/ko_KR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독"
-"을 다시 업그레이드하여 채팅을 계속 이용하거나, Plus 또는 무료 모델로 전환하세"
-"요."
+"%1$s는 Pro를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 DuckDuckGo 구독을 다시 업그레이드하여 채팅을 계속 "
+"이용하거나, Plus 또는 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -220,8 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구"
-"독을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
+"%1$s 서비스는 DuckDuckGo를 구독하셔야 이용할 수 있습니다. 이 브라우저에서 구독을 다시 활성화해서 채팅을 계속 이용하거나, "
+"무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -229,9 +227,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다"
-"시 시도하세요."
+msgstr "%1$s 모델을 일시적으로 사용할 수 없습니다. 다른 모델로 전환하거나 나중에 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -334,8 +330,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사"
-"용자의 메시지나 모델의 응답을 보거나 서버에 이 채팅을 저장할 수 없습니다."
+"%1$s(은)는 신뢰할 수 있는 실행 환경에서 실행됩니다. 즉, 모델 제공자조차도 사용자의 메시지나 모델의 응답을 보거나 서버에 이 "
+"채팅을 저장할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -382,8 +378,7 @@ msgstr "%1$s 사용"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
+msgstr "%1$s은(는) 기본 모델보다 사용 한도를 최대 2~5배 더 빠르게 소진합니다. %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -421,9 +416,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔"
-"서 이 채팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후(%3$s)에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -433,9 +426,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채"
-"팅을 계속할 수 있습니다."
+msgstr "%1$s 모델은 %2$s일 후에 Duck.ai에서 제거됩니다. 그 후에는 모델을 바꿔서 이 채팅을 계속할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -447,9 +438,7 @@ msgstr "단어 %1$s개"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합"
-"니다.%7$s"
+msgstr "%1$s추가%2$s를 클릭합니다.%3$s허용%4$s에 체크 표시한 후%5$s 확인%6$s을 클릭합니다.%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -457,8 +446,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 "
-"표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s허용%2$s을 클릭합니다.%3$s추가%4$s를 클릭합니다.%5$s허용%6$s에 %7$s체크 표시한 후 %8$s확인%9$s을 "
+"클릭합니다."
 
 # Firefox
 # smartling.placeholder_format=C
@@ -468,8 +457,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s"
-"에 체크 표시한 후 %8$s확인%9$s을 클릭합니다."
+"%1$s설치 진행하기%2$s를 클릭합니다.%3$s%4$s추가%5$s를 클릭합니다.%6$s허용%7$s에 체크 표시한 후 "
+"%8$s확인%9$s을 클릭합니다."
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -477,9 +466,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 "
-"시도해 보세요."
+msgstr "이 검색 결과가 표시되어야 한다고 생각되는 경우 %1$s여기%2$s를 클릭해서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -497,8 +484,7 @@ msgstr "%1$s더 알아보기%2$s."
 #. Link to a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
-msgstr ""
-"%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
+msgstr "%1$sDuckDuckGo가 사용자의 위치 정보를 어떻게 보호하는지 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -512,8 +498,7 @@ msgstr "%1$s자세히 알아보기%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
+msgstr "DuckDuckGo 서버에 채팅이 비공개로 저장되는 방식 %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -531,8 +516,7 @@ msgstr "홈 화면에서 DuckDuckGo 앱 아이콘을 %1$s길게 누릅니다%2$s
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
+msgstr "%1$s이런!%2$s%3$s문제가 발생했습니다. %4$s새로고침%5$s하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -883,17 +867,14 @@ msgstr "6시간 사용 제한에 도달했습니다."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "6시간 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니"
-"다."
+msgstr "6시간 사용 한도에 도달했습니다. 일일 한도를 사용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -946,17 +927,14 @@ msgstr "A"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 "
-"확인하고 다시 시도하세요."
+msgstr "Search Assist가 네트워크 문제로 답변을 생성하지 못하고 있습니다. 연결 상태를 확인하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
+msgstr "새로운 버전의 AI Chat이 나왔습니다! 이 페이지를 새로고침해서 진행하세요."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1007,9 +985,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능"
-"을 끄면 DuckDuckGo Search의 AI Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 "
-"%1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 이용할 수 있습니다."
+"AI Chat을 사용하면 외부 AI Chat 모델과 익명으로 대화할 수 있습니다. 이 기능을 끄면 DuckDuckGo Search의 AI "
+"Chat 기능이 숨겨집니다. 이 설정이 꺼져 있어도 %1$sduckduckgo.com/aichat%2$s를 통해 AI Chat을 계속 "
+"이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1070,10 +1048,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문"
-"을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 제공하는 경우는 많습니다. Duck.ai"
-"는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI 기반 "
-"채팅 서비스입니다."
+"현재 AI 지원 답변은 직접적인 후속 질문을 지원하지 않습니다. 하지만 후속 질문을 위해 %1$sDuck.ai%2$s를 제안하고 링크를 "
+"제공하는 경우는 많습니다. Duck.ai는 OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 AI "
+"기반 채팅 서비스입니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1269,9 +1246,7 @@ msgctxt ""
 msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
-msgstr ""
-"이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전"
-"환하세요."
+msgstr "이 브라우저에서 %1$s을 다시 활성화해서 채팅을 계속 이용하거나, 무료 모델로 전환하세요."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1306,18 +1281,14 @@ msgstr "광고"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사"
-"용되지 않습니다."
+msgstr "광고 클릭은 %1$s의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
 msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
-msgstr ""
-"광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 "
-"데 사용되지 않습니다."
+msgstr "광고 클릭은 Microsoft의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1387,9 +1358,7 @@ msgstr "DuckDuckGo 확장 프로그램 추가"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세"
-"요."
+msgstr "다운로드 한 번으로 브라우저에 DuckDuckGo Privacy Essentials를 무료로 추가하세요."
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1665,9 +1634,7 @@ msgctxt ""
 "model picker dropdown"
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. "
-"%1$s"
+msgstr "고급 모델은 다른 모델보다 사용 한도에 2~5배 더 빠르게 도달할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1675,8 +1642,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
+msgstr "고급 모델은 다른 모델보다 한도를 2~5배 더 빠르게 소진할 수 있습니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1718,8 +1684,7 @@ msgstr "다운로드가 완료되고 파일이 열리면 %1$s설치%2$s를 클�
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
+msgstr "다운로드가 완료되면 확장 프로그램 파일을 찾아 더블 클릭하여 설치합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1855,8 +1820,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 "
-"대화 내용을 채팅 모델 훈련에 사용하지 않습니다."
+"DuckDuckGo가 모든 채팅을 익명화하며, DuckDuckGo 또는 모델 공급사는 사용자의 대화 내용을 채팅 모델 훈련에 사용하지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1894,8 +1859,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
+msgstr "모든 모델 제공사가 사용자의 대화를 AI에 학습시킬 수 없도록 금지되어 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1909,9 +1873,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니"
-"다."
+msgstr "AI 제공자에 채팅을 보내기 전에 모든 개인 메타데이터(예: IP 주소)가 제거됩니다."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1949,8 +1911,7 @@ msgstr "허용"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
+msgstr "음성 채팅을 사용하려면 시스템 설정에서 DuckDuckGo 마이크 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1982,17 +1943,15 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이"
-"터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 보냅니다. %2$s 모델의 프롬"
-"프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
+"%1$s 모델의 웹 검색을 허용하여 관련 프롬프트에 대한 응답을 향상합니다. 데이터 보유가 제한된 검색 엔진에만 AI가 생성한 쿼리를 "
+"보냅니다. %2$s 모델의 프롬프트 및 응답은 계속해서 %3$s제공자에게 전혀 노출되지 않습니다%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
-msgstr ""
-"Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
+msgstr "Cloud Save 키가 기기에 로컬로 저장되도록 허용(Cloud Save를 사용하는 데 필요)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2129,8 +2088,7 @@ msgctxt "AI Chat description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2138,8 +2096,7 @@ msgctxt "Duck.ai description"
 msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
-msgstr ""
-"%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
+msgstr "%1$s 및 %2$s, 오픈 소스 %3$s 및 %4$s 같은 인기 AI 모델에 익명으로 접속하세요."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2152,9 +2109,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택"
-"하거나 완전히 비활성화할 수 있습니다."
+msgstr "웹 콘텐츠를 기반으로 검색 질의에 익명으로 답변을 생성합니다. 표시 빈도를 선택하거나 완전히 비활성화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2200,9 +2155,7 @@ msgctxt "Placeholder for additional instructions textarea"
 msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
-msgstr ""
-"Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보"
-"를 들려줘)?"
+msgstr "Duck.ai가 따랐으면 하는 그 밖의 지침이 있으신가요(예: 항상 오리에 대한 정보를 들려줘)?"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2374,8 +2327,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거"
-"나 공유하지 않습니다. 모든 개인정보 보호는 사용자의 기기에서 이루어집니다."
+"DuckDuckGo의 개인정보 보호정책에 따라 DuckDuckGo는 어떠한 개인정보도 수집하거나 공유하지 않습니다. 모든 개인정보 보호는 "
+"사용자의 기기에서 이루어집니다."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2517,11 +2470,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 "
-"생성할 수 있습니다. Assist 표시 빈도 선택 가능: 안 함(검색 결과에서 Assist UI"
-"를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), 가끔(관"
-"련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표"
-"시). 현재 AI 지원 답변은 미국(영어) 지역에서만 이용 가능합니다."
+"Assist는 일부 검색에 대해 관련 웹 콘텐츠를 요약하여 익명으로 AI 지원 답변을 생성할 수 있습니다. Assist 표시 빈도 선택 "
+"가능: 안 함(검색 결과에서 Assist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 AI 지원 답변 표시), "
+"가끔(관련성이 높은 경우에만 AI 지원 답변 표시), 자주(광범위한 검색에서 더 자주 표시). 현재 AI 지원 답변은 미국(영어) "
+"지역에서만 이용 가능합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2533,10 +2485,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이"
-"며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관"
-"련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤"
-"링%2$s을 기반으로 자동 생성합니다."
+"Assist는 검색 질의에 익명으로 AI 지원 답변을 생성하는 검색 결과 옵션 기능이며 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 "
+"자연어 기술을 사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 "
+"자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2561,9 +2512,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에"
-"서 IP 주소를 감출 수 있습니다."
+msgstr "카페, 공항, 호텔에서 DuckDuckGo VPN을 사용하면 연결을 암호화하고 와이파이에서 IP 주소를 감출 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2678,17 +2627,13 @@ msgstr "자동 응답"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습"
-"니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 "
-"있습니다."
+msgstr "나열된 자료를 바탕으로 자동 생성된 응답이며 부정확한 내용이 포함되어 있을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2713,9 +2658,8 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 "
-"익명으로 정보를 조회하고 요약할 수 있습니다. 현재 Assist 서비스는 영어 사용 "
-"지역에서만 제공됩니다."
+"관련 검색어에 대한 Assist를 자동으로 표시합니다. Assist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
+"현재 Assist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2724,16 +2668,14 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색"
-"에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. 현재 DuckAssist 서비스"
-"는 영어 사용 지역에서만 제공됩니다."
+"관련 검색어에 대한 DuckAssist를 자동으로 표시합니다. DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 "
+"수 있습니다. 현재 DuckAssist 서비스는 영어 사용 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
+msgstr "영상 결과에 마우스를 올리면 짧은 무음 영상 미리 보기가 자동으로 재생됩니다."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2933,8 +2875,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데"
-"이터와 같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
+"이 보고서를 저장하기 전에 DuckDuckGo는 이름, 이메일 주소, 식별 가능한 메타데이터와 같은 개인정보(PII)를 제거하여 대화 "
+"내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2947,6 +2889,8 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"이 보고서를 저장하기 전에 DuckDuckGo는 업로드된 파일과 생성된 이미지를 삭제하고 이름, 이메일 주소, 식별 가능한 메타데이터와 "
+"같은 개인정보(PII)를 제거하여 대화 내용을 익명화합니다."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3075,9 +3019,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이"
-"용하세요."
+msgstr "구독을 통해 유해 사이트 차단, IP 주소 숨기기, 더 많은 프리미엄 보호 기능을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3337,18 +3279,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 "
-"%1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 "
-"이용할 수 있습니다."
+"기존과 동일하게 검색하세요. 개인정보는 저희가 보호해 드릴게요. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확"
-"장 프로그램%3$s으로 검색 엔진, 추적 차단, 암호화 보호 강화 기능을 이용할 수 "
-"있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 하나의 %1$s%2$s확장 프로그램%3$s으로 검색 엔진, 추적 차단, "
+"암호화 보호 강화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3356,9 +3296,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으"
-"로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 차단, 사이트 암호화 기능을 이"
-"용할 수 있습니다."
+"기존과 동일하게 검색하세요. 검색 기록이 저장되지 않습니다. 다운로드 한 번으로 %1$s주요 브라우저%2$s에서 비공개 검색, 추적 "
+"차단, 사이트 암호화 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3465,10 +3404,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 "
-"Cloud Save를 사용하여 설정을 보다 영구적으로 저장할 수 있습니다(클라우드의 원"
-"격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암"
-"호 또한 서버에 저장되지 않습니다."
+"기본적으로 설정은 비개인 브라우저 쿠키(사용자의 브라우저)에 저장됩니다. 익명 Cloud Save를 사용하여 설정을 보다 영구적으로 "
+"저장할 수 있습니다(클라우드의 원격 서버에 저장). 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호 또한 서버에 저장되지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3476,8 +3414,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"받아쓰기를 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s "
+"페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3486,8 +3424,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 "
-"OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 %1$s 페이지를 확인하세요."
+"음성 채팅을 활성화함으로써, 이 기능을 사용하기 위해 본인의 음성 데이터가 OpenAI로 전송되는 것에 동의합니다. 시작하기 전에 "
+"%1$s 페이지를 확인하세요."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3522,8 +3460,7 @@ msgstr "카메룬"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
+msgstr "닭고기, 브로콜리, 쌀을 재료로 한 몇 가지 간단한 요리법을 만들 수 있나요?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3857,9 +3794,7 @@ msgstr "전체 사이트에 적용되는 배경 색상을 변경합니다."
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경"
-"합니다."
+msgstr "검색 결과(마우스 커서를 올렸을 때), 모듈 및 드롭다운 메뉴의 배경 색상을 변경합니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -3988,9 +3923,8 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 "
-"타사 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 DuckDuckGo "
-"Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"Duck.ai 서비스를 통한 채팅을 사용하면 OpenAI, Anthropic 등의 모델을 지원하는 타사 AI 채팅 모델과 익명으로 대화할 "
+"수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 채팅 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
 "%1$shttps://duck.ai%2$s에 바로 접속해서 채팅을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
@@ -4046,18 +3980,14 @@ msgstr "비공개로 채팅하기"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅"
-"하세요."
+msgstr "DuckDuckGo 무료 브라우저에 내장된 Duck.ai로 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공"
-"개로 채팅하세요."
+msgstr "DuckDuckGo 무료 브라우저에서 Duck.ai 사이드바를 통해 어떤 웹사이트에서든 비공개로 채팅하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4137,9 +4067,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
-"채팅이 DuckDuckGo 서버에 안전하게 저장되고 종단간 암호화가 적용됩니다. 회원님"
-"의 데이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "채팅이 DuckDuckGo 서버에 안전하게 저장되고 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4147,9 +4075,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채"
-"팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
+msgstr "채팅은 DuckDuckGo 서버나 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제돼."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4161,10 +4087,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅"
-"을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버"
-"에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로"
-"운 프롬프트와 응답의 임시 저장이 중단됩니다."
+"채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 "
+"저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4187,17 +4112,15 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일"
-"은 %2$s의 콘텐츠 조정 공급자에 의한 익명 검토를 거칩니다."
+"%1$s과(와)의 채팅은 공급자 가시성이 전혀 없지만, Duck.ai에 업로드된 모든 파일은 %2$s의 콘텐츠 조정 공급자에 의한 익명 "
+"검토를 거칩니다."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
 msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
-msgstr ""
-"첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화"
-"를 재개할 수 있습니다."
+msgstr "첨부 파일이 있는 채팅의 동기화가 중단되었습니다. 저장 공간을 확보하면 동기화를 재개할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4250,8 +4173,7 @@ msgstr "철자 검사"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
+msgstr "DuckDuckGo 서브레딧에서 이번 서비스 중단에 대한 최신 소식을 확인하세요."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4353,9 +4275,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
-msgstr ""
-"전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세"
-"요."
+msgstr "전 세계 40개 이상의 서버 위치를 사용하며 유해 사이트와 온라인 사기를 차단하세요."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4553,9 +4473,8 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무"
-"기한으로 보관하거나, AI Chat을 7일 이상 사용하지 않으면 자동으로 삭제할 수 있"
-"습니다."
+"브라우저 데이터를 삭제하면 채팅이 사라집니다. 일부 브라우저는 최근 채팅을 무기한으로 보관하거나, AI Chat을 7일 이상 사용하지 "
+"않으면 자동으로 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4565,9 +4484,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅"
-"이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 사용하지 않으면 자동으로 "
-"삭제될 수도 있습니다."
+"브라우저 데이터를 삭제하면 최근 채팅이 삭제됩니다. 브라우저에 따라 최근 채팅이 무기한으로 저장될 수도 있고, Duck.ai를 7일 이상 "
+"사용하지 않으면 자동으로 삭제될 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4575,9 +4493,7 @@ msgctxt "settings"
 msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
-msgstr ""
-"브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 "
-"DuckDuckGo 무료 브라우저에"
+msgstr "브라우저 데이터를 삭제하면 차단된 사이트가 초기화됩니다. 차단 목록을 DuckDuckGo 무료 브라우저에"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4586,9 +4502,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모"
-"델을 지원하는 DuckDuckGo의 비공개 AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 "
-"후속 질문을 하세요."
+"'더 보기'를 클릭해서 주제를 더 깊이 탐색하고, OpenAI와 Anthropic 등의 채팅 모델을 지원하는 DuckDuckGo의 비공개 "
+"AI 기반 채팅 서비스 %1$sDuck.ai%2$s를 통해 후속 질문을 하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4629,9 +4544,7 @@ msgstr "드롭다운 메뉴에서 %1$s검색 설정 변경%2$s을 클릭하세�
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환"
-"경설정%4$s을 클릭하세요."
+msgstr "Windows에서는 %1$s편집 > 환경설정%2$s을 클릭하고, Mac에서는%3$sSeaMonkey > 환경설정%4$s을 클릭하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4647,9 +4560,7 @@ msgstr "DuckDuckGo 확장 프로그램을 다운로드하려면 %1$s여기%2$s�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세"
-"요."
+msgstr "%1$s열기%2$s를 클릭해서 DuckDuckGo Safari 확장 프로그램을 다운로드하고 여세요."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4663,9 +4574,7 @@ msgstr "왼쪽 사이드바에서 %1$s개인정보 및 서비스%2$s를 클릭�
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s"
-"기어 모양 아이콘%4$s을 클릭하세요)."
+msgstr "상단 메뉴의 %1$sSafari%2$s를 클릭하세요(Windows에서는 오른쪽 상단에 있는 %3$s기어 모양 아이콘%4$s을 클릭하세요)."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4694,8 +4603,7 @@ msgstr "%1$s예%2$s를 클릭하세요."
 # smartling.placeholder_format=C
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
-msgstr ""
-"Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
+msgstr "Chrome 툴바(오른쪽 상단)에서 %1$ssettings/hamburger icon%2$s을 클릭하세요."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4757,9 +4665,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지"
-"만 브라우저에는 남아있습니다. 남아있는 데이터를 제거하려면 %3$s모든 검색 설"
-"정 초기화%4$s를 클릭하거나 누르세요."
+"%1$s데이터 삭제하기%2$s를 클릭하거나 누르면 클라우드에서는 데이터가 제거되지만 브라우저에는 남아있습니다. 남아있는 데이터를 "
+"제거하려면 %3$s모든 검색 설정 초기화%4$s를 클릭하거나 누르세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4770,9 +4677,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서"
-"는 데이터가 삭제되지만, %3$s모든 설정 초기화%4$s를 클릭하거나 누를 때까지 브"
-"라우저에는 데이터가 남아 있게 됩니다."
+"%1$s내 데이터 삭제%2$s를 클릭하거나 누릅니다. 이 작업을 수행하면 클라우드에서는 데이터가 삭제되지만, %3$s모든 설정 "
+"초기화%4$s를 클릭하거나 누를 때까지 브라우저에는 데이터가 남아 있게 됩니다."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4840,18 +4746,14 @@ msgstr "검색 창에서 드롭다운을 클릭하세요."
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 "
-"%3$sDuckDuckGo%4$s를 선택하세요."
+msgstr "주소 표시줄%2$s에 사용된 %1$s검색 엔진 옆 드롭다운 메뉴를 클릭하고 %3$sDuckDuckGo%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
 msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
-msgstr ""
-"광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리"
-"에 있습니다."
+msgstr "광고 차단 확장 프로그램 아이콘을 클릭하세요. 주로 브라우저 오른쪽 상단 모서리에 있습니다."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5051,9 +4953,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 "
-"수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
+msgstr "Cloud Save는 현재 설정을 영구적으로 저장하고 암호를 입력해 간편하게 불러올 수 있는 기능으로, 꼭 사용하실 필요는 없습니다."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5324,8 +5224,7 @@ msgstr "광고 차단 계속하기"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
+msgstr "최근 채팅을 여기서 계속 이어가거나, Fire Button을 눌러 삭제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5455,8 +5354,7 @@ msgstr "복사"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
+msgstr "주소 표시줄에 %1$sabout:preferences#search%2$s를 복사하여 붙여넣으세요."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5509,8 +5407,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & "
-"Backup › Sync With Another Device%2$s로 들어가서 다시 시도해 보세요."
+"다른 기기에서 코드를 복사하세요. %1$sDuck.ai Settings › Chats › Sync & Backup › Sync With "
+"Another Device%2$s로 들어가서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5682,8 +5580,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
-msgstr ""
-"링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
+msgstr "링크를 생성하면 링크를 연 모든 사람이 볼 수 있는 채팅 사본이 생성됩니다."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5921,17 +5818,14 @@ msgstr "일일 한도에 도달했습니다."
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
+msgstr "일일 사용 한도에 도달했습니다. %1$s 이후에 이 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있"
-"습니다."
+msgstr "일일 사용 한도에 도달했습니다. 주간 채팅 제한을 이용해서 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6248,9 +6142,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대"
-"화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 계속 보유할 수 있습니"
-"다."
+"링크를 삭제하면 더 이상 링크를 사용할 수 없습니다. 이미 링크를 열어서 해당 대화를 자신의 채팅에 추가한 사람은 자신이 추가한 사본을 "
+"계속 보유할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6346,8 +6239,7 @@ msgstr "Duck.ai 받아쓰기"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 받아쓰기 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6364,9 +6256,7 @@ msgstr "받아쓰기를 일시적으로 사용할 수 없습니다"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력"
-"하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
+msgstr "받아쓰기 기능은 OpenAI 모델을 사용하여 음성을 텍스트로 변환하므로, 직접 입력하지 않고도 Duck.ai에서 채팅을 할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6499,7 +6389,7 @@ msgstr "소스가 싫습니다"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "시각적 스타일이 마음에 들지 않음"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6615,7 +6505,7 @@ msgstr "지부티"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "지시를 따르지 않음"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6665,9 +6555,7 @@ msgstr "목록에 DuckDuckGo가 보이지 않으시나요?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요."
-"%4$s"
+msgstr "파일을 찾을 수 없으신가요? %1$s%2$s%3$s여기를 클릭하여 다시 다운로드하세요.%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6705,8 +6593,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 "
-"AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 AI 기능을 제공하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6715,8 +6603,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하"
-"지 않고 AI 이미지를 걸러냅니다. %3$s자세히 알아보세요%4$s"
+"AI를 원치 않으시나요? %1$snoai.duckduckgo.com%2$s은 검색에 AI 기능을 사용하지 않고 AI 이미지를 걸러냅니다. "
+"%3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6831,9 +6719,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
-msgstr ""
-"실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하"
-"세요."
+msgstr "실링 팬 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6841,9 +6727,7 @@ msgctxt "Full sentence for writing an email"
 msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
-msgstr ""
-"가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 "
-"작성하세요."
+msgstr "가정용 냉장고 수리 업체에 보낼 견적 요청 이메일 초안을 간결하면서도 상세하게 작성하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6863,9 +6747,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성"
-"하세요."
+msgstr "다가오는 파티에 사람들을 초대하기 위해 SNS에 올릴 글을 몇 가지 버전으로 작성하세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6873,9 +6755,7 @@ msgctxt "Full sentence for suggesting a blog post title"
 msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
-msgstr ""
-"팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써"
-"보세요."
+msgstr "팀 협업 강화 전략에 대해 내가 쓰고 있는 게시물의 제목을 여러 가지 버전으로 써보세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7007,9 +6887,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있"
-"습니다. 페이지 내용은 사용자가 첨부할 때만 포함됩니다. 또는 설정에서 페이지 "
-"자동 첨부를 선택하세요."
+"이제 내가 보고있는 페이지에 대해 궁금한 점이 있을 때 Duck.ai가 답해드릴 수 있습니다. 페이지 내용은 사용자가 첨부할 때만 "
+"포함됩니다. 또는 설정에서 페이지 자동 첨부를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7019,8 +6898,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 "
-"설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 시도하세요."
+"Duck.ai가 채팅을 저장하기 위해 로컬 저장소에 액세스할 수 없습니다. 브라우저 설정을 확인하거나 확장 프로그램을 비활성화한 후 다시 "
+"시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7028,16 +6907,13 @@ msgctxt "Error message for service limit"
 msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
-msgstr ""
-"Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
+msgstr "Duck.ai의 하루 메시지 전송 한도에 도달했습니다. 내일 대화를 이어가세요."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합"
-"니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 브라우저 DuckDuckGo에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7046,9 +6922,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사"
-"람들을 위한 독립된 온라인 보호 기업입니다."
+msgstr "Duck.ai를 만든 DuckDuckGo는 자신의 개인정보에 대한 통제권을 되찾고자 하는 사람들을 위한 독립된 온라인 보호 기업입니다."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7062,9 +6936,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기"
-"억하기 쉽게 바뀌었습니다."
+msgstr "Duck.ai는 여전히 DuckDuckGo 제품이지만, 웹사이트 주소가 https://duck.ai로 기억하기 쉽게 바뀌었습니다."
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7078,18 +6950,14 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)"
-"를 %2$s 이메일로 보내주세요"
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세"
-"요."
+msgstr "Duck.ai를 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7103,9 +6971,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄"
-"면 Duck.ai 버튼과 링크가 숨겨지지만 %1$sduck.ai%2$s에 들어가서 직접 기능을 이"
-"용할 수 있습니다."
+"Duck.ai를 사용하면 인기 AI 모델과 비공개로 채팅할 수 있습니다. 이 기능을 끄면 Duck.ai 버튼과 링크가 숨겨지지만 "
+"%1$sduck.ai%2$s에 들어가서 직접 기능을 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7116,10 +6983,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화"
-"할 수 있습니다. 이 설정을 끄면 DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보"
-"이지 않습니다. 하지만 이 설정이 꺼져 있어도 %1$shttps://duck.ai%2$s에 바로 접"
-"속해서 Duck.ai를 이용할 수 있습니다."
+"Duck.ai를 사용하면 OpenAI, Anthropic 등의 외부 AI 채팅 모델과 익명으로 대화할 수 있습니다. 이 설정을 끄면 "
+"DuckDuckGo Search에서 Duck.ai 버튼과 링크가 보이지 않습니다. 하지만 이 설정이 꺼져 있어도 "
+"%1$shttps://duck.ai%2$s에 바로 접속해서 Duck.ai를 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7133,9 +6999,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
-msgstr ""
-"Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하"
-"실 수 있습니다."
+msgstr "Duck.ai에서 나의 최근 채팅이 사라졌을 수 있습니다. Duck.ai는 평소처럼 사용하실 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7172,8 +7036,7 @@ msgstr "Duck.ai가 업그레이드되었습니다!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
+msgstr "Duck.ai는 개인정보가 보호되는 무료 DuckDuckGo 앱에서 최고 성능을 발휘합니다!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7183,9 +7046,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필"
-"요 없는 AI 채팅, OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이"
-"버시 중심 AI, 계정 필요 없는 AI 채팅"
+"Duck.ai, DuckDuckGo AI, 비공개 AI 챗봇, 무료 AI 채팅, 익명 AI 채팅, 가입 필요 없는 AI 채팅, "
+"OpenAI, Anthropic, Llama, Mistral, 오픈 소스 AI 모델, 프라이버시 중심 AI, 계정 필요 없는 AI 채팅"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7213,11 +7075,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. "
-"DuckAssist 표시 빈도 선택 가능: 안 함(검색 결과에서 DuckAssist UI를 완전히 제"
-"거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 표"
-"시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영"
-"어) 지역에서만 제공됩니다."
+"DuckAssist는 일부 검색에 대하여 익명으로 정보를 조회하고 요약할 수 있습니다. DuckAssist 표시 빈도 선택 가능: 안 "
+"함(검색 결과에서 DuckAssist UI를 완전히 제거), 주문형(Assist 버튼을 클릭할 때만 표시), 가끔(관련성이 높은 경우에만 "
+"표시), 자주(광범위한 검색에서 더 자주 표시). 현재 DuckAssist 서비스는 미국(영어) 지역에서만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7226,9 +7086,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 %1$sDuckDuckGo AI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7237,9 +7096,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 "
-"지원하는 비공개 AI 기반 채팅 서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니"
-"다."
+"DuckAssist는 후속 질문에 답변할 수 없지만 OpenAI 및 Anthropic의 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스인 DuckDuckGo %1$sAI Chat%2$s도 제공합니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7251,10 +7109,9 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 "
-"관련 사이트에서 의미있는 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여 "
-"해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용"
-"을 기반으로 답변을 제공하며 정확성 검사는 하지 않습니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 새 기능입니다. Wikipedia와 관련 사이트에서 의미있는 콘텐츠를 검색한 "
+"다음 AI 기반 자연어 기술을 사용하여 해당 정보를 요약하는 방식으로 답변을 생성합니다. 현재 Wikipedia와 관련 내용을 기반으로 "
+"답변을 제공하며 정확성 검사는 하지 않습니다."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7268,21 +7125,17 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관"
-"련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 사용하여, 검색된 관련 정보를 바"
-"탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 "
-"바로 링크하고 답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정"
-"보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 기반으로 자"
-"동 생성합니다."
+"DuckAssist는 검색 질의에 익명으로 답변을 생성하는 옵션 기능입니다. 웹에서 관련 콘텐츠를 검색한 다음 AI 기반 자연어 기술을 "
+"사용하여, 검색된 관련 정보를 바탕으로 간단한 답변을 생성합니다. DuckAssist는 응답을 할 때 항상 출처 1~2개를 바로 링크하고 "
+"답변 출처를 인용하기 때문에 사용자가 쉽게 이동하여 더 자세한 정보를 얻을 수 있습니다. 답변은 인용된 출처와 %1$s웹 크롤링%2$s을 "
+"기반으로 자동 생성합니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
-msgstr ""
-"DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습"
-"니다."
+msgstr "DuckAssist 응답은 나열된 소스를 기반으로 자동 생성하며 정확성을 확인하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7290,9 +7143,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채"
-"팅은 내일 계속하세요."
+msgstr "하루에 보낼 수 있는 DuckDuckGo AI Chat 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7301,8 +7152,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7311,8 +7162,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공"
-"개 AI 기반 채팅 서비스입니다."
+"DuckDuckGo AI Chat은 현재 %1$s의 %2$s, %3$s의 %4$s 채팅 모델을 지원하는 비공개 AI 기반 채팅 "
+"서비스입니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7320,9 +7171,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
-msgstr ""
-"DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있"
-"습니다."
+msgstr "DuckDuckGo AI Chat은 베타 버전이므로 부정확하거나 불쾌한 정보가 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7330,9 +7179,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 "
-"코드(%1$s)를 %2$s 이메일로 보내주세요"
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 문제가 지속되면 이 익명 코드(%1$s)를 %2$s 이메일로 보내주세요"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7340,16 +7187,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다"
-"시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 페이지를 새로고침한 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
+msgstr "DuckDuckGo AI Chat을 일시적으로 사용할 수 없습니다. 잠시 후 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7499,17 +7343,15 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정"
-"보(PII)를 자동으로 제거해 이러한 보고서를 익명화합니다."
+"DuckDuckGo는 이름, 이메일 주소, 전화번호, 식별 가능한 메타데이터 같은 개인정보(PII)를 자동으로 제거해 이러한 보고서를 "
+"익명화합니다."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동"
-"의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 Duck.ai의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7517,9 +7359,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s"
-"에 동의합니다."
+msgstr "DuckDuckGo는 채팅을 익명으로 처리합니다. %1$s 클릭을 통해 DuckDuckGo의 %2$s에 동의합니다."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7528,8 +7368,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에"
-"서 사용자 추적을 시도하는 Google과 Facebook 등의 추적기도 차단합니다."
+"DuckDuckGo는 사용자가 방문하는 웹사이트의 추적기를 차단하며, 다른 웹사이트에서 사용자 추적을 시도하는 Google과 "
+"Facebook 등의 추적기도 차단합니다."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7541,11 +7381,10 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위"
-"치 정보는 로컬 기기에만 저장됩니다. 사용자가 검색을 하면 사용자의 기기는 해"
-"당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 "
-"데 사용한 후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보"
-"를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 알아보세요%2$s."
+"DuckDuckGo는 개인정보 보호를 위한 검색 엔진입니다. 위치 기능을 활성화하면 위치 정보는 로컬 기기에만 저장됩니다. 사용자가 "
+"검색을 하면 사용자의 기기는 해당 검색 정보를 DuckDuckGo로 전송하며, DuckDuckGo는 이를 검색 결과를 개선하는 데 사용한 "
+"후 즉시 폐기하여 사용자의 검색 기록을 남기지 않습니다. %1$s개인정보를 보호하기 위해 개발된 DuckDuckGo의 기술에 대해 자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7565,8 +7404,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋"
-"은 결과를 제공할 수 있습니다. %1$s자세히 알아보세요%2$s."
+"DuckDuckGo는 사용자의 대략적인 위치만 사용합니다. 이 정보만으로도 충분히 좋은 결과를 제공할 수 있습니다. %1$s자세히 "
+"알아보세요%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7658,9 +7497,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 "
-"목록을 받습니다. 그러 다음 브라우저에서 목록에 포함된 4~5개의 무작위 단어를 "
-"선택하여 최소 18~20자 이상의 암호를 만듭니다."
+"암호 제안 버튼을 클릭할 때마다 DuckDuckGo는 서버에서 무작위 단어로 조합된 긴 목록을 받습니다. 그러 다음 브라우저에서 목록에 "
+"포함된 4~5개의 무작위 단어를 선택하여 최소 18~20자 이상의 암호를 만듭니다."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7873,9 +7711,7 @@ msgstr "웹 검색 활성화"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변"
-"경할 수 있습니다."
+msgstr "보다 정확한 결과를 얻으려면 익명 위치 기능을 활성화하세요. 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7917,9 +7753,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위"
-"치는 DuckDuckGo에 공개하지 않을 수 있습니다."
+msgstr "익명 위치를 활성화하면 더 정확한 결과를 얻으면서도 사용자의 검색과 정확한 위치는 DuckDuckGo에 공개하지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8094,9 +7928,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이"
-"터가 새 암호로 저장됩니다."
+msgstr "새 암호를 입력하고 %1$s설정 저장%2$s을 클릭하거나 누르세요. 그러면 해당 데이터가 새 암호로 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8121,9 +7953,7 @@ msgstr "번역할 내용 입력하기"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네"
-"임%6$s: d%7$s"
+msgstr "다음 내용을 적어주세요: %1$s이름%2$s: DuckDuckGo%3$s URL%4$s: %5$s 닉네임%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8223,9 +8053,7 @@ msgstr "지도 확장하기"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습"
-"니다."
+msgstr "개인 정보 보호를 덕히 중요하게 생각하는 사람들을 위해 전문성을 다해 만들었습니다."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8468,7 +8296,7 @@ msgstr "빠른"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "빠른 이미지 생성"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8514,8 +8342,7 @@ msgstr "피드백이 성공적으로 전송되었습니다."
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8523,9 +8350,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사"
-"용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
+msgstr "여러분이 주시는 피드백은 제품 업데이트와 개선에 직접적인 영향을 미칩니다. 사용자님이 보내주신 문제도 해결하기 위해 노력하겠습니다."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8620,16 +8445,13 @@ msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니�
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
+msgstr "이미지 검색 결과에서 AI가 생성한 이미지를 걸러냅니다. %1$s자세히 알아보기%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세"
-"요%2$s"
+msgstr "이미지 검색 결과에서 알려진 AI 스팸 사이트를 걸러냅니다. %1$s자세히 알아보세요%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8670,8 +8492,7 @@ msgstr "다운로드 폴더에서 <b>%1$s</b> 파일을 찾으세요"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
+msgstr "표시된 목록에서 DuckDuckGo를 찾아 %1$s기본값으로 설정%2$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8708,8 +8529,7 @@ msgstr "여러분과 보다 관련있는 결과를 찾아보세요."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
+msgstr "내 주변 결과를 보세요. %1$s내 위치는 익명 비공개로 안전하게 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8772,9 +8592,7 @@ msgstr "안개"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 "
-"클릭해야 할 수도 있습니다."
+msgstr "안내에 따라 DuckDuckGo의 광고 차단기를 끄세요. 메뉴 옵션을 선택하거나 버튼을 클릭해야 할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8797,7 +8615,7 @@ msgstr "후속 질문은 비공개로 유지됩니다."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "안내를 따랐어요"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8903,8 +8721,7 @@ msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
+msgstr "DuckDuckGo가 익명화하는 무료 비공개 채팅입니다. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9015,8 +8832,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 확"
-"인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
+"Mac의 앱 메뉴 표시줄에서 <strong>DuckDuckGo</strong> &gt; <strong>업데이트 "
+"확인...</strong>을 선택한 후 <strong>업데이트 설치</strong>를 선택합니다."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9309,8 +9126,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
+msgstr "DuckDuckGo VPN, 고급 Duck.ai, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9396,8 +9212,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, "
-"Identity Theft Restoration을 이용해 보세요."
+"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Personal Info Removal, Identity Theft "
+"Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9405,9 +9221,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration"
-"을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 제공되는 고급 AI 채팅, Identity Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9415,9 +9229,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo를 구독해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9427,9 +9239,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 "
-"Duck.ai의 고급 AI 모델을 이용하세요."
+msgstr "VPN을 비롯한 프리미엄 개인 정보 보호 기능이 제공되는 DuckDuckGo 구독을 통해 Duck.ai의 고급 AI 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9472,9 +9282,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 "
-"다양한 프리미엄 보호 기능을 이용해 보세요."
+msgstr "빠른 노로그 VPN, 옵션으로 이용 가능한 고급 AI 모델(채팅 한도 더 높음), 그 외 다양한 프리미엄 보호 기능을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9483,24 +9291,20 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information "
-"Removal 및 Identity Theft Restoration을 이용해 보세요."
+"안전한 노로그 VPN, 고급 Duck.ai를 사용해 보세요. Personal Information Removal 및 Identity "
+"Theft Restoration을 이용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 "
-"보세요."
+msgstr "안전한 노로그 VPN, 고급 Duck.ai, Identity Theft Restoration 서비스를 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 "
-"수 있습니다."
+msgstr "다운로드 한 번으로 브라우저에서 무료로 개인정보 보호 기능을 원활하게 이용할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9536,8 +9340,7 @@ msgstr "앱 받기"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
+msgstr "무료 DuckDuckGo 브라우저를 다운로드하여 %1$sYouTube 광고를 차단하세요.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9596,8 +9399,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device › Copy Text Code%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9606,8 +9409,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9617,8 +9420,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9628,9 +9431,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & "
-"Backup › Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR"
-"을 스캔하세요."
+"다른 브라우저나 DuckDuckGo App의 %1$sDuck.ai 설정%2$s에서 %3$sChats › Sync & Backup › "
+"Sync With Another Device%4$s로 들어갑니다. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9654,9 +9456,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비"
-"스'가 켜져 있는지 확인합니다."
+msgstr "%1$s설정 > 개인 정보 보호 및 보안 > 위치 서비스%2$s로 이동하여 '위치 서비스'가 켜져 있는지 확인합니다."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9664,9 +9464,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 "
-"%3$sDuckDuckGo%4$s를 찾습니다."
+msgstr "%1$s 설정 > 개인 정보 보호 > 권한 관리자 > 위치%2$s에서 화면을 내려 %3$sDuckDuckGo%4$s를 찾습니다."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9738,7 +9536,7 @@ msgstr "바람직한 개인정보 보호정책"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "시각적 스타일 훌륭"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10360,9 +10158,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 "
-"강조 표시합니다."
+msgstr "중요한 정보를 더 빨리 찾는 데 도움이 되도록 Search Assist 답변의 주요 사실을 강조 표시합니다."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10389,8 +10185,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그"
-"런 다음 %5$s기본값으로 설정%6$s을 클릭하세요"
+"키보드의 %1$sReturn%2$s 키를 눌러 %3$sDuckDuckGo를 목록에 저장하세요. %4$s그런 다음 %5$s기본값으로 "
+"설정%6$s을 클릭하세요"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10403,9 +10199,7 @@ msgstr "몽족어"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 "
-"보호 기능을 사용할 수 없게 됩니다."
+msgstr "잠깐만요! 다시 변경하면 DuckDuckGo 확장 기능프로그램이 비활성화되어 개인정보 보호 기능을 사용할 수 없게 됩니다."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10454,9 +10248,7 @@ msgstr "더움"
 msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
-msgstr ""
-"호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수"
-"집하는 데 사용되지 않습니다."
+msgstr "호텔 광고 클릭은 Tripadvisor의 광고 네트워크에서 관리되며 사용자의 정보를 수집하는 데 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10724,9 +10516,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으"
-"며, 그 이유는 무엇인가요?"
+msgstr "바람의 이름이라는 책을 좋아합니다. 다른 재미있는 책/시리즈에는 무엇이 있으며, 그 이유는 무엇인가요?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10760,9 +10550,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 "
-"및 개인정보 보호 재설정%2$s으로 이동하세요."
+msgstr "여전히 브라우저 위치를 사용할 수 없는 경우 %1$s설정 > 일반 > 재설정 > 위치 및 개인정보 보호 재설정%2$s으로 이동하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10772,8 +10560,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사"
-"이트 설정 > 위치%2$s로 이동하여 DuckDuckGo의 위치 접근을 허용하세요."
+"여전히 브라우저 위치를 사용할 수 없는 경우 브라우저에서 %1$s메뉴 > 설정 > 사이트 설정 > 위치%2$s로 이동하여 "
+"DuckDuckGo의 위치 접근을 허용하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10787,9 +10575,7 @@ msgstr "이 오류가 계속되면 %1$s에 문의하세요."
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가"
-"해야 합니다."
+msgstr "만약 %1$sDuckDuckGo%2$s가 보이지 않는다면 %3$s기타 검색 엔진%4$s 목록에 추가해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10797,9 +10583,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이"
-"지에 직접 문의하실 수도 있습니다."
+msgstr "채팅 또는 특정 채팅 응답에 대해 우려되는 부분이 있으면 %1$s 및 %2$s 지원 페이지에 직접 문의하실 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10807,17 +10591,13 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니"
-"다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
+msgstr "기기에 접근할 수 없게 되었을 때 저장된 채팅을 복구하려면 이 코드가 필요합니다. 이 코드를 기기에 텍스트 파일로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주"
-"세요%2$s"
+msgstr "저희를 계속 지원하고 싶으시다면, %1$sDuckDuckGo를 더 많은 사람들에게 소개해주세요%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10826,8 +10606,7 @@ msgstr ""
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
+msgstr "JavaScript 없이 DuckDuckGo를 사용하려면 %1$s 또는 %2$s버전을 사용하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10877,7 +10656,7 @@ msgstr "이미지 프롬프트는 Duck.ai %1$s을 준수해야 합니다."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "이미지 품질"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10981,8 +10760,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 "
-"서버를 통해 처리되도록 경로 변경이 필요합니다. %1$s자세히 알아보세요%2$s."
+"일부 이전 버전의 브라우저에서는 검색 결과 유출을 방지하기 위해 클릭한 정보가 서버를 통해 처리되도록 경로 변경이 필요합니다. "
+"%1$s자세히 알아보세요%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10992,9 +10771,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동"
-"기화”로 이동하세요."
+msgstr "DuckDuckGo 브라우저에서 설정 > Sync & Backup으로 이동한 다음 “다른 장치와 동기화”로 이동하세요."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11008,9 +10785,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개"
-"됩니다."
+msgstr "투명성을 위해 이 정보는 암호화되지 않으며, 저장된 정보는 전부 사용자에게 공개됩니다."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11415,9 +11190,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 "
-"통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 연결되며, 광고와는 달리 "
-"DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
+"항목은 검색어와의 관련성에 따라 순위가 지정되며 Microsoft의 광고 네트워크를 통해 제공됩니다. 클릭하면 판매자 랜딩 페이지로 바로 "
+"연결되며, 광고와는 달리 DuckDuckGo는 이러한 결과에 대해 수익을 얻지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11425,8 +11199,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
+msgstr "임의의 문자 및 숫자 10개보다 단어 4~5개를 기억하는 것이 훨씬 쉽고 안전합니다."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11498,8 +11271,7 @@ msgstr "두 기기 모두에서 Sync & Backup을 열어둘 수 있습니다."
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
+msgstr "한번에 최대 5대의 기기에서 모든 앱과 온라인 활동을 비공개로 유지하세요."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -12691,8 +12463,7 @@ msgstr "미크로네시아"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
+msgstr "마이크 액세스가 거부되었습니다. 마이크 액세스를 허용하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13476,10 +13247,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트"
-"와 응답을 암호화하여 DuckDuckGo 서버에 임시로 저장합니다. 채팅 기록을 비활성"
-"화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니"
-"다."
+"사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 DuckDuckGo 서버에 임시로 "
+"저장합니다. 채팅 기록을 비활성화하면 고정된 채팅이 삭제되고, 새로운 프롬프트와 응답의 임시 저장이 중단됩니다."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13801,8 +13570,7 @@ msgstr "검색 결과가 없습니다."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
+msgstr "음성이 감지되지 않았습니다. 다시 시도해 주세요. 마이크에 대고 말씀해 주세요."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14314,9 +14082,7 @@ msgstr "요청 시"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이"
-"콘 > 설정을 클릭하세요.%5$s"
+msgstr "Mac에서는 %1$sMaxthon > 환경설정%2$s을 클릭하고, Windows%3$s에서는 %4$s아이콘 > 설정을 클릭하세요.%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14325,8 +14091,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14335,8 +14101,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가서 코드 스캔:"
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가서 코드 스캔:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14345,8 +14111,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
+"다른 기기에서 %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s로 들어가거나 복구 PDF에 있는 QR 코드를 스캔하세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14373,9 +14139,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 "
-"파일을 업로드하세요."
+msgstr "첨부된 파일 중 하나가 지원 가능한 페이지 수를 초과합니다. %1$s페이지 이하의 파일을 업로드하세요."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14401,9 +14165,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지"
-"를 참고하세요."
+msgstr "사용자가 변경한 설정만 저장됩니다. 자세한 내용은 %1$sURL 매개 변수%2$s 페이지를 참고하세요."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14417,8 +14179,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
+msgstr "이런! 번역 중 예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14748,9 +14509,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 "
-"추적하지 않습니다."
+msgstr "다른 검색 엔진은 시크릿 모드에서도 사용자를 추적하지만, DuckDuckGo는 절대로 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14763,18 +14522,14 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미"
-"엄 보호 기능을 올인원 구독으로 이용해 보세요."
+msgstr "빠른 노로그 VPN과 함께 더 높은 한도의 스마트한 AI 채팅, 그 외 다양한 프리미엄 보호 기능을 올인원 구독으로 이용해 보세요."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
-msgstr ""
-"DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공"
-"유하지 않습니다."
+msgstr "DuckDuckGo의 개인정보 보호정책은 간단합니다. 어떠한 개인 정보도 수집하거나 공유하지 않습니다."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14782,8 +14537,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강"
-"화 등의 기능이 탑재되어 있습니다. %1$siOS 및 Android%2$s에서 다운로드하세요."
+"DuckDuckGo 모바일용 비공개 브라우저에는 검색 엔진, 추적 차단, 암호화 보호 강화 등의 기능이 탑재되어 있습니다. %1$siOS "
+"및 Android%2$s에서 다운로드하세요."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15035,9 +14790,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 "
-"않기 때문에 암호를 복구할 수 없습니다."
+msgstr "해당 파일에는 사용자의 IP 주소, 브라우저 지문 또는 기타 정보가 연결되어 있지 않기 때문에 암호를 복구할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15193,8 +14946,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용"
-"자의 정보를 찾아내서 정보 삭제를 도와드립니다."
+"Personal Information Removal은 정보를 판매하는 데이터 브로커 사이트에서 사용자의 정보를 찾아내서 정보 삭제를 "
+"도와드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15265,9 +15018,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 "
-"답변 수준이 높아질 수 있습니다. 이 기능을 끄고 Assist 버튼을 숨기려면 %1$s검"
-"색 설정%2$s으로 들어가세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 AI 지원 답변이 자동으로 나오고 답변 수준이 높아질 수 있습니다. 이 기능을 끄고 "
+"Assist 버튼을 숨기려면 %1$s검색 설정%2$s으로 들어가세요."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15276,9 +15028,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어"
-"난 답을 얻을 가능성이 높아집니다. %1$sDuckAssist 설정%2$s에서 이 기능을 끄거"
-"나 작동 방식을 조정할 수 있습니다."
+"검색어를 완전한 문장 형태의 질문으로 작성하면 DuckAssist가 나타나고 더 뛰어난 답을 얻을 가능성이 높아집니다. "
+"%1$sDuckAssist 설정%2$s에서 이 기능을 끄거나 작동 방식을 조정할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15288,9 +15039,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 "
-"더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 끄고 Assist 버튼을 감추려면 "
-"%1$sDuckAssist 설정%2$s을 방문하세요."
+"검색어를 완전한 문장 형태의 질문으로 작성하면, DuckAssist가 자동으로 나오고 더 좋은 답을 얻을 가능성이 높아집니다. 이 기능을 "
+"끄고 Assist 버튼을 감추려면 %1$sDuckAssist 설정%2$s을 방문하세요."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15322,9 +15072,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15332,9 +15080,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠"
-"보세요."
+msgstr "GPT-5 mini, Claude Haiku 4.5, Mistral 등 인기 있는 AI를 선택하여 대화를 나눠보세요."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15342,9 +15088,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보"
-"호 기능이 제공되지 않습니다."
+msgstr "목적지로 가능 방법을 확인할 서비스를 선택하세요. 외부 앱에서는 DuckDuckGo 보호 기능이 제공되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15492,9 +15236,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해"
-"하거나 불법적인 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 유해하거나 불법적인 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15502,9 +15244,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법"
-"이거나 해로운 이유를 설명해 주세요."
+msgstr "해당 프롬프트와 문제가 있는 산출물(개인 정보 제거)을 붙여 넣고, 콘텐츠가 불법이거나 해로운 이유를 설명해 주세요."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15656,9 +15396,7 @@ msgstr "DuckDuckGo를 구독하면 더 많은 프리미엄 기능들도 따라�
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니"
-"다."
+msgstr "또한 Duck Player에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15720,15 +15458,13 @@ msgstr "형식이 조악함"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "이미지 품질이 낮음"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo"
-"가 익명화하는 채팅입니다."
+msgstr "인기 있는 AI 모델을 사용할 수 있습니다. 계정이 없어도 괜찮습니다. DuckDuckGo가 익명화하는 채팅입니다."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16165,8 +15901,7 @@ msgstr "DuckDuckGo는 절대 저장하지 않는 비공개 채팅"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
+msgstr "DuckDuckGo에는 정보가 기록되지 않고 사용자의 기기에서 보안이 유지됩니다."
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16238,9 +15973,7 @@ msgstr "재생하기 전에 물어보기"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니"
-"다."
+msgstr "내 대략적인 위치를 사용하여 주변 결과를 표시하라는 메시지가 표시되도록 합니다."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16258,8 +15991,7 @@ msgstr "검색과 인터넷 이용 과정에서 데이터를 보호하세요."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
+msgstr "검색하고, 인터넷을 이용하고 AI를 사용하는 과정에서 데이터를 보호하세요."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16289,9 +16021,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입"
-"력]"
+msgstr "다음 글을 더 간결하게 정리하기 위한 제안을 몇 가지 해주세요. [여기에 바로 입력]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16520,8 +16250,7 @@ msgstr "추론을 통해 복잡한 질문에 대해 더 나은 답변을 얻을 
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
+msgstr "추론 기능이 더 뛰어나지만, 사용 한도에 2~5배 더 빠르게 도달합니다. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16576,9 +16305,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16586,9 +16313,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장"
-"됩니다."
+msgstr "최근 채팅은 DuckDuckGo 서버나 다른 원격 서버가 아닌 사용자의 기기 자체에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16598,9 +16323,8 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 "
-"때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 암호화하여 "
-"DuckDuckGo 서버에 임시로 저장합니다."
+"최근 채팅은 사용자의 기기에 직접 저장됩니다. 사용자의 인터넷 연결이 끊겼을 때 채팅을 복원할 수 있도록, 전송된 새 프롬프트와 응답을 "
+"암호화하여 DuckDuckGo 서버에 임시로 저장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16881,9 +16605,7 @@ msgstr "Duck.ai를 다시 불러오기"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 "
-"DuckDuckGo를 새로고침하세요."
+msgstr "안내된 방법을 따르거나 브라우저에서 '새로고침' 또는 'Reload' 버튼을 눌러 DuckDuckGo를 새로고침하세요."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16990,18 +16712,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 "
-"항상 자동으로 표시됩니다."
+msgstr "'Ask' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변"
-"이 항상 자동으로 표시됩니다."
+msgstr "'생성' 버튼을 제거하면 관련 검색 시 답변이 자동으로 표시됩니다. 캐시된 답변이 항상 자동으로 표시됩니다."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17065,18 +16783,15 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. "
-"사용자님이 익명으로 보내주신 의견은 %1$s 사에도 서비스 개선을 위해 제공됩니"
-"다."
+"보고서는 익명으로 제공되며, 검색 서비스 향상을 위해 DuckDuckGo로 전송됩니다. 사용자님이 익명으로 보내주신 의견은 %1$s "
+"사에도 서비스 개선을 위해 제공됩니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 "
-"기재하지 마세요."
+msgstr "DuckDuckGo로 전송되는 보고서는 익명입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17085,9 +16800,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 "
-"요청하는 모든 텍스트가 들어있으며, 이 텍스트는 익명 상태입니다. 피드백에 개"
-"인 정보나 식별 정보를 기재하지 마세요."
+"DuckDuckGo로 전송되는 보고서에는 사용자가 이 페이지를 불러오는 중 번역하도록 요청하는 모든 텍스트가 들어있으며, 이 텍스트는 "
+"익명 상태입니다. 피드백에 개인 정보나 식별 정보를 기재하지 마세요."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17179,9 +16893,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. AI 지원 답변에는 %1$s서비스 약관%2$s"
-"이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. AI 지원 "
+"답변에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17190,9 +16903,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. DuckAssist에는 %1$s서비스 약관%2$s이 "
-"적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. "
+"DuckAssist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17202,10 +16914,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적"
-"인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 바탕으로 자동 생성된 응답"
-"이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약"
-"관%2$s이 적용됩니다."
+"응답은 교육 목적으로만 제공되며 의학적, 법률적, 금융적, 투자, 그 밖의 전문적인 조언을 제공하기 위한 것이 아닙니다. 웹 콘텐츠를 "
+"바탕으로 자동 생성된 응답이며 부정확한 내용이 섞여있을 수 있습니다. Search Assist에는 %1$s서비스 약관%2$s이 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17629,9 +17339,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많"
-"이 저장할 수도 있습니다."
+msgstr "최근 채팅을 30개까지 기기에 로컬로 저장하며, 암호화된 저장소를 사용하면 더 많이 저장할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17686,8 +17394,7 @@ msgstr "안녕하세요, Duck.ai입니다!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
+msgstr "DuckDuckGo가 선보이는 비공개 무료 AI 채팅 서비스, Duck.ai를 만나보세요."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17804,9 +17511,7 @@ msgstr "아래로 스크롤하여 %1$s고급 설정 보기%2$s를 클릭하세�
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변"
-"경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾으세요. 그리고 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17814,9 +17519,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 "
-"%5$s새로 추가%6$s)을 클릭하세요."
+msgstr "아래로 스크롤하여 %1$s주소 표시줄에서 검색%2$s을 찾은 후 %3$s변경%4$s(또는 %5$s새로 추가%6$s)을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17840,9 +17543,7 @@ msgstr "%1$sDuckDuckGo%2$s로 스크롤하여 사용자의 위치를 사용하�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클"
-"릭하세요."
+msgstr "아래로 스크롤하여 %1$s서비스%2$s 섹션으로 이동한 후 %3$s주소 표시줄%4$s을 클릭하세요."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17904,12 +17605,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 "
-"콘텐츠를 검색한 다음 AI를 사용하여 간단한 답변을 생성합니다. 답변 표시 빈도"
-"는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클"
-"릭했을 때만), 가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 "
-"때 표시) 중 선택하세요. 현재 Search Assist는 영어를 사용하는 일부 지역에만 제"
-"공됩니다."
+"Search Assist는 검색 질의에 익명으로 답변을 생성하며, 이를 위해 웹에서 관련 콘텐츠를 검색한 다음 AI를 사용하여 간단한 "
+"답변을 생성합니다. 답변 표시 빈도는 사용자가 직접 선택할 수 있습니다. 안 함, 요청 시(검색 결과에서 Assist를 클릭했을 때만), "
+"가끔(관련성이 높은 경우에만 표시), 자주(검색 결과가 광범위할 때 표시) 중 선택하세요. 현재 Search Assist는 영어를 "
+"사용하는 일부 지역에만 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17917,8 +17616,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 "
-"충분히 찾지 못했습니다. 다른 검색을 시도해 보세요."
+"Search Assist가 이 질문에 대한 답변을 생성하기에 위해 신뢰할 수 있는 정보를 충분히 찾지 못했습니다. 다른 검색을 시도해 "
+"보세요."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17927,9 +17626,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이"
-"를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s 한 다음 AI를 사용하여 찾은 정보를 "
-"기반으로 간단한 답변을 생성합니다."
+"Search Assist는 검색 질의에 대해 익명으로 답변을 생성하는 옵션 기능이며, 이를 위해 %1$s웹에서 관련 콘텐츠를 스캔%2$s "
+"한 다음 AI를 사용하여 찾은 정보를 기반으로 간단한 답변을 생성합니다."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18050,8 +17748,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 "
-"위키피디아에서 바로 'ducks'를 바로 검색합니다."
+"다른 사이트에서 검색할 때 %1$s 단축 키를 사용하세요. '!w ducks'라고 입력하면 위키피디아에서 바로 'ducks'를 바로 "
+"검색합니다."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18070,18 +17768,15 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하"
-"는 브라우저에 비공개 웹 검색 기능을 설치하거나, %1$sduckduckgo.com%2$s에서 바"
-"로 검색하세요."
+"DuckDuckGo 앱 또는 확장 프로그램을 사용하여 비공개로 검색하거나, 자주 사용하는 브라우저에 비공개 웹 검색 기능을 설치하거나, "
+"%1$sduckduckgo.com%2$s에서 바로 검색하세요."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
 msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
-msgstr ""
-"검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용"
-"합니다)."
+msgstr "검색 쿼리가 URL에 포함됩니다('꺼짐'으로 설정된 경우 검색 시 POST 요청을 사용합니다)."
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18093,10 +17788,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저"
-"장됩니다. 하지만 Cloud Save를 사용하여 클라우드 원격 서버에 설정을 익명으로 "
-"저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으"
-"며, 암호가 브라우저 밖으로 유출되지 않습니다."
+"검색 설정은 비개인 브라우저 쿠키와 사용자의 브라우저 안에 있는 로컬 공간에 저장됩니다. 하지만 Cloud Save를 사용하여 클라우드 "
+"원격 서버에 설정을 익명으로 저장할 수도 있습니다. 클라우드에는 사용자의 개인 신원 정보가 저장되지 않으며, 암호가 브라우저 밖으로 "
+"유출되지 않습니다."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18198,9 +17892,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18208,9 +17900,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18218,9 +17908,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하"
-"고 모든 동기화된 기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 무제한에 가까운 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 동기화된 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18228,9 +17916,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 "
-"기기에 접근할 수 있습니다."
+msgstr "종단간 암호화를 사용해 사용자의 채팅을 Duck.ai 서버에 안전하게 저장하고 모든 기기에 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18244,9 +17930,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데"
-"이터는 본인 외에 누구도 볼 수 없습니다."
+msgstr "DuckDuckGo 서버에 안전하게 저장되며, 종단간 암호화가 적용됩니다. 회원님의 데이터는 본인 외에 누구도 볼 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18396,9 +18080,7 @@ msgstr "Safari 메뉴에서 %1$s'이 웹사이트의 설정'%2$s을 선택하세
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
-msgstr ""
-"%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입"
-"력하세요."
+msgstr "%1$s사용자 지정%2$s을 선택하고 입력 창에 %3$shttps://duckduckgo.com%4$s를 입력하세요."
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18462,18 +18144,14 @@ msgstr "드롭다운 메뉴에서 %1$s추가 기능 관리%2$s를 선택하세�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설"
-"정%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$s메뉴 > 설정%4$s을 선택하세요."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵"
-"션%4$s을 선택하세요."
+msgstr "Mac에서는 %1$sOpera > 환경설정%2$s을 선택하고, Windows에서는 %3$sOpera > 옵션%4$s을 선택하세요."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18537,8 +18215,7 @@ msgstr "%1$s설정%2$s을 선택한 다음 %3$s검색 엔진%4$s을 선택하세
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
+msgstr "%1$s이 웹페이지를 홈 화면으로 사용%2$s을 선택하세요(다른 옵션도 선택 가능)."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18659,9 +18336,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞"
-"으로 나와 나누는 모든 대화에 적용됩니다."
+msgstr "AI 모델에 메시지와 응답 방법에 대한 지침을 프롬프트로 보냅니다. 이 지침은 앞으로 나와 나누는 모든 대화에 적용됩니다."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18783,9 +18458,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지"
-"하세요."
+msgstr "채팅 기록을 켜고 Sync & Backup을 설정하여 기기 간 채팅을 동기화된 상태로 유지하세요."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18865,9 +18538,7 @@ msgstr "공유"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세"
-"요!"
+msgstr "DuckDuckGo를 더 많은 친구들에게 알려서 개인정보를 보호할 수 있도록 도와주세요!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18894,8 +18565,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용"
-"자의 정확한 위치를 우리에게나 AI 모델에게나 절대 공개하지 않습니다."
+"관련성을 높이기 위해, 어느 도시에 있는지 AI 모델에 알려주세요. Duck.ai는 사용자의 정확한 위치를 우리에게나 AI 모델에게나 "
+"절대 공개하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18996,8 +18667,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
+msgstr "DuckDuckGo에 프롬프트 및 채팅 응답 공유하기(불법적이고 유해한 신고에 필요)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19045,9 +18715,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언"
-"제든 쉽게 켜고 끌 수 있어요."
+msgstr "로그를 남기지 않는 빠른 VPN으로 온라인 활동을 보호하세요. 설정이 간편하고 언제든 쉽게 켜고 끌 수 있어요."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19411,17 +19079,15 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알"
-"림을 숨기며 검색 개인정보에는 영향을 주지 않습니다."
+"DuckDuckGo의 모든 검색은 항상 비공개라는 알림을 표시합니다. 이 기능을 끄면 알림을 숨기며 검색 개인정보에는 영향을 주지 "
+"않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림"
-"만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
+msgstr "DuckDuckGo의 검색은 항상 보호 받는다는 알림을 표시합니다. 이 기능을 끄면 알림만 감춰지고, 검색 보호에는 영향이 가지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19566,8 +19232,7 @@ msgstr "사이트 이름"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
+msgstr "사이트 검색을 일시적으로 사용할 수 없습니다. 현재 문제를 해결하고 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19799,8 +19464,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
+msgstr "업로드하신 이미지를 처리할 수 없습니다. 다른 이미지나 형식을 사용해 보세요."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19808,9 +19472,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는"
-"지 확인하세요."
+msgstr "죄송합니다. 이 코드는 유효하지 않습니다. 코드를 정확하게 입력했거나 스캔했는지 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19824,9 +19486,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여"
-"기를 클릭%2$s하세요."
+msgstr "죄송하지만 이 결과를 표시하는 동안 오류가 생겼습니다. 다시 시도하려면 %1$s여기를 클릭%2$s하세요."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -19886,8 +19546,7 @@ msgstr "원문 지움"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
+msgstr "원본이 너무 길어서 요약할 수 없습니다. 길이를 줄여서 다시 시도해 보세요."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20236,9 +19895,7 @@ msgctxt "Description prompting subscription for higher limits"
 msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
-msgstr ""
-"DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많"
-"이 만들어 보세요."
+msgstr "DuckDuckGo를 구독해서 Duck.ai 한도를 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20704,9 +20361,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup을 사용하면 더 많은 채팅을 저장하고 모든 기기에서 동기화할 수 있"
-"습니다."
+msgstr "Sync & Backup을 사용하면 더 많은 채팅을 저장하고 모든 기기에서 동기화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20755,13 +20410,11 @@ msgid ""
 msgstr ""
 "동기화 복구 코드\n"
 "\n"
-"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅"
-"을 동기화할 수 있으며, 장치에 액세스할 수 없는 경우 동기화된 데이터를 복구할 "
-"수 있습니다.\n"
+"복구 코드를 사용하면 여러 장치에서 비밀번호, 자동 입력 데이터 및 Duck.ai 채팅을 동기화할 수 있으며, 장치에 액세스할 수 없는 "
+"경우 동기화된 데이터를 복구할 수 있습니다.\n"
 "\n"
 "이 정보를 안전하게 보관하세요.\n"
-"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니"
-"다.\n"
+"이 코드에 액세스할 수 있는 모든 사람이 동기화된 데이터에 액세스할 수 있습니다.\n"
 "\n"
 "%1$s\n"
 "\n"
@@ -20770,8 +20423,8 @@ msgstr ""
 "2. \"Sync & Backup\"를 선택한 다음, \"동기화된 데이터 복구\"를 선택합니다.\n"
 "3. 위 복구 코드를 복사하여 \"여기에 코드 붙여넣기\"에 붙여넣습니다.\n"
 "\n"
-"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 "
-"않으면 서버에서 데이터가 삭제되어 복원할 수 없습니다."
+"Sync & Backup이 활성화된 상태에서 DuckDuckGo 브라우저를 18개월 이상 사용하지 않으면 서버에서 데이터가 삭제되어 "
+"복원할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20909,9 +20562,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱"
-"에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서든 더 빠르게 이용할 수 있도록 무료 앱에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20919,9 +20570,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있"
-"도록 무료 브라우저에 내장하세요."
+msgstr "어디서나 Duck.ai를 이용해 보세요. 어디서 웹서핑을 하든 더 빠르게 이용할 수 있도록 무료 브라우저에 내장하세요."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21165,9 +20814,8 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 "
-"가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 비밀번호 또는 결제 세부 정"
-"보가 이에 포함됩니다."
+"이는 사용자의 기기와 이 링크 뒤의 웹 페이지 사이에 전송되는 정보를 제삼자가 가로챌 위험이 높아짐을 의미합니다. 드문 경우이지만 "
+"비밀번호 또는 결제 세부 정보가 이에 포함됩니다."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21175,9 +20823,7 @@ msgctxt "cloudsave"
 msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
-msgstr ""
-"Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으"
-"로 저장할 수 있습니다."
+msgstr "Cloud Save 북마클릿을 사용하면 설정에 대한 모든 변경 사항을 클라우드에 자동으로 저장할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21185,9 +20831,7 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr ""
-"Duck.ai 전환 기능을 사용하면 DuckDuckGo를 통해 익명화되는 비공개 검색과 AI 채"
-"팅 사이를 간편하게 오갈 수 있습니다."
+msgstr "Duck.ai 전환 기능을 사용하면 DuckDuckGo를 통해 익명화되는 비공개 검색과 AI 채팅 사이를 간편하게 오갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21216,8 +20860,7 @@ msgctxt "Second paragraph for the Sync & Backup intro screen"
 msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
-msgstr ""
-"암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
+msgstr "암호화 키는 브라우저의 로컬 저장소에만 저장되며, 본인만 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21296,9 +20939,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활"
-"성화되어 있는지 브라우저 설정에서 확인하세요."
+msgstr "이 채팅을 로컬에 저장하는 중 오류가 발생했습니다. 로컬 데이터 저장 공간이 활성화되어 있는지 브라우저 설정에서 확인하세요."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21312,8 +20953,7 @@ msgctxt "noresults"
 msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
-msgstr ""
-"검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
+msgstr "검색 결과를 표시하는 중에 오류가 발생했습니다. 몇 분 후 다시 시도해 주세요."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21332,9 +20972,8 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, "
-"DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 웹사이트의 개인정보 보호를 "
-"강화하는 데 적용됩니다."
+"이 브라우저 권한은 숨겨진 추적기를 차단하고, 가능한 경우 연결을 암호화하고, DuckDuckGo를 기본 검색 엔진으로 설정하여 방문하는 "
+"웹사이트의 개인정보 보호를 강화하는 데 적용됩니다."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21371,9 +21010,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세"
-"요."
+msgstr "이 AI 모델은 더 이상 이용할 수 없습니다. 다른 모델로 새로 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21381,9 +21018,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅"
-"을 시작해 보세요."
+msgstr "이 AI 모델 버전은 더 이상 지원되지 않습니다. 이 모델의 최신 버전으로 새 채팅을 시작해 보세요."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21422,8 +21057,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 "
+"수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21433,8 +21068,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅"
-"은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %2$s 참조)."
+"이 대화는 여러 채팅 모델을 사용하여 Duck.ai(%1$s)로 생성되었습니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 "
+"있습니다(자세한 내용은 %2$s 참조)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21443,8 +21078,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌"
-"한 정보를 제공할 수 있습니다(자세한 내용은 %2$s 참고)."
+"이 대화는 Duck.ai 음성 채팅(%1$s)으로 생성되었습니다. AI가 부정확하거나 불쾌한 정보를 제공할 수 있습니다(자세한 내용은 "
+"%2$s 참고)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21454,9 +21089,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습"
-"니다. AI 채팅은 부정확하거나 공격적인 정보를 보여줄 수 있습니다(자세한 내용"
-"은 %4$s 참조)."
+"이 대화는 %2$s의 %3$s 모델을 사용하여 DuckDuckGo AI Chat(%1$s)으로 생성되었습니다. AI 채팅은 부정확하거나 "
+"공격적인 정보를 보여줄 수 있습니다(자세한 내용은 %4$s 참조)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21472,9 +21106,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 "
-"채팅 %1$s개는 로컬 저장소에 남습니다."
+msgstr "이 기기는 앞으로 다른 기기에서 동기화된 데이터에 접근할 수 없습니다. 마지막 채팅 %1$s개는 로컬 저장소에 남습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21545,16 +21177,14 @@ msgstr "이 이미지를 만들 수 없습니다."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
+msgstr "이 이미지 유형은 지원되지 않으니 JPG, PNG, WebP, GIF 중 하나로 첨부하세요."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21581,9 +21211,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계"
-"속 표시되도록 하세요."
+msgstr "샘플 채팅입니다. 메뉴(점 3개)를 열고 '고정'을 선택하여 채팅 목록 맨 위에 계속 표시되도록 하세요."
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21591,8 +21219,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
+msgstr "샘플 채팅입니다. 측면 메뉴에 있는 Fire Button을 사용하여 삭제해 보세요!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21612,9 +21239,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 "
-"제공사는 데이터를 보유하지 않는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 30일 이내에 삭제합니다. 다른 모델 제공사는 데이터를 보유하지 않는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21622,9 +21247,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공"
-"사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
+msgstr "이 모델 제공사는 이 채팅과 관련된 데이터를 저장하지 않습니다. 다른 모델 제공사는 데이터를 제한적으로 보유하는 모델을 따릅니다."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21660,9 +21283,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 "
-"모든 브라우저에서 접근할 수 있습니다."
+msgstr "이렇게 하면 채팅이 DuckDuckGo의 보안 서버에 종단간 암호화로 저장되며, 나중에 모든 브라우저에서 접근할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21670,9 +21291,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다."
+msgstr "이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21682,9 +21301,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우"
-"면 AI 지원 답변이 다시 표시될 수 있습니다. 하지만 AI 지원 답변이 절대 표시되"
-"지 않는 시작 페이지(%1$s)도 있습니다."
+"이 설정은 브라우저에 저장됩니다. 따라서 duckduckgo.com 브라우저 데이터를 지우면 AI 지원 답변이 다시 표시될 수 있습니다. "
+"하지만 AI 지원 답변이 절대 표시되지 않는 시작 페이지(%1$s)도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21719,17 +21337,13 @@ msgstr "이 번역은 잘못되었습니다."
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 "
-"수 있습니다."
+msgstr "아직 현재 페이지에서는 이 동영상을 재생할 수 없습니다. %1$s에서 직접 시청할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 "
-"사용하지 않고 있습니다."
+msgstr "이 웹사이트는 사용자를 안전하게 보호하고 통신을 암호화하는 HTTPS 프로토콜을 사용하지 않고 있습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21739,9 +21353,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결"
-"이 끊깁니다. Sync & Backup에 연결된 다른 브라우저에서는 계속 채팅을 볼 수 있"
-"습니다."
+"이렇게 하면 이 브라우저에서 Duck.ai 채팅이 모두 삭제되고 Sync & Backup 연결이 끊깁니다. Sync & Backup에 "
+"연결된 다른 브라우저에서는 계속 채팅을 볼 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21749,9 +21362,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌"
-"릴 수 없습니다."
+msgstr "이렇게 하면 고정된 채팅을 제외한 최근 채팅이 전부 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21843,9 +21454,7 @@ msgstr "팁"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니"
-"다.%2$s"
+msgstr "개인 정보를 추적하는 웹사이트가 지긋지긋하시다고요? %1$s저희가 도와드리겠습니다.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21890,9 +21499,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인"
-"쇄 아이콘을 클릭하세요.%4$s"
+msgstr "경로를 인쇄하려면 %1$s지도로 돌아가세요.%2$s원하는 경로를 선택하세요.%3$s인쇄 아이콘을 클릭하세요.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21902,9 +21509,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합"
-"니다. 이 코드는 Sync를 설치할 때 원래 사용한 기기에 PDF로 저장되었을 수 있습"
-"니다."
+"동기화된 데이터를 복원하려면 처음 Sync를 설치할 때 저장한 복구 코드가 필요합니다. 이 코드는 Sync를 설치할 때 원래 사용한 "
+"기기에 PDF로 저장되었을 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21912,18 +21518,14 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트"
-"하고 다시 시도하세요."
+msgstr "채팅 기록을 Duck.ai로 전송하려면 DuckDuckGo 브라우저를 최신 버전으로 업데이트하고 다시 시도하세요."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
-msgstr ""
-"받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허"
-"용해 주세요."
+msgstr "받아쓰기를 사용하려면 시스템 설정에서 브라우저가 마이크에 접근할 수 있도록 허용해 주세요."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21951,9 +21553,7 @@ msgstr "전환하여 비공개 AI 채팅을 사용하거나 %1$s설정에서 비
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요."
-"%3$s"
+msgstr "전환하여 비공개 AI 채팅을 사용해 보거나 %1$s %2$s 메뉴에서 비활성화하세요.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22019,7 +21619,7 @@ msgstr "너무 느림"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "생성이 너무 느림"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22132,9 +21732,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되"
-"었는지 둘러보세요."
+msgstr "DuckDuckGo가 차단한 추적 시도가 여기에 표시됩니다. 얼마나 많은 시도가 차단되었는지 둘러보세요."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22181,9 +21779,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22191,9 +21787,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 "
-"주세요."
+msgstr "'여기에서 가장 가까운 영화관에 어떻게 가나요?'라는 문장을 프랑스어로 번역해 주세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22465,7 +22059,7 @@ msgstr "더 짧은 검색어를 사용해 보세요."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "무료 체험"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22585,9 +22179,7 @@ msgstr "위치를 수동으로 설정하세요."
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 "
-"보호."
+msgstr "%1$sDuckDuckGo%2$s 브라우저를 사용해 보세요. 빠른 검색. 무료 제공. 개인 정보 보호."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22679,8 +22271,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 "
-"설치하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 싶으신가요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램을 설치하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22689,8 +22281,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 "
-"전환하면 설정을 기억시킬 수 있습니다. %3$s자세히 알아보세요%4$s"
+"AI 기능을 해제하고 하시나요? %1$sDuckDuckGo No AI%2$s 검색 확장 프로그램으로 전환하면 설정을 기억시킬 수 "
+"있습니다. %3$s자세히 알아보세요%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22890,9 +22482,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표"
-"시되기까지 시간이 조금 지연될 수 있습니다."
+msgstr "DuckAssist 답변이 생성되는 대로 입력합니다. 이 기능을 끄면 검색 시 답변이 표시되기까지 시간이 조금 지연될 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23021,30 +22611,24 @@ msgstr "장점과 단점 파악"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이"
-"지 설정%6$s을 클릭하세요."
+msgstr "%1$s시작 페이지%2$s 항목에서 %3$s특정 페이지 열기%4$s를 클릭한 다음 %5$s페이지 설정%6$s을 클릭하세요."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com"
-"을 입력하세요."
+msgstr "%1$s시작 페이지%2$s에서 %3$s홈페이지%4$s를 선택한 다음 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
+msgstr "%1$s다음으로 열기%2$s에서 %3$s특정 페이지(또는 여러 페이지)%4$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
+msgstr "%1$s시작 페이지 > 홈페이지%2$s에서 https://duckduckgo.com을 입력하세요."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23054,8 +22638,7 @@ msgstr "%1$s검색 설정%2$s에서 %3$sDuckDuckGo%4$s를 선택하세요."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
+msgstr "%1$s주소창에서 다음을 사용하여 검색%2$s에서 %3$s새로 추가%4$s를 선택하세요."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23067,8 +22650,7 @@ msgstr "%1$s검색%2$s 섹션에서, %3$s검색 엔진 관리...%4$s를 클릭�
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
+msgstr "시작 페이지에서 %1$s특정 페이지 또는 페이지 모음 열기%2$s를 선택하세요."
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23151,9 +22733,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사"
-"용 한도를 이용하세요."
+msgstr "Pro로 업그레이드하여 %1$s, 더 높은 AI 추론 및 Plus 요금제보다 2배 더 높은 사용 한도를 이용하세요."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23310,9 +22890,7 @@ msgctxt "Old app version banner component in Duck.ai"
 msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
-msgstr ""
-"DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 "
-"이용하세요."
+msgstr "DuckDuckGo 브라우저를 업데이트하여 Duck.ai에서 구독을 활성화하고 고급 모델을 이용하세요."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23436,9 +23014,7 @@ msgctxt ""
 msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
-msgstr ""
-"Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 "
-"더 많이 만들어 보세요."
+msgstr "Pro로 업그레이드해서 한도를 Plus의 2배로 높이거나, 나중에 돌아와서 이미지를 더 많이 만들어 보세요."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
@@ -23540,8 +23116,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채"
-"팅을 보호하세요. 정보를 기밀로 유지하세요. 무료로. 계정이 없어도 괜찮습니다."
+"ChatGPT, Claude 등의 AI를 비공개로 사용하세요. 해커, 사기꾼, 기업으로부터 채팅을 보호하세요. 정보를 기밀로 유지하세요. "
+"무료로. 계정이 없어도 괜찮습니다."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23595,17 +23171,14 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 "
-"보관하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 데이터를 복원하세요. 안전하게 보관하세요."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
 msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
-msgstr ""
-"기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
+msgstr "기기에 접근할 수 없는 경우 이 코드를 사용하여 저장된 채팅을 복원하세요."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23729,8 +23302,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"DuckDuckGo가 제공하는 비공개 무료 AI 채팅 Duck.ai에서 공유된 대화를 열람하세"
-"요. 내 채팅에 저장하고 비공개로 대화를 이어갈 수 있습니다."
+"DuckDuckGo가 제공하는 비공개 무료 AI 채팅 Duck.ai에서 공유된 대화를 열람하세요. 내 채팅에 저장하고 비공개로 대화를 "
+"이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23764,9 +23337,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소"
-"프트의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 마이크로소프트의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23774,9 +23345,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 "
-"TripAdvisor의 광고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 TripAdvisor의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23784,9 +23353,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
-"광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 Yelp의 광"
-"고 네트워크에서 관리합니다."
+msgstr "광고 보기 시 DuckDuckGo에 의해 개인 정보가 보호됩니다. 광고 클릭은 Yelp의 광고 네트워크에서 관리합니다."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23813,9 +23380,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명"
-"을 따르세요."
+msgstr "휴대전화 또는 태블릿에서 %1$sDuckDuckGo.com%2$s을 접속한 다음, 제공되는 설명을 따르세요."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23830,8 +23395,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
-"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
+"다른 브라우저에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & Backup%4$s > "
+"%5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23841,9 +23406,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아"
-"래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF"
-"에 있는 QR을 스캔하세요."
+"다른 브라우저에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 '켜기'를 선택하고 "
+"''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23853,9 +23417,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > "
-"%3$sSync & Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선"
-"택하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 열고 %1$sDuck.ai 설정%2$s > %3$sSync & "
+"Backup%4$s > %5$s관리%6$s로 들어가 %7$s다른 기기와 동기화%8$s를 선택하세요."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23865,9 +23428,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. "
-"Sync & Backup 아래에 있는 '켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세"
-"요. 또는 복구 PDF에 있는 QR을 스캔하세요."
+"다른 브라우저나 DuckDuckGo 앱에서 Duck.ai를 방문하여 Duck.ai 설정을 여세요. Sync & Backup 아래에 있는 "
+"'켜기'를 선택하고 ''다른 기기와 동기화'를 선택하세요. 또는 복구 PDF에 있는 QR을 스캔하세요."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23919,8 +23481,7 @@ msgstr "음성 채팅이 끝났습니다"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
+msgstr "당사는 음성 채팅 내용을 익명화하며, AI 모델 학습에 절대 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24069,9 +23630,7 @@ msgstr "Duck Player에서 보기"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 "
-"YouTube 추천 영상이 달라지지 않습니다."
+msgstr "Duck Player로 영상을 시청하면 YouTube 맞춤 광고가 차단되고 시청 내역에 따라 YouTube 추천 영상이 달라지지 않습니다."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24091,9 +23650,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하"
-"는 웹사이트에서 사용자를 추적할 수 있습니다. DuckDuckGo는 동영상 대부분을 호"
-"스팅하는 YouTube와 무관한 독립적인 기업입니다."
+"여기서 영상을 시청하면 콘텐츠를 스트리밍해야 하기 때문에 해당 영상을 호스팅하는 웹사이트에서 사용자를 추적할 수 있습니다. "
+"DuckDuckGo는 동영상 대부분을 호스팅하는 YouTube와 무관한 독립적인 기업입니다."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24105,9 +23663,7 @@ msgstr "DuckDuckGo의 익명화"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니"
-"다."
+msgstr "더 정확한 결과를 보여드리기 위해 %1$s사용자의 위치%2$s를 익명화할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24119,8 +23675,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저"
-"희가 문제를 조사하고 해결할 수 있도록 이대화를 DuckDuckGo와 공유해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답을 신고하려면 저희가 문제를 조사하고 해결할 수 있도록 이대화를 "
+"DuckDuckGo와 공유해 주세요."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24132,9 +23688,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저"
-"희가 문제를 조사하고 해결할 수 있도록 사용하신 프롬프트와 응답 내용을 보내서 "
-"신고해 주세요."
+"문제는 눈에 보여야 고칠 수 있습니다. 유해하거나 불법적인 응답이 나온 경우, 저희가 문제를 조사하고 해결할 수 있도록 사용하신 "
+"프롬프트와 응답 내용을 보내서 신고해 주세요."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -24175,9 +23730,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따"
-"라다니며 광고를 게재하지 않습니다. DuckDuckGo는 사용자를 추적하지 않습니다. "
-"절대."
+"DuckDuckGo는 사용자의 개인정보를 저장하지 않습니다. DuckDuckGo는 사용자를 따라다니며 광고를 게재하지 않습니다. "
+"DuckDuckGo는 사용자를 추적하지 않습니다. 절대."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24190,9 +23744,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 "
-"알려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 다시 방문하게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24200,9 +23752,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알"
-"려주시면 도움이 될 것 같습니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 따라서 오늘 사용해보게 된 계기를 알려주시면 도움이 될 것 같습니다."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24213,9 +23763,7 @@ msgstr "DuckDuckGo는 절대로 사용자를 추적하지 않습니다."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24244,24 +23792,19 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사"
-"용자를 추적하는 광고주에게 판매할 수 있는 어떠한 정보도 보유하고 있지 않습니"
-"다."
+"DuckDuckGo는 사용자의 검색 기록을 저장하지 않습니다. 따라서 인터넷을 통해 사용자를 추적하는 광고주에게 판매할 수 있는 어떠한 "
+"정보도 보유하고 있지 않습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하"
-"지 않습니다."
+msgstr "DuckDuckGo는 개인정보 보호 모드 사용 여부에 관계없이 절대로 사용자를 추적하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입"
-"니다."
+msgstr "DuckDuckGo는 사용자를 추적하지 않습니다. 그게 바로 우리의 개인정보 보호정책입니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24275,9 +23818,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 "
-"함께 이용하세요."
+msgstr "데이터 브로커 사이트에서 개인정보를 찾아 삭제해 드립니다. VPN 등의 기능까지 함께 이용하세요."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24285,9 +23826,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않"
-"도록 보장합니다."
+msgstr "DuckDuckGo는 모든 AI 제공업체와 협약을 맺어 채팅 내용이 AI 학습에 사용되지 않도록 보장합니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24311,9 +23850,7 @@ msgstr "연결이 끊겼습니다. 메시지를 다시 보내 보세요."
 msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
-msgstr ""
-"우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터"
-"를 악용하지 않습니다."
+msgstr "우리는 %1$s프라이버시를 존중하는 검색 광고%2$s로 돈을 벌고, 여러분의 데이터를 악용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24321,9 +23858,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든"
-"지 설정을 변경할 수 있습니다."
+msgstr "익명 위치는 사용자 주변의 더 정확한 결과를 제공하기 위해서만 사용되며, 언제든지 설정을 변경할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24331,24 +23866,18 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하"
-"기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
+msgstr "데이터 브로커 사이트에 있는 사용자의 개인정보를 정기적으로 스캔해서, 사용하기 쉬운 대시보드를 통해 진행 상황을 알려드립니다."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 "
-"좋게 발전시킵니다."
+msgstr "여러분이 익명으로 보내주시는 피드백을 바탕으로 DuckDuckGo를 모두가 사용하기 좋게 발전시킵니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 "
-"포함해서 말이죠."
+msgstr "여러분의 검색 기록을 그 누구도 수집할 수 없게 차단합니다. 물론 DuckDuckGo도 포함해서 말이죠."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24364,8 +23893,8 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s"
-"의 재량에 따라 적용됩니다. 정정 사항이 결과에 바로 나타나지 않을 수 있습니다."
+"DuckDuckGo는 이러한 의견을 참고하여 서비스를 개선합니다. 보내주신 제안은 %1$s의 재량에 따라 적용됩니다. 정정 사항이 결과에 "
+"바로 나타나지 않을 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24378,9 +23907,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정"
-"보가 삭제되도록 도와드립니다."
+msgstr "데이터 브로커 사이트에서 사용자의 이메일, 이름, 주소 등을 스캔해서 발견된 정보가 삭제되도록 도와드립니다."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24388,9 +23915,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문"
-"의하세요."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 이 오류가 계속되면 %1$s에 문의하세요."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24398,9 +23923,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제"
-"가 해결되는 경우도 있습니다."
+msgstr "현재 이 문제를 인지하고 해결책을 모색 중입니다. 브라우저 캐시를 삭제하면 문제가 해결되는 경우도 있습니다."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24414,9 +23937,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노"
-"력 중입니다."
+msgstr "불편을 드려서 죄송합니다. 사용자 여러분이 더 쾌적한 경험을 하실 수 있도록 노력 중입니다."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24424,9 +23945,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
-msgstr ""
-"Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치"
-"세요."
+msgstr "Duck.ai 서비스를 업데이트했습니다. 변경 사항을 적용하려면 페이지를 새로 고치세요."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24534,8 +24053,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
+msgstr "주간 사용 한도에 도달했습니다. 월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24549,8 +24067,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되"
-"며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"Duck.ai에 오신 걸 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 "
+"사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24559,8 +24077,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공"
-"개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 "
+"저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24570,9 +24088,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 "
-"세션입니다. 여기서 이루어지는 모든 채팅은 비공개로 진행되며, DuckDuckGo에 저"
-"장되거나 AI 모델 학습에 사용되지 않습니다."
+"DuckDuckGo AI Chat에 오신 것을 환영합니다! %1$s의 %2$s 모델로 작동하는 채팅 세션입니다. 여기서 이루어지는 모든 "
+"채팅은 비공개로 진행되며, DuckDuckGo에 저장되거나 AI 모델 학습에 사용되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24645,9 +24162,7 @@ msgctxt "duckai_fatal_error"
 msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
-msgstr ""
-"정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로"
-"고침해 보세요."
+msgstr "정말 죄송하지만 Duck.ai를 불러오는 중 문제가 생긴 것 같습니다. 페이지를 새로고침해 보세요."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24681,9 +24196,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 "
-"개 알려 주세요."
+msgstr "“우리 정말 더 잘해야 합니다.”라는 문맥에서 '더 잘'이라는 단어의 대체어를 몇 개 알려 주세요."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24708,10 +24221,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? "
-"DuckDuckGo 공식 출처만 참고하세요. 답변은 명료하게 섹션을 나누어 작성하고 제"
-"목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 "
-"유무에 관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
+"Duck.ai를 사용하려고 할 때 DuckDuckGo 브라우저를 설치하면 어떤 점이 좋나요? DuckDuckGo 공식 출처만 참고하세요. "
+"답변은 명료하게 섹션을 나누어 작성하고 제목을 답니다. Duck.ai 통합과 개인정보 보호에 중점을 두고, AI나 기술 관련 경험 유무에 "
+"관계 없이 누구나 이해하기 쉽도록 간단하게 설명하세요."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24946,8 +24458,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
+msgstr "Cloud Save 북마클릿이란 무엇이며 URL 매개변수 북마클릿과 어떻게 다른가요?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25022,8 +24533,7 @@ msgstr "무엇에 대해 피드백을 주고 싶으세요?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
+msgstr "DuckDuckGo에서 시청하는 콘텐츠는 YouTube의 추천에 영향을 미치지 않습니다."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25048,9 +24558,7 @@ msgctxt "Full sentence for identifying product brands"
 msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
-msgstr ""
-"초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나"
-"요?"
+msgstr "초보자가 연주할 일렉트릭 기타를 살 때 가장 추천할 만한 브랜드에는 무엇이 있나요?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25251,8 +24759,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. "
-"'%1$s' 메뉴에서 언제든지 켜거나 끌 수 있습니다."
+"Duck.ai를 사용하면 채팅 내용이 익명화되며, AI 학습에 절대 사용되지 않습니다. '%1$s' 메뉴에서 언제든지 켜거나 끌 수 "
+"있습니다."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25281,9 +24789,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, "
-"이름, 주소 등의 정보를 삭제해 드립니다."
+msgstr "사용자의 기기에서 직접 작동하여 데이터 브로커 사이트에 있는 사용자의 이메일, 이름, 주소 등의 정보를 삭제해 드립니다."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25550,9 +25056,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있"
-"습니다."
+msgstr "%1$s 모델과 채팅 중입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25560,9 +25064,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 "
-"검색할 수 있습니다."
+msgstr "%1$s 또는 %2$s 검색 단축키를 사용하여 DuckDuckGo에서 다른 검색 엔진으로 직접 검색할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25575,8 +25077,7 @@ msgstr "%1$s에서 DuckDuckGo AI Chat에 바로 접속할 수 있습니다."
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
+msgstr "%1$s검색 설정%2$s에서 언제든 %3$s 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25584,22 +25085,17 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
-msgstr ""
-"%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니"
-"다."
+msgstr "%1$s검색 설정%2$s에서 언제든 Assist의 작동 방식을 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
+msgstr "%1$sDuck.ai%2$s를 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
-msgstr ""
-"%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 "
-"있습니다."
+msgstr "%1$sDuckDuckGo AI Chat%2$s을 사용해 질문에 대한 답을 찾거나 글을 요약할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25612,9 +25108,7 @@ msgstr "텍스트 선택은 %1$s개까지 첨부할 수 있습니다."
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 "
-"수 있습니다."
+msgstr "%1$sSearch Settings%2$s에서 검색 Assist가 표시되는 빈도를 변경하거나 해제할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25634,9 +25128,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트"
-"를 삭제할 수도 있습니다."
+msgstr "다른 암호로 설정을 저장하여 암호를 변경할 수 있으며, 필요한 경우 첫 번째 세트를 삭제할 수도 있습니다."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25665,8 +25157,7 @@ msgstr "월 한도를 사용하여 채팅을 이어갈 수 있습니다."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
+msgstr "이제 이 기기에 최근 채팅을 최대 100개 저장할 수 있습니다. 마음껏 채팅하세요!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25729,9 +25220,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이"
-"트 차단을 먼저 해제해야 합니다."
+msgstr "차단할 수 있는 사이트는 최대 %1$s개입니다. %2$s 사이트를 차단하려면 다른 사이트 차단을 먼저 해제해야 합니다."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25794,9 +25283,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습"
-"니다."
+msgstr "이제 %1$s, 더 뛰어난 AI 추론, Plus보다 2배 높은 사용량 한도를 경험할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25805,8 +25292,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 "
-"DuckDuckGo 구독 보호 기능을 이용할 수 있습니다."
+"이제 고급 AI 모델을 이용하실 수 있습니다. DuckDuckGo 브라우저에서 VPN과 각종 DuckDuckGo 구독 보호 기능을 이용할 "
+"수 있습니다."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25828,9 +25315,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25840,9 +25326,8 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채"
-"팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 채팅이 삭제되지는 않습니"
-"다."
+"이 브라우저에서 저장된 대화에 더 이상 액세스할 수 없습니다. 마지막 30개의 채팅은 로컬 저장소에 계속 남습니다. 암호화된 서버에서 "
+"채팅이 삭제되지는 않습니다."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25870,8 +25355,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용"
-"해 보세요. 이미 설치되어 있으며 다음과 같은 기능이 제공됩니다."
+"이제 Chrome에서 비공개로 검색할 수 있습니다. Chrome 대신 DuckDuckGo 앱도 사용해 보세요. 이미 설치되어 있으며 "
+"다음과 같은 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25883,9 +25368,7 @@ msgstr "이제 개인정보 보호를 받으며 검색할 수 있습니다!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 "
-"팁을 알아보세요."
+msgstr "현재 개인정보 보호 모드로 검색하고 있습니다. %1$s보안을 더욱 강화할 수 있는 팁을 알아보세요."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25961,9 +25444,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화"
-"를 재개하려면 가장 오래된 채팅 %1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않"
-"습니다."
+"첨부 파일이 있는 Duck.ai 채팅의 Sync & Backup 저장 공간이 부족합니다. 동기화를 재개하려면 가장 오래된 채팅 "
+"%1$s개를 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25973,9 +25455,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 "
-"첨부 파일이 있는 채팅을 오래된 순으로 %1$s개 삭제하세요. 고정된 채팅은 삭제되"
-"지 않습니다."
+"Duck.ai 채팅용 Sync & Backup 저장 공간이 소진되었습니다. 동기화를 재개하려면 첨부 파일이 있는 채팅을 오래된 순으로 "
+"%1$s개 삭제하세요. 고정된 채팅은 삭제되지 않습니다."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25989,8 +25470,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기"
-"서 YouTube 동영상을 시청하면 YouTube나 Google의 추적을 받게 됩니다."
+"YouTube(Google 소유)에서는 익명으로 동영상을 시청할 수 없습니다. 따라서 여기서 YouTube 동영상을 시청하면 "
+"YouTube나 Google의 추적을 받게 됩니다."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26049,8 +25530,7 @@ msgctxt "First body paragraph in the Delete Server Data confirmation modal"
 msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
-msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
+msgstr "백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26060,8 +25540,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 %1$s개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 %1$s개가 로컬 "
+"저장소에 저장됩니다."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26071,8 +25551,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 "
-"브라우저에서는 최근 채팅 100개가 로컬 저장소에 저장됩니다."
+"백업이 DuckDuckGo 서버에서 삭제됩니다. 모든 기기의 동기화가 해제됩니다. 다음 브라우저에서는 최근 채팅 100개가 로컬 저장소에 "
+"저장됩니다."
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26096,18 +25576,14 @@ msgctxt "new tab page"
 msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
-msgstr ""
-"가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo"
-"는 절대 이 데이터에 접근할 수 없습니다."
+msgstr "가장 많이 방문한 사이트 목록은 사용자의 브라우저에서 제공됩니다. DuckDuckGo는 절대 이 데이터에 접근할 수 없습니다."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터"
-"에 절대 액세스할 수 없습니다."
+msgstr "브라우저는 가장 많이 방문한 사이트 목록을 제공합니다. DuckDuckGo는 이 데이터에 절대 액세스할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26115,9 +25591,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표"
-"시할 수 있습니다."
+msgstr "%1$s 서비스와의 채팅은 비공개입니다. AI 채팅은 부정확하거나 불쾌한 정보를 표시할 수 있습니다."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26142,36 +25616,28 @@ msgstr "사용자의 채팅은 비공개로 처리되며 AI 모델 훈련에 사
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않"
-"습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
 msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
 msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
-msgstr ""
-"내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하"
-"지 않습니다."
+msgstr "내 채팅은 비공개이며 당사는 이 내용을 저장하지 않고, AI 모델 훈련에도 사용하지 않습니다."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26186,8 +25652,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련"
-"에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 다음과 같습니다."
+"내 채팅은 여전히 비공개입니다. Duck.ai는 이 내용을 익명화하고, AI 모델 훈련에 사용하지 않습니다. 채팅 기록을 보관하는 방법은 "
+"다음과 같습니다."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26226,9 +25692,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. "
-"[%2$s메시지 예시%3$s]"
+msgstr "사용자의 이메일은 공유되지 않으며 %1$s비공개 검색에도 사용되지 않습니다. [%2$s메시지 예시%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26271,10 +25735,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 "
-"키를 생성합니다. 키와 연관된 설정 파일만 브라우저 외부로 전송됩니다. "
-"DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 "
-"암호를 절대 알 수 없습니다."
+"사용자의 암호는 %1$sSHA-2%2$s라고 알려진 보안 해시 알고리즘을 사용해 512비트 키를 생성합니다. 키와 연관된 설정 파일만 "
+"브라우저 외부로 전송됩니다. DuckDuckGo는 해당 키를 파일 이름으로 사용하여 설정 파일을 저장하며, 사용자의 암호를 절대 알 수 "
+"없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26289,9 +25752,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데"
-"이터는 제거됩니다. 따라서 모델 제공사는 대화를 특정 사용자에 연결할 수 없습니"
-"다."
+"DuckDuckGo 서버를 통해 프롬프트가 전달되며 개인 정보를 식별할 수 있는 메타데이터는 제거됩니다. 따라서 모델 제공사는 대화를 "
+"특정 사용자에 연결할 수 없습니다."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26336,8 +25798,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 사용 설정하세요."
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"사용 설정하세요."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26346,8 +25808,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 "
-"%1$sDuckDuckGo No AI%2$s 확장 프로그램을 설치하세요. %3$s자세히 알아보기%4$s"
+"설정이 저장되지만 쿠키를 삭제하면 초기화됩니다. 설정을 영구적으로 적용하려면 %1$sDuckDuckGo No AI%2$s 확장 프로그램을 "
+"설치하세요. %3$s자세히 알아보기%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26375,9 +25837,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 "
-"DuckDuckGo 브라우저를 이용해서 더 철저하게 보호받으세요. 이미 설치되어 있으"
-"며 다음 기능이 제공됩니다."
+"이제 Chrome에서 개인 정보 노출 없이 검색할 수 있습니다. Chrome 대신 DuckDuckGo 브라우저를 이용해서 더 철저하게 "
+"보호받으세요. 이미 설치되어 있으며 다음 기능이 제공됩니다."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26393,9 +25854,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌"
-"러 이 대화를 지우세요."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속 진행하려면 Fire Button을 눌러 이 대화를 지우세요."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26403,8 +25862,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
+msgstr "이 대화에서 채팅 길이 한도에 도달했습니다. 계속하려면 새 채팅을 시작해."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26418,9 +25876,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세"
-"요."
+msgstr "하루에 보낼 수 있는 메시지 개수 한도에 도달했습니다. 이 채팅은 내일 계속하세요."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26728,9 +26184,7 @@ msgstr "공식 웹사이트"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s "
-"문자입니다)"
+msgstr "또는 원하는 색상 코드를 직접 입력하세요. 예: %1$s (%2$s(은)는 인코딩된 %3$s 문자입니다)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ku/LC_MESSAGES/duckduckgo.po
+++ b/locales/ku/LC_MESSAGES/duckduckgo.po
@@ -2385,6 +2385,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5257,6 +5268,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Paşguh bike"
@@ -5346,6 +5362,11 @@ msgid "Division Record"
 msgstr "Encama Şaxê"
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6820,6 +6841,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7075,6 +7101,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7824,6 +7855,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8759,6 +8795,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12725,6 +12766,11 @@ msgstr "Polendî"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17807,6 +17853,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18168,6 +18219,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Kêmtir kilîtpêvan bicerbîne."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/kw_GB/LC_MESSAGES/duckduckgo.po
+++ b/locales/kw_GB/LC_MESSAGES/duckduckgo.po
@@ -2371,6 +2371,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5212,6 +5223,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5301,6 +5317,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6758,6 +6779,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7011,6 +7037,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7758,6 +7789,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8678,6 +8714,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12612,6 +12653,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17653,6 +17699,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18011,6 +18062,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ky_KG/LC_MESSAGES/duckduckgo.po
+++ b/locales/ky_KG/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ln_CD/LC_MESSAGES/duckduckgo.po
+++ b/locales/ln_CD/LC_MESSAGES/duckduckgo.po
@@ -2371,6 +2371,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5212,6 +5223,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5301,6 +5317,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6758,6 +6779,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7011,6 +7037,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7758,6 +7789,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8676,6 +8712,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12610,6 +12651,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17651,6 +17697,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18009,6 +18060,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -386,7 +387,8 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
+msgstr ""
+"%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -522,7 +524,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr ""
+"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -958,14 +961,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr ""
+"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr ""
+"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1723,7 +1728,8 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr ""
+"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1978,7 +1984,8 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr ""
+"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2030,7 +2037,8 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr ""
+"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2697,7 +2705,8 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr ""
+"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2954,6 +2963,18 @@ msgstr ""
 "Prieš išsaugodama šią ataskaitą, „DuckDuckGo“ nuasmenins jūsų pokalbį "
 "pašalindama asmenį identifikuojančią informaciją, pvz., vardus, el. pašto "
 "adresus ir identifikuojančius metaduomenis."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3865,7 +3886,8 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr ""
+"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4196,9 +4218,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
-"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
-"teikėjas, ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
+"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
+"ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4668,7 +4690,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr ""
+"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4695,7 +4718,8 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr ""
+"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4762,7 +4786,8 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr ""
+"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5470,7 +5495,8 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr ""
+"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6361,7 +6387,8 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6510,6 +6537,12 @@ msgid "Dislike source"
 msgstr "Nepatinka šaltinis"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Atmesti"
@@ -6618,6 +6651,12 @@ msgstr "Diviziono Rezultatas"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Džibutis"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7319,8 +7358,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7330,8 +7369,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
-"„%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
+"„%3$s“ „%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7367,7 +7406,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr ""
+"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7527,8 +7567,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
-"„Duck.ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
+"ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7679,9 +7719,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
-"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
-"18–20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
+"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
+"20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -8034,13 +8074,15 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr ""
+"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr ""
+"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8188,7 +8230,8 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr ""
+"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8294,7 +8337,8 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr ""
+"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8372,7 +8416,8 @@ msgstr "Naršyti „Duck.ai“"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr ""
+"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8488,6 +8533,12 @@ msgid "Fast"
 msgstr "Greitas"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8551,7 +8602,8 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr ""
+"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8678,7 +8730,8 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr ""
+"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8802,7 +8855,8 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr ""
+"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8814,6 +8868,12 @@ msgstr "Papildomas klausimas"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Tolesnės žinutės lieka privačios."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8919,7 +8979,8 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr ""
+"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9327,7 +9388,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+msgstr ""
+"Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9392,7 +9454,8 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr ""
+"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9484,7 +9547,8 @@ msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr ""
+"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
@@ -9519,7 +9583,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr ""
+"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9556,8 +9621,8 @@ msgstr "Gauti programą"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
-"„YouTube“.%2$s"
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas „YouTube“."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9757,6 +9822,12 @@ msgstr "Geras dizainas"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Gera privatumo politika"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10754,7 +10825,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr ""
+"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10899,6 +10971,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Vaizdų užklausoms taikomos „Duck.ai“ %1$s."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Vaizdo plytelės"
@@ -10987,7 +11065,8 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr ""
+"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11419,7 +11498,8 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr ""
+"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11943,7 +12023,8 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
+msgstr ""
+"Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12055,7 +12136,8 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr ""
+"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12166,7 +12248,8 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr ""
+"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -14303,7 +14386,8 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr ""
+"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14497,7 +14581,8 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr ""
+"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14674,7 +14759,8 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr ""
+"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15501,7 +15587,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr ""
+"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15689,7 +15776,8 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr ""
+"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -15755,6 +15843,12 @@ msgstr "Lenkų"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Prastas formatavimas"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16271,7 +16365,8 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr ""
+"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -17876,7 +17971,8 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr ""
+"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18275,8 +18371,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
-"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
+"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18443,24 +18539,27 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
-"%3$shttps://duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
+"duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18474,7 +18573,8 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr ""
+"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18486,7 +18586,8 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr ""
+"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18497,7 +18598,8 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr ""
+"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18571,7 +18673,8 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr ""
+"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18593,7 +18696,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr ""
+"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18665,7 +18769,8 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr ""
+"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19224,7 +19329,8 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr ""
+"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19407,7 +19513,8 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
+msgstr ""
+"Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19483,7 +19590,8 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr ""
+"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19550,7 +19658,8 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr ""
+"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19892,7 +20001,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr ""
+"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20161,13 +20271,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr ""
+"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20205,12 +20317,14 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr ""
+"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr ""
+"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20383,7 +20497,8 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr ""
+"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22103,6 +22218,12 @@ msgid "Too slow"
 msgstr "Per lėtas"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22388,7 +22509,8 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr ""
+"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22547,6 +22669,12 @@ msgid "Try fewer keywords."
 msgstr "Bandyk įvesti mažiau raktažodžių."
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22590,7 +22718,8 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr ""
+"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22629,7 +22758,8 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr ""
+"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22900,7 +23030,8 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr ""
+"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22918,7 +23049,8 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr ""
+"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23123,7 +23255,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr ""
+"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23133,13 +23266,15 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr ""
+"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr ""
+"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23296,7 +23431,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr ""
+"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -24015,7 +24151,8 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr ""
+"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24247,7 +24384,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr ""
+"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24349,7 +24487,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr ""
+"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24666,9 +24805,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
-"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
-"nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
+"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
+"niekada nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24682,7 +24821,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr ""
+"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24773,7 +24913,8 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr ""
+"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25040,7 +25181,8 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr ""
+"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25125,7 +25267,8 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr ""
+"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25640,7 +25783,8 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr ""
+"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -26047,7 +26191,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr ""
+"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26133,7 +26278,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
+msgstr ""
+"Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26264,14 +26410,16 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr ""
+"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26633,7 +26781,8 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr ""
+"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lt_LT/LC_MESSAGES/duckduckgo.po
+++ b/locales/lt_LT/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -387,8 +386,7 @@ msgstr "%1$s išnaudota"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
+msgstr "%1$s išnaudoja limitus iki 2–5 kartų greičiau nei baziniai modeliai %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -524,8 +522,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
+msgstr "%1$sSužinok daugiau%2$s, kaip pokalbiai saugomi privačiai tavo įrenginyje."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -961,16 +958,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
+msgstr "Pasirodė nauja „AI Chat“ versija! Jei nori tęsti, atnaujink šį puslapį."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
+msgstr "Pasirodė nauja „Duck.ai“ versija! Jei norite tęsti, atnaujinkite šį puslapį."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1728,8 +1723,7 @@ msgstr "Kai atsisiųsi ir atidarysi, spustelėk %1$sĮdiegti%2$s"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
+msgstr "Kai atsisiųsi, surask plėtinio failą ir du kartus jį spustelėk, kad įdiegtum"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1984,8 +1978,7 @@ msgstr "Leisti anonimiškai peržiūrėti šio pokalbio failus?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
+msgstr "Leisti privatumo paisančius skelbimus „DuckDuckGo Private Search“ paieškoje"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2037,8 +2030,7 @@ msgstr "Jau sinchronizuota."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
+msgstr "Taip pat ieškok privačiai savo „iPad“, „iPhone“ arba „Android“ įrenginyje!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2705,8 +2697,7 @@ msgstr "Automatinis atsakymas"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
+msgstr "Automatiškai generuojama pagal išvardytus šaltinius. Gali būti netikslumų."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2975,6 +2966,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Prieš išsaugant šį pranešimą, „DuckDuckGo“ pašalins įkeltus failus ir "
+"sugeneruotus vaizdus, taip pat anonimizuos tavo pokalbį pašalindama asmens "
+"duomenis, tokius kaip vardai, el. pašto adresai ir identifikuojantys "
+"metaduomenys."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3886,8 +3881,7 @@ msgstr "Pakeičia fono spalvą visoje svetainėje"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
+msgstr "Pakeičia žymeklio, modulių ir išskleidžiamųjų meniu rezultatų fono spalvą"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4218,9 +4212,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į Duck."
-"ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų teikėjas, "
-"ieškantis tokio turinio: %2$s."
+"Pokalbiai su %1$s paslaugų teikėjui visiškai nematomi, tačiau visus į "
+"Duck.ai įkeltus failus anonimiškai peržiūri turinio moderavimo paslaugų "
+"teikėjas, ieškantis tokio turinio: %2$s."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4690,8 +4684,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
+msgstr "Dešiniojoje šoninėje juostoje spustelėk %1$sPrivatumas ir Paslaugos%2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4718,8 +4711,7 @@ msgstr "Išskleidžiamajame meniu spustelėk %1$sNustatymai%2$s."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
+msgstr "Spustelėk %1$sNaudoti dabartinius puslapius%2$s, tada %3$s– „Gerai%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4786,8 +4778,7 @@ msgstr "Paieškos juostoje spustelėk %1$sdidinamąjį stiklą%2$s"
 # smartling.placeholder_format=C
 #. Tells users what icon to click in their browser to change their default search engine.
 msgid "Click on the magnifying glass in the search box at the top right"
-msgstr ""
-"Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
+msgstr "Viršuje dešinėje esančiame paieškos langelyje spustelėk didinamąjį stiklą"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -5495,8 +5486,7 @@ msgstr "Kopijuoti"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
+msgstr "Nukopijuok ir įklijuok %1$sabout:preferences#search%2$s į adreso juostą"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -6387,8 +6377,7 @@ msgstr "Diktavimas „Duck.ai“"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Diktavimą mes anonimizuojame ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6540,7 +6529,7 @@ msgstr "Nepatinka šaltinis"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nepatinka vizualinis stilius"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6656,7 +6645,7 @@ msgstr "Džibutis"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nesilaiko nurodymų"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7358,8 +7347,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7369,8 +7358,8 @@ msgid ""
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
 "„DuckDuckGo AI Chat“ yra privati dirbtiniu intelektu pagrįsta pokalbių "
-"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir "
-"„%3$s“ „%4$s“."
+"paslauga, kuri šiuo metu palaiko pokalbių modelius „%1$s“ „%2$s“ ir „%3$s“ "
+"„%4$s“."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7406,8 +7395,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
+msgstr "„DuckDuckGo DI Chat“ laikinai nepasiekiamas. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7567,8 +7555,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su „Duck."
-"ai“ %2$s."
+"„DuckDuckGo“ anonimina tavo pokalbius. Jei spusteli „%1$s“, sutinki su "
+"„Duck.ai“ %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7719,9 +7707,9 @@ msgid ""
 "characters long."
 msgstr ""
 "Kiekvieną kartą, kai paprašai pasiūlyti slaptafrazę, naudojame didelį "
-"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame 4–"
-"5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent 18–"
-"20 simbolių ilgio."
+"atsitiktinių žodžių sąrašą iš „DuckDuckGo“ serverių. Naršyklėje parenkame "
+"4–5 atsitiktinius žodžius iš sąrašo užtikrindami, kad slaptafrazė būtų bent "
+"18–20 simbolių ilgio."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -8074,15 +8062,13 @@ msgstr "Ar tau patinka „Duck.ai“?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
+msgstr "Įsitikink, kad pasirinkta nustatymo „Vieta“ parinktis %1$s„Leisti“%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
+msgstr "Įsitikink, kad parinktis „Buvimo vietos nustatymo paslaugos“ %1$sįjungta%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8230,8 +8216,7 @@ msgstr "Pusiaujo Gvinėja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
+msgstr "Naršymo duomenis ištrinkite akimirksniu naudodami mūsų %1$s„Fire Button“%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8337,8 +8322,7 @@ msgstr "Paprastais žodžiais paaiškink priimtą atsakymą."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
+msgstr "Paaiškink pagrindines juodųjų skylių sąvokas vidurinės mokyklos lygmeniu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8416,8 +8400,7 @@ msgstr "Naršyti „Duck.ai“"
 #. Links to a page that provides a list of DuckDuckGo product updates
 msgctxt "SERP footer content"
 msgid "Explore DuckDuckGo's latest product and feature updates."
-msgstr ""
-"Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
+msgstr "Susipažinkite su naujausiais „DuckDuckGo“ produktų ir funkcijų atnaujinimais."
 
 # smartling.placeholder_format=C
 #. Links to a page that provides a list of DuckDuckGo product updates
@@ -8536,7 +8519,7 @@ msgstr "Greitas"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Greitas vaizdų generavimas"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8602,8 +8585,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
+msgstr "Keisk savo nustatymus žemiau. Tada, tiesiog nukopijuok kodą į savo svetainę."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8730,8 +8712,7 @@ msgstr "Finansų konsultantas"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
+msgstr "Surask %1$sDuckDuckGo%2$s ir spustelėk%3$sNustatyti kaip numatytąjį%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8855,8 +8836,7 @@ msgstr ""
 #. Privacy reassurance and instructions intro.
 msgctxt "duckai_migration"
 msgid "Follow these steps to move your chats to the new Duck.ai"
-msgstr ""
-"Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
+msgstr "Atlik šiuos veiksmus, kad perkeltum pokalbius į naująją „Duck.ai“ versiją"
 
 # smartling.placeholder_format=C
 #. A placeholder for the AI Chat prompt input when used in the context of asking follow-up questions based on a DuckAssist reponse on mobile
@@ -8873,7 +8853,7 @@ msgstr "Tolesnės žinutės lieka privačios."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Laikėsi nurodymų"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8979,8 +8959,7 @@ msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
+msgstr "Nemokami ir privatūs pokalbiai, kuriuos anonimizuojame. Paskyros nereikia."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9388,8 +9367,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
+msgstr "Gauk „DuckDuckGo VPN“, pažangųjį „Duck.ai“ ir „Identity Theft Restoration“."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9454,8 +9432,7 @@ msgstr "Pradėti"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
+msgstr "Gaukite VPN ir dar dvi apsaugos priemones iš vienos paprastos prenumeratos."
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9547,8 +9524,7 @@ msgstr "Gauk didesnius naudojimo limitus su „DuckDuckGo“ prenumerata."
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
 msgctxt "Browser Promo Popover"
 msgid "Get our browser to never lose your settings."
-msgstr ""
-"Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
+msgstr "Atsisiųsk ir naudok mūsų naršyklę, kad niekada neprarastum savo nustatymų."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; shown in every market. 'No-log' means the VPN keeps no activity logs; 'advanced AI models' with 'higher chat limits' refer to Duck.ai; the VPN and other premium protections are bundled subscription features.
@@ -9583,8 +9559,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
-msgstr ""
-"Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
+msgstr "Vienu atsisiuntimu nemokamai gauk sklandžią privatumo apsaugą naršyklėje:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9621,8 +9596,8 @@ msgstr "Gauti programą"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas „YouTube“."
-"%2$s"
+"Gauk nemokamą „DuckDuckGo“ naršyklę, %1$skad blokuotum reklamas "
+"„YouTube“.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9827,7 +9802,7 @@ msgstr "Gera privatumo politika"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Geras vizualinis stilius"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10825,8 +10800,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
+msgstr "Man reikia daugiau pagalbos / informacijos apie tai, kaip naudotis pokalbiu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10974,7 +10948,7 @@ msgstr "Vaizdų užklausoms taikomos „Duck.ai“ %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Vaizdo kokybė"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11065,8 +11039,7 @@ msgstr "Pagerink argumentus"
 msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
-msgstr ""
-"Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
+msgstr "Pagerina rezultato skaitomumą atnaujintu URL formatu, išdėstymu ir spalva"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11498,8 +11471,7 @@ msgstr "Ji greita, nemokama ir užtikrina dar daugiau apsaugos internete."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
+msgstr "Leidžiu (labai retai) manęs klausti apie naudojimosi „DuckDuckGo“ patirtį"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12023,8 +11995,7 @@ msgstr "Leidžia ieškoti anonimiškai su „DuckDuckGo“"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
+msgstr "Leidžia perjungti tarp paieškos užklausų ir DI užklausų pateikimo „Duck.ai“"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12136,8 +12107,7 @@ msgstr "Nuorodos:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
+msgstr "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12248,8 +12218,7 @@ msgstr "Įkeliama daugiau vaizdų slenkant"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
+msgstr "Slenkant įkeliama daugiau Vaizdų, Vaizdo Įrašų ir Apsipirkimo rezultatų"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -14386,8 +14355,7 @@ msgstr "Omanas"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
+msgstr "Praleidžiami nepageidaujami (daugiausia tik suaugusiesiems skirti) rezultatai"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14581,8 +14549,7 @@ msgstr "Atidaryti %1$s svetainę"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
+msgstr "Atidarykite %1$sVieta%2$s ir įsitikinkite, kad vieta yra %3$sįjungta%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14759,8 +14726,7 @@ msgstr "Atidaryti skydelį „Kaip veikia Duck.ai“"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
+msgstr "Atidarykite „Safari“ meniu ir pasirinkite %1$s„DuckDuckGo“ nustatymai...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15587,8 +15553,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
+msgstr "Aprašyk, kodėl šis pokalbio atsakymas neteisėtas ar žalingas. (Neprivaloma)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15776,8 +15741,7 @@ msgstr "Luktelk..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
+msgstr "„Plus“ – daugiau aukščiausios kokybės funkcijų su „DuckDuckGo“ prenumerata."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
@@ -15848,7 +15812,7 @@ msgstr "Prastas formatavimas"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Prasta vaizdo kokybė"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16365,8 +16329,7 @@ msgstr "Paraginti mane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
+msgstr "Paraginti mane naudoti apytikslę vietą, kad gaučiau tikslesnių rezultatų."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -17971,8 +17934,7 @@ msgstr "Slink žemyn ir sąraše rask %1$ssavo naršyklę%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
+msgstr "Slinkite žemyn iki %1$sDuckDuckGo%2$s ir leiskite jai naudoti jūsų vietovę."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18371,8 +18333,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. <em>end-to-"
-"end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
+"Saugok savo susirašinėjimus mūsų serveryje su ištisiniu (angl. "
+"<em>end-to-end</em>) šifravimu ir pasiek juos bet kuriame įrenginyje."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18539,27 +18501,24 @@ msgstr "„Safari“ meniu pasirink %1$s„Šios svetainės nustatymas...“%2$s
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk %3$shttps://"
-"duckduckgo.com%4$s"
+"Pasirink %1$sPasirinktinis%2$s ir įvesties laukelyje įvesk "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sPridėti kaip numatytąją%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s ir spustelėk %3$sNustatyti kaip numatytąją%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18573,8 +18532,7 @@ msgstr ""
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
+msgstr "Sąraše pasirinkite %1$sDuckDuckGo%2$s ir %3$sleiskite%4$s pasiekti vietą"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18586,8 +18544,7 @@ msgstr "Paieškos teikėjų sąraše pasirink %1$s„DuckDuckGo“%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
+msgstr "Pasirink %1$s„DuckDuckGo“%2$s skiltyje%3$sNumatytoji Paieškos Sistema%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18598,8 +18555,7 @@ msgstr "Pasirink %1$s„DuckDuckGo“%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
+msgstr "Išskleidžiamajame meniu pasirink %1$sRedaguoti Paieškos Sistemas...%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18673,8 +18629,7 @@ msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sIšplėstiniai nustatymai%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
+msgstr "Pasirink %1$sNustatymai%2$s, tuomet %3$sNumatytoji paieškos sistema%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18696,8 +18651,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
+msgstr "Sąraše pasirinkite %1$ssavo naršyklę%2$s ir %3$sleiskite%4$s vietos prieigą"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18769,8 +18723,7 @@ msgstr "Pažymėtas tekstas iš %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
+msgstr "Pasirinktas tekstas per ilgas. Bandykite dar kartą su trumpesniu pasirinkimu."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19329,8 +19282,7 @@ msgstr "Rodyti „DuckAssist“ <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
+msgstr "Rodykite „DuckAssist“ dažniau. (Taip pat galite visiškai %1$sišjungti%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19513,8 +19465,7 @@ msgstr "Rodyk šoninę juostą"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
+msgstr "Rodyti nuoseklius patarimus, kaip geriausiai išnaudoti „ Duck.ai“ galimybes."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19590,8 +19541,7 @@ msgstr "Rodomos horizontalios linijos ties rezultatų puslapio lūžiais"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
+msgstr "Rodo nuorodas į instrukcijas, kaip pridėti „DuckDuckGo“ prie savo naršyklės"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19658,8 +19608,7 @@ msgstr "Rodomas sveikinamasis pranešimas paieškos rezultatų viršuje"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
+msgstr "Rodomas sveikinamasis pranešimas ES „Android“ nuostatų meniu naudotojams"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -20001,8 +19950,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
+msgstr "Atsiprašome, negalėjome pateikti tavo atsiliepimo. Bandyk dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20271,15 +20219,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
+msgstr "Apsisaugok ir gauk informacijos užsisakęs mūsų privatumo naujienlaiškius."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20317,14 +20263,12 @@ msgstr "Sustabdyti generavimą"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
+msgstr "Užkirsk kelią paslėptoms stebėjimo priemonėms, slypinčioms kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
+msgstr "Sustabdyk daugumą paslėptų stebėjimo priemonių, slypinčių kitose svetainėse."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20497,8 +20441,7 @@ msgstr "Pasiūlyk tinklaraščio įrašo pavadinimą"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
+msgstr "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22221,7 +22164,7 @@ msgstr "Per lėtas"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Per lėtai generuoja"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22509,8 +22452,7 @@ msgstr "Pabandyk %1$s, kad daugiau nematytum tokių pranešimų."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
+msgstr "Išbandyk %1$s – mūsų pirmąjį modelį be jokio matomumo paslaugų teikėjui."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22672,7 +22614,7 @@ msgstr "Bandyk įvesti mažiau raktažodžių."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Išbandyk nemokamai"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22718,8 +22660,7 @@ msgstr "Išbandyti nemokamai"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
+msgstr "Išbandyk nemokamai! Saugus VPN, pažangus ir privatus DI, ir dar daugiau."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22758,8 +22699,7 @@ msgstr "Išbandyk mūsų naršyklę,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
+msgstr "Išbandyk mūsų pradžios puslapį, kuriame niekada nerodomi šie pranešimai:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23030,8 +22970,7 @@ msgstr "Norėdami gauti tikslesnius rezultatus, įjunkite %1$sTiksli vieta%2$s"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
+msgstr "Įjunkite „Duck Player“, kad galėtumėte žiūrėti „YouTube“ be tikslinių reklamų"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23049,8 +22988,7 @@ msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Tiksli vietovė
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
+msgstr "Kad rezultatai būtų tikslesni, įjunkite nustatymą „Naudoti tikslią vietovę“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23255,8 +23193,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
+msgstr "Laukelyje %1$sPALEISTIS > Pradžios puslapis%2$s įvesk: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23266,15 +23203,13 @@ msgstr "Laukelyje %1$sPaieškos nustatymai%2$s pasirink %3$s„DuckDuckGo“%4$s
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
+msgstr "Laukelyje %1$sIeškoti adreso juostoje su%2$s pasirink %3$sPridėti naują%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
+msgstr "Skiltyje %1$sIeškoti%2$s spustelėk %3$sValdyti paieškos sistemas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23431,8 +23366,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
+msgstr "Gauk prieigą prie galingesnių DI modelių su „DuckDuckGo“ prenumerata. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -24151,8 +24085,7 @@ msgstr "Balso pokalbis baigtas"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
+msgstr "Balso pokalbius nuasmeniname ir niekada nenaudojame DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24384,8 +24317,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
+msgstr "Negalime perskaityti pridėtų failų, nes bent vienas iš jų yra užšifruotas."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24487,8 +24419,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
+msgstr "Nestebime tavęs, kai naudojiesi arba nesinaudoji privačiu naršymo režimu."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24805,9 +24736,9 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia "
-"„%1$s“ „%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų "
-"niekada nesaugo ir nenaudoja DI modeliams mokyti."
+"Sveiki, čia – „DuckDuckGo AI Chat“! Šią pokalbių sesiją teikia „%1$s“ "
+"„%2$s“. Visi jūsų pokalbiai čia yra privatūs ir „DuckDuckGo“ jų niekada "
+"nesaugo ir nenaudoja DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24821,8 +24752,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
+msgstr "Sveikiname išbandžius naująją „Duck.ai“ versiją, laikas importuoti pokalbius"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -24913,8 +24843,7 @@ msgstr "Į kokius veiksnius reikia atsižvelgti perkant kompiuterio monitorių?"
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
+msgstr "Kokias lankytinas vietas Paryžiuje būtina pamatyti lankantis pirmą kartą?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25181,8 +25110,7 @@ msgstr "Kokia informacija yra išsaugoma?"
 #. Prompt sent to the AI when the user taps the "Help me prep for the interview" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What interview questions might come up for this role?"
-msgstr ""
-"Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
+msgstr "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -25267,8 +25195,7 @@ msgstr "Apie ką norėtum pateikti atsiliepimą?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
+msgstr "Tai, ką žiūrite „DuckDuckGo“, neturės įtakos jūsų rekomendacijoms „YouTube“."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25783,8 +25710,7 @@ msgstr "Taip, naujas naudotojas!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
+msgstr "Taip, mes pašaliname duomenis, kai baigi naudotis, ir jų nebegalima atkurti."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -26191,8 +26117,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
+msgstr "Šiuo metu pasiekėte maksimalų pranešimų skaičių. Bandykite dar kartą vėliau."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26278,8 +26203,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
+msgstr "Tavo „Duck.ai“ pokalbiai sinchronizuojami naudojant ištisinį šifravimą."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26410,16 +26334,14 @@ msgstr ""
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
+msgstr "Jūsų pokalbiai yra privatūs, anonimizuoti ir nenaudojami DI modeliams mokyti."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26781,8 +26703,7 @@ msgstr "sukurta %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
+msgstr "kūrėjas „DuckDuckGo“ – interneto apsauga, kuria kasdien pasitiki milijonai."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -386,7 +386,8 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
+msgstr ""
+"%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -962,14 +963,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr ""
+"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr ""
+"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1674,8 +1677,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt "
-"2–5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
+"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt 2–"
+"5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1850,7 +1853,8 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr ""
+"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2324,7 +2328,8 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2336,7 +2341,8 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr ""
+"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2965,6 +2971,18 @@ msgstr ""
 "tādus personas datus kā vārdus, e-pasta adreses un identificējošus metadatus."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3539,7 +3557,8 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr ""
+"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3873,7 +3892,8 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr ""
+"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4006,8 +4026,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
-"%1$shttps://duck.ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4643,7 +4663,8 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4744,7 +4765,8 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr ""
+"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4764,7 +4786,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr ""
+"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4893,7 +4916,8 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr ""
+"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5353,7 +5377,8 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
+msgstr ""
+"Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5595,7 +5620,8 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr ""
+"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6479,7 +6505,8 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr ""
+"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6527,6 +6554,12 @@ msgstr "Nepatīk dizains"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Nepatīk avots"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6639,6 +6672,12 @@ msgid "Djibouti"
 msgstr "Džibutija"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6686,7 +6725,8 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr ""
+"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7110,7 +7150,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr ""
+"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7125,8 +7166,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
-"%1$sduck.ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
+"ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7196,7 +7237,8 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr ""
+"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7773,7 +7815,8 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr ""
+"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8109,13 +8152,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr ""
+"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8209,7 +8254,8 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr ""
+"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8315,7 +8361,8 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr ""
+"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8509,6 +8556,12 @@ msgid "Fast"
 msgstr "Ātri"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8552,7 +8605,8 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr ""
+"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8698,7 +8752,8 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr ""
+"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8834,6 +8889,12 @@ msgstr "Papildjautājums"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Papildjautājumi paliek privāti."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9055,9 +9116,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
-"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
-"(&quot;Instalēt atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
+"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
+"atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9350,7 +9411,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+msgstr ""
+"Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9579,7 +9641,8 @@ msgstr "Iegūt lietotni"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
+msgstr ""
+"Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9691,7 +9754,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr ""
+"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9779,6 +9843,12 @@ msgstr "Labs dizains"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Laba privātuma politika"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10364,8 +10434,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
-"cilnē/vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
+"vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10619,7 +10689,8 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr ""
+"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10776,7 +10847,8 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr ""
+"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10863,7 +10935,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr ""
+"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10881,7 +10954,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr ""
+"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10919,6 +10993,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Attēlu uzvednēm ir jāatbilst Duck.ai %1$s prasībām."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11439,7 +11519,8 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr ""
+"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -12980,7 +13061,8 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr ""
+"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13889,7 +13971,8 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr ""
+"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14552,7 +14635,8 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr ""
+"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -15512,7 +15596,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15520,7 +15605,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr ""
+"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15731,7 +15817,8 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr ""
+"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15788,6 +15875,12 @@ msgstr "Poļu"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Slikta formatēšana"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16324,7 +16417,8 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr ""
+"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16964,7 +17058,8 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr ""
+"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17914,7 +18009,8 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr ""
+"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18446,7 +18542,8 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr ""
+"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18480,18 +18577,20 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
-"%3$shttps://duckduckgo.com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr ""
+"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18503,7 +18602,8 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr ""
+"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18523,7 +18623,8 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18556,7 +18657,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr ""
+"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -19521,7 +19623,8 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr ""
+"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19542,7 +19645,8 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr ""
+"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19818,13 +19922,15 @@ msgstr "Ielādējot šo kopīgoto tērzēšanu, radās kļūda."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr ""
+"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19911,8 +20017,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
-"Duck.ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19928,7 +20034,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr ""
+"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20189,19 +20296,22 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr ""
+"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20403,7 +20513,8 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr ""
+"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -21045,7 +21156,8 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr ""
+"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -22061,7 +22173,8 @@ msgstr "Šodien"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Pārslēdzies uz privātu MI tērzēšanu vai %1$sizslēdz to iestatījumos%2$s."
+msgstr ""
+"Pārslēdzies uz privātu MI tērzēšanu vai %1$sizslēdz to iestatījumos%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22117,7 +22230,8 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr ""
+"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22130,6 +22244,12 @@ msgstr "Pārāk daudz rezultātu no šī avota"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Pārāk lēni"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22558,7 +22678,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22572,6 +22693,12 @@ msgstr "Pamēģini eksperimentēt ar katru modeli – tie sniegs dažādas atbil
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Pamēģini mazāk atslēgas vārdu."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22949,7 +23076,8 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr ""
+"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23100,7 +23228,8 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr ""
+"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23141,8 +23270,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
-"https://duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23168,13 +23297,15 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr ""
+"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr ""
+"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23282,7 +23413,8 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr ""
+"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23725,7 +23857,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr ""
+"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -23984,8 +24117,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
-"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
+"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -24273,7 +24406,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr ""
+"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24289,7 +24423,8 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr ""
+"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24422,7 +24557,8 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr ""
+"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24464,7 +24600,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr ""
+"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24699,7 +24836,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr ""
+"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25150,7 +25288,8 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr ""
+"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25240,7 +25379,8 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr ""
+"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25662,7 +25802,8 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr ""
+"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25759,7 +25900,8 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr ""
+"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25798,7 +25940,8 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr ""
+"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25979,7 +26122,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr ""
+"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26088,7 +26232,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr ""
+"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26147,14 +26292,16 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
+msgstr ""
+"Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
+msgstr ""
+"Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26276,7 +26423,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr ""
+"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26576,7 +26724,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr ""
+"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26880,7 +27029,8 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr ""
+"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/lv_LV/LC_MESSAGES/duckduckgo.po
+++ b/locales/lv_LV/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: lv_LV\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -386,8 +386,7 @@ msgstr "%1$s izmantots"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
+msgstr "%1$s patērē lietojuma limitu līdz pat 2–5 reizes ātrāk nekā pamatmodeļi %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -963,16 +962,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
+msgstr "Ir pieejama jauna AI Chat versija! Lūdzu, atsvaidzini šo lapu, lai turpinātu."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
+msgstr "Ir pieejama jauna Duck.ai versija! Lai turpinātu, lūdzu, atsvaidzini šo lapu."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1677,8 +1674,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt 2–"
-"5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
+"Izmantojot jaudīgākus modeļus, lietošanas ierobežojumu var sasniegt "
+"2–5 reizes ātrāk nekā ar citiem modeļiem. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1853,8 +1850,7 @@ msgstr "Visas tērzēšanas sarunas ir %1$s"
 #. Disclaimer text shown below chat input. %s is replaced with a clickable underlined 'private' link that opens the privacy protection modal.
 msgctxt "Disclaimer below chat input in Duck.ai"
 msgid "All chats are %s. AI can make mistakes."
-msgstr ""
-"Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
+msgstr "Visas tērzēšanas sarunas ir %1$s. Mākslīgais intelekts var pieļaut kļūdas."
 
 # smartling.placeholder_format=C
 #. Heading shown on the empty chat screen. The text between the two %s markers is displayed inside a clickable privacy button. First %s renders a shield icon, second %s is an invisible end marker. Keep the word 'private' between both %s markers.
@@ -2328,8 +2324,7 @@ msgstr "Vai tu joprojām esi tur?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies notīrīt visas tērzēšanas sarunas? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2341,8 +2336,7 @@ msgstr "Vai tiešām vēlies notīrīt šo sarunu un sākt jaunu?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
+msgstr "Vai tiešām vēlies izdzēst šo tērzēšanas sarunu? Šo darbību nevar atsaukt."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2981,6 +2975,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Pirms šī ziņojuma saglabāšanas DuckDuckGo noņems augšupielādētos failus un "
+"ģenerētos attēlus, kā arī anonimizēs tavu sarunu, noņemot tādus personas "
+"datus kā vārdus, e-pasta adreses un identificējošus metadatus."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3557,8 +3554,7 @@ msgstr "Kamerūna"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
+msgstr "Vai vari izveidot dažas vienkāršas receptes ar vistu, brokoļiem un rīsiem?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3892,8 +3888,7 @@ msgstr "Maina fona krāsu visā vietnē"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
+msgstr "Maina rezultātu fona krāsu zem kursora, moduļos un nolaižamajās izvēlnēs"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4026,8 +4021,8 @@ msgstr ""
 "ar trešo pušu mākslīgā intelekta tērzēšanas modeļiem, kas atbalsta OpenAI, "
 "Anthropic un citus rīkus. Izslēdzot šo iestatījumu tiks paslēptas tērzēšanas "
 "pogas un saites DuckDuckGo Search platformā. Taču tu joprojām vari piekļūt "
-"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot %1$shttps://duck."
-"ai%2$s tieši."
+"tērzēšanai, ja šis iestatījums ir izslēgts, apmeklējot "
+"%1$shttps://duck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4663,8 +4658,7 @@ msgstr "Nospied %1$sAtļaut%2$s, pēc tam %3$sPievienot%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Click %sChange Search Settings%s in the drop down"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -4765,8 +4759,7 @@ msgstr "Sānjoslā noklikšķini uz %1$sPārlūks%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sChange Search Settings%s in the dropdown menu"
-msgstr ""
-"Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
+msgstr "Nolaižamajā izvēlnē noklikšķini uz %1$sMainīt meklēšanas iestatījumus%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4786,8 +4779,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
+msgstr "Pārlūkprogrammas augšējā labajā stūrī noklikšķini uz %1$sRīku ikonas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4916,8 +4908,7 @@ msgstr "Noklikšķini uz palielināmā stikla ikonas meklēšanas lodziņā"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
+msgstr "Noklikšķini uz palielināmā stikla meklēšanas lodziņā (parlūka augšdaļā)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5377,8 +5368,7 @@ msgstr "Turpināt bloķēt reklāmas"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
+msgstr "Turpini nesenās tērzēšanas sarunas šeit. Vai arī dzēs tās ar Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5620,8 +5610,7 @@ msgstr "Kostarika"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
+msgstr "Nevarēja ielādēt tavu atkopšanas kodu. Lūdzu, aizver šo un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6505,8 +6494,7 @@ msgstr "Atspējot un atvienot"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
+msgstr "Vai atspējot tērzēšanas vēsturi un pārtraukt savienojumu ar Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6559,7 +6547,7 @@ msgstr "Nepatīk avots"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nepatīk vizuālais stils"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6675,7 +6663,7 @@ msgstr "Džibutija"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Neievēro norādījumus"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6725,8 +6713,7 @@ msgstr "Neredzi DuckDuckGo sarakstā?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
+msgstr "Neredzi to? %1$s%2$s%3$sNoklikšķini šeit, lai lejupielādētu vēlreiz%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7150,8 +7137,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
+msgstr "Duck.ai uz laiku nav pieejams. Lūdzu, atsvaidzini lapu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7166,8 +7152,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai ļauj tev privāti tērzēt ar populāriem MI modeļiem. Atspējošana "
-"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt %1$sduck."
-"ai%2$s tieši."
+"paslēpj Duck.ai pogas un saites, taču tu joprojām vari apmeklēt "
+"%1$sduck.ai%2$s tieši."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7237,8 +7223,7 @@ msgstr "Duck.ai atjaunināts!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
+msgstr "Duck.ai vislabāk darbojas mūsu privātajā un bezmaksas DuckDuckGo lietotnē!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7815,8 +7800,7 @@ msgstr "Rediģē attēlu..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
+msgstr "Rediģējot savu ziņu, tiks dzēsta zemāk esošā atbilde un izveidota jauna."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8152,15 +8136,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
+msgstr "Pārliecinies, vai pārlūkprogrammai ir atļauta piekļuve atrašanās vietai."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8254,8 +8236,7 @@ msgstr "Ekvatoriālā Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
+msgstr "Ātri izdzēs savus pārlūkošanas datus, izmantojot mūsu %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8361,8 +8342,7 @@ msgstr "Izskaidro pieņemto atbildi vienkāršā valodā."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
+msgstr "Paskaidro man pamatjēdzienus par melnajiem caurumiem vidusskolas līmenī."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8559,7 +8539,7 @@ msgstr "Ātri"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Ātra attēlu ģenerēšana"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8605,8 +8585,7 @@ msgstr "Atsauksme sekmīgi iesniegta"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
+msgstr "Tavas atsauksmes tieši ietekmē mūsu produktu atjauninājumus un uzlabojumus."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8752,8 +8731,7 @@ msgstr "Finanšu konsultants"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
+msgstr "Atrodi %1$sDuckDuckGo%2$s un noklikšķini uz%3$sPadarīt par noklusējumu%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8894,7 +8872,7 @@ msgstr "Papildjautājumi paliek privāti."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Izpildīja norādījumus"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9116,9 +9094,9 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac datorā lietotnes izvēlnes joslā izvēlies <strong>DuckDuckGo</strong> "
-"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt atjauninājumus..."
-"&quot;) un tad <strong>Install Update</strong> (&quot;Instalēt "
-"atjauninājumu&quot;)."
+"&gt; <strong>Check for Updates...</strong> (&quot;Meklēt "
+"atjauninājumus...&quot;) un tad <strong>Install Update</strong> "
+"(&quot;Instalēt atjauninājumu&quot;)."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9411,8 +9389,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
+msgstr "Iegūsti DuckDuckGo VPN, padziļināto Duck.ai un Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9641,8 +9618,7 @@ msgstr "Iegūt lietotni"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
+msgstr "Iegūsti bezmaksas pārlūku DuckDuckGo, %1$slai bloķētu reklāmas YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9754,8 +9730,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
+msgstr "Atver sadaļas %1$sPrivātums un drošība > Atrašanās vietas pakalpojumi%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9848,7 +9823,7 @@ msgstr "Laba privātuma politika"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Labs vizuālais stils"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10434,8 +10409,8 @@ msgstr "Slēp savu e-pasta adresi"
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
 msgstr ""
-"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas cilnē/"
-"vēsturē"
+"Nodrošina, ka meklētais vienums netiek parādīts pārlūkprogrammas "
+"cilnē/vēsturē"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10689,8 +10664,7 @@ msgstr "Cik daudz tu vēlies, lai parādītos MI atbalstītas atbildes?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
+msgstr "Cik daudz no saviem dienas un nedēļas limitiem tu esi līdz šim izmantojis."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10847,8 +10821,7 @@ msgstr ""
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
+msgstr "Man ir nepieciešama papildu palīdzība/informācija par tērzēšanas izmantošanu"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10935,8 +10908,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
+msgstr "Ja tu tiešām vēlies mūs atbalstīt, %1$spalīdzi popularizēt DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10954,8 +10926,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
+msgstr "Ja vēlies, nospied Sākuma lapu pie Jauna loga un Jaunas cilnes (atvērt ar)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10998,7 +10969,7 @@ msgstr "Attēlu uzvednēm ir jāatbilst Duck.ai %1$s prasībām."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Attēla kvalitāte"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11519,8 +11490,7 @@ msgstr "Tas varētu aizņemt dažas minūtes"
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
+msgstr "Tas ir ātrs, bezmaksas un sniedz tev vēl lielāku aizsardzību tiešsaistē."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -13061,8 +13031,7 @@ msgstr "Tu esi sasniedzis mēneša limitu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
+msgstr "Sasniegts mēneša lietošanas limits. Tu varēsi turpināt šo tērzēšanu pēc %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13971,8 +13940,7 @@ msgstr "Tikai meklēšana – bez izsekošanas un mērķētas reklāmas!"
 #. Refers to how web searches on DuckDuckGo aren't tracked.
 msgctxt "homepage onboarding"
 msgid "No tracking, no ad targeting, just searching."
-msgstr ""
-"Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
+msgstr "Tikai meklēšana, bez izsekošanas, bez reklāmas mērķauditorijas atlases."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search. The placeholder is the user's search term. For example: 'No videos found for 'bad dogs''
@@ -14635,8 +14603,7 @@ msgstr "Atver %1$sIestatījumi%2$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
-msgstr ""
-"Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
+msgstr "Atver opciju “Atrašanās vieta” un pārliecinies, ka tā ir %1$siespējota%2$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -15596,8 +15563,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
+msgstr "Lūdzu, izpildi uzdevumu, lai apstiprinātu, ka šo vaicājumu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15605,8 +15571,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
+msgstr "Lūdzu, izpildi šo uzdevumu, lai apstiprinātu, ka meklēšanu veic cilvēks."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15817,8 +15782,7 @@ msgstr "Plus vēl citas premium funkcijas ar DuckDuckGo abonementu."
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
+msgstr "Turklāt tas, ko tu skaties Duck Player, neietekmē tavus ieteikumus YouTube."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15880,7 +15844,7 @@ msgstr "Slikta formatēšana"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Slikta attēla kvalitāte"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16417,8 +16381,7 @@ msgstr "Aizsargā savus datus meklēšanas un pārlūkošanas laikā."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
+msgstr "Aizsargā savus datus, meklējot, pārlūkojot un izmantojot mākslīgo intelektu."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -17058,8 +17021,7 @@ msgstr "Atcerēties manu izvēli"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
+msgstr "Atcerēties manu izvēli (to var mainīt sadaļā %1$s%2$s%3$sIestatījumi%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -18009,8 +17971,7 @@ msgstr "Ritini uz leju un sarakstā atrodi %1$ssavu pārlūkprogrammu%2$s."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
+msgstr "Ritini uz leju līdz %1$sDuckDuckGo%2$s un ļauj izmantot savu atrašanās vietu."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18542,8 +18503,7 @@ msgstr "Apskati dažus no mūsu pēdējiem atjauninājumiem"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
+msgstr "Apskati %1$sURL parametru uzziņas lapa%2$s, lai iegūtu vairāk informācijas."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18577,20 +18537,18 @@ msgstr "Safari izvēlnē atlasi %1$s“Šīs vietnes iestatījumi...”%2$s."
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Atlasi %1$sPielāgots%2$s un ievades laukā raksti %3$shttps://duckduckgo."
-"com%4$s"
+"Atlasi %1$sPielāgots%2$s un ievades laukā raksti "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sPievienot kā noklusējumu%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
+msgstr "Atlasi %1$sDuckDuckGo%2$s un noklikšķini uz %3$sIestatīt kā noklusējumu%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18602,8 +18560,7 @@ msgstr "Atlasi %1$sDuckDuckGo%2$s un nospied %3$sIestatīt kā noklusējumu%4$s.
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
+msgstr "Noklusējuma meklētājprogrammas nolaižamajā izvēlnē atlasi %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18623,8 +18580,7 @@ msgstr "Meklēšanas pakalpojumu sniedzēju sarakstā atlasi %1$sDuckDuckGo%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
+msgstr "Sadaļā%3$sNoklusējuma meklētājprogramma%4$s izvēlies %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18657,8 +18613,7 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
+msgstr "Atver %1$sOpera > Preferences%2$s (Mac) vai %3$sOpera > Opcijas%4$s (Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -19623,8 +19578,7 @@ msgstr "Parāda horizontālas līnijas rezultātu lapu pārtraukumos"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
+msgstr "Parāda saites uz instrukcijām, kā pievienot DuckDuckGo savai pārlūkprogrammai"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19645,8 +19599,7 @@ msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu pārlūk
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
+msgstr "Ik pa laikam rāda atgādinājumus par DuckDuckGo pievienošanu tavām ierīcēm"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19922,15 +19875,13 @@ msgstr "Ielādējot šo kopīgoto tērzēšanu, radās kļūda."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, mēģinot saglabāt serverī, lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
+msgstr "Kaut kas nogāja greizi, iespējojot Sync & Backup. Lūdzu, mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20017,8 +19968,8 @@ msgstr ""
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt Duck."
-"ai."
+"Atvaino, mēs nevarējām sniegt plašāku atbildi. Tu vari mēģināt jautāt "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -20034,8 +19985,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
+msgstr "Diemžēl mums neizdevās iesniegt tavu atsauksmi. Lūdzu, mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20296,22 +20246,19 @@ msgstr "Paliec DuckDuckGo platformā"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
+msgstr "Lasi mūsu privātuma informatīvos ziņojumus savai drošībai un informētībai."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20513,8 +20460,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
+msgstr "Iesaki frāzi, ko uzrakstīt uz kartītes kādam, kurš atveseļojas pēc operācijas"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -21156,8 +21102,7 @@ msgstr "Esi noteicējs pār saviem personīgajiem datiem!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
+msgstr "Aizpildi šo anonīmo aptauju, lai mēs uzzinātu, kā varam uzlabot Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -22173,8 +22118,7 @@ msgstr "Šodien"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Pārslēdzies uz privātu MI tērzēšanu vai %1$sizslēdz to iestatījumos%2$s."
+msgstr "Pārslēdzies uz privātu MI tērzēšanu vai %1$sizslēdz to iestatījumos%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22230,8 +22174,7 @@ msgstr "Pārāk daudz reklāmu"
 #. Displayed when the user has sent too many requests in a short period of time.
 msgctxt "Error message for rate limit"
 msgid "Too many requests. Please take a short break and try again."
-msgstr ""
-"Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
+msgstr "Pārāk daudz pieprasījumu. Lūdzu, paņem nelielu pārtraukumu un mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -22249,7 +22192,7 @@ msgstr "Pārāk lēni"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Pārāk lēna ģenerēšana"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22678,8 +22621,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
+msgstr "Lai iegūtu precīzākus rezultātus, pamēģini iespējot anonīmu atrašanās vietu."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22698,7 +22640,7 @@ msgstr "Pamēģini mazāk atslēgas vārdu."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Izmēģināt bez maksas"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23076,8 +23018,7 @@ msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Precīza atrašanās v
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
+msgstr "Lai iegūtu precīzākus rezultātus, ieslēdz “Izmantot precīzu atrašanās vietu”."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23228,8 +23169,7 @@ msgstr "Nevar iesniegt atsauksmi"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
+msgstr "Nevar izveidot savienojumu ar balss tērzēšanu. Lūdzu, vēlāk mēģini vēlreiz. "
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23270,8 +23210,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: https://"
-"duckduckgo.com"
+"Sadaļā %1$sPie palaišanas%2$s atlasi %3$sMājaslapa%4$s un ievadi: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23297,15 +23237,13 @@ msgstr "Zem %1$sMeklēt adreses joslā ar%2$s nospied %3$sPievienot jaunu%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
+msgstr "Zem %1$sMeklēt%2$s sekcijas nospied %3$sPārvaldīt meklējumprogrammas...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
+msgstr "Sadaļā \"Pie palaišanas\" atlasi %1$sAtvērt noteiktu lapu vai lapu kopu%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23413,8 +23351,7 @@ msgstr "Atbloķē ar DuckDuckGo abonementu"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
+msgstr "Atbloķē uzlabotus MI modeļus un augstākas robežas ar DuckDuckGo abonementu"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23857,8 +23794,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
+msgstr "Vai izmantot aptuveno atrašanās vietu, lai iegūtu precīzākus rezultātus?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24117,8 +24053,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver Duck."
-"ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
+"Apmeklē Duck.ai citā pārlūkprogrammā vai DuckDuckGo lietotnē un atver "
+"Duck.ai iestatījumus. Sadaļā “Sync & Backup” izvēlies “Ieslēgt” un tad "
 "“Sinhronizēt ar citu ierīci”. Vai arī noskenē kvadrātkodu savā atkopšanas "
 "PDF failā."
 
@@ -24406,8 +24342,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
+msgstr "Mēs nevaram nolasīt pievienotos failus, jo vismaz viens no tiem ir šifrēts."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24423,8 +24358,7 @@ msgstr "Mēs neglabājam lietotājvārdus un personu identificējošu informāci
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
+msgstr "Mēs neuzglabājam tavu personisko informāciju un neizsekojam tevi. Nekad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24557,8 +24491,7 @@ msgstr "Mēs zaudējām savienojumu, lūdzu, vēlāk mēģini vēlreiz."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
+msgstr "Mēs pazaudējām savienojumu. Lūdzu, mēģini nosūtīt savu ziņojumu vēlreiz."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24600,8 +24533,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
+msgstr "Mēs neļaujam nevienam piekļūt tavai meklēšanas vēsturei – to nevaram arī mēs."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24836,8 +24768,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
+msgstr "Laipni lūdzam jaunajā Duck.ai! Tagad vari importēt lejupielādētās sarakstes."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25288,8 +25219,7 @@ msgstr "Par ko tu vēlētos sniegt atsauksmes?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
+msgstr "Tas, ko skaties DuckDuckGo, neietekmēs tavus ieteikumus pakalpojumā YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25379,8 +25309,7 @@ msgstr "Kas mēs esam"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
+msgstr "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25802,8 +25731,7 @@ msgstr "Jā, jauns lietotājs!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
+msgstr "Jā, mēs izmetam datus, kad tu beidz ar tiem darboties, un tos nevar atgūt."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25900,8 +25828,7 @@ msgstr "Tu vari mainīt to jebkurā laikā sadaļā %1$sMeklēšanas iestatījum
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
+msgstr "Tu varēsi turpināt šo tērzēšanu, kad tavs limits tiks atiestatīts (%1$s)."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25940,8 +25867,7 @@ msgstr "Tu vari turpināt tērzēt, izmantojot savu mēneša limitu."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
+msgstr "Tagad šajā ierīcē vari saglabāt līdz pat 100 tērzēšanas sarunām. Tērzē!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26122,8 +26048,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
+msgstr "Tu vairs neredzēsi šo ziņojumu, ja vien nenotīrīsi pārlūkprogrammas datus."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26232,8 +26157,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
+msgstr "Tu esi sasniedzis diktēšanas lietošanas ierobežojumu. Mēģini vēlreiz vēlāk."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26292,16 +26216,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
+msgstr "Tavas %1$s jaunākās tērzēšanas būs pieejamas lokālajā krātuvē šajos pārlūkos:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
+msgstr "Tavas Duck.ai tērzēšanas tiek sinhronizētas, izmantojot pilnīgu šifrēšanu."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26423,8 +26345,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
+msgstr "Tava tērzēšana ir privāta, un tā nekad netiek izmantota MI modeļu apmācībai"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26724,8 +26645,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
+msgstr "Tu esi sasniedzis balss tērzēšanas ierobežojumu. Lūdzu, vēlāk mēģini vēlreiz."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -27029,8 +26949,7 @@ msgstr "oficiālā vietne"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
+msgstr "vai uzraksti krāsas kodu pats, piemēram, %1$s (%2$s ir %3$s zīmes kods)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,9 +190,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,9 +201,8 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
-"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -220,9 +218,8 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
-"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -231,8 +228,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
-"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -315,8 +312,7 @@ msgstr "%1$s റാങ്കിംഗുകൾ ഇതുവരെ ലഭ്യ�
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
 msgstr ""
-"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ "
-"എത്തുന്നു. %2$s"
+"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ എത്തുന്നു. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -337,9 +333,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
-"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
-"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
+"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
+"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -425,8 +421,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
-"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -437,8 +433,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
+"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -451,8 +447,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
-"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
+"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -460,8 +456,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
+"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -471,9 +467,8 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
-"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -482,8 +477,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
-"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
+"കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -502,8 +497,7 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -518,16 +512,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
-"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -540,8 +534,7 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
-"വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -899,9 +892,7 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr ""
-"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -955,8 +946,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
-"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
+"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -1014,10 +1005,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
-"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
-"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
+"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1078,11 +1069,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
-"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
-"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
-"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
+"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
+"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
+"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1279,8 +1269,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
-"സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1316,8 +1306,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
-"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
+"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1325,8 +1315,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
+"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1397,8 +1387,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
-"Essentials ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
+"ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1675,8 +1665,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
-"പരിധിയിൽ എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിൽ "
+"എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1685,8 +1675,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
-"കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ കഴിഞ്ഞേക്കാം. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1722,17 +1712,15 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
-"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1868,9 +1856,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
-"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
+"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1909,8 +1896,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
-"ദാതാക്കളെയും അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
+"അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1925,8 +1912,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
-"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
+"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1965,8 +1952,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
-"ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1998,11 +1984,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
-"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
-"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
-"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
-"ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
+"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
+"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
+"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2149,8 +2134,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2159,8 +2144,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
-"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
+"അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2174,9 +2159,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
-"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
+"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2351,8 +2335,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
+"ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2361,8 +2345,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
-"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
+"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2400,9 +2384,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2544,15 +2527,13 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
-"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
-"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
-"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
-"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
-"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
-"മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
+"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
+"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
+"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
+"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2564,14 +2545,13 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
-"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
+"പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2597,9 +2577,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ "
-"കണക്ഷൻ എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും "
-"ചെയ്യുന്നു."
+"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ കണക്ഷൻ "
+"എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2715,16 +2694,15 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
-"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2749,9 +2727,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
-"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
+"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
+"മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2760,17 +2738,16 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
-"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
+"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
-"സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2802,9 +2779,7 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr ""
-"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
-"ഒഴിവാക്കുക."
+msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2972,9 +2947,20 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
-"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
-"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
+"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3104,8 +3090,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വഴി കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
+"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി "
+"കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3365,18 +3351,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
-"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
-"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
+"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
+"ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3384,9 +3370,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
-"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
-"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
+"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
+"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3472,9 +3458,7 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr ""
-"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
-"അംഗീകരിക്കുന്നു."
+msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3495,11 +3479,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
-"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
-"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
-"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
+"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
+"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3508,9 +3491,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
+"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3519,9 +3501,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
-"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
-"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
+"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
+"കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3557,8 +3539,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
-"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
+"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3874,8 +3856,7 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
-"പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3894,17 +3875,13 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
-"മാറ്റുന്നു"
+msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr ""
-"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
-"മാറ്റുന്നു"
+msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4027,11 +4004,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
-"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
-"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
-"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
-"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
+"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
+"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
+"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -4088,8 +4064,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4097,8 +4073,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
-"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4180,8 +4156,8 @@ msgid ""
 "Nobody but you can see your data, not even us."
 msgstr ""
 "ചാറ്റുകൾ DuckDuckGo-യുടെ സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിങ്ങൾക്കല്ലാതെ മറ്റാർക്കും നിങ്ങളുടെ ഡാറ്റ കാണാൻ "
-"കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"സംഭരിച്ചിരിക്കുന്നു. നിങ്ങൾക്കല്ലാതെ മറ്റാർക്കും നിങ്ങളുടെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് "
+"പോലും."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4190,9 +4166,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4204,13 +4180,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
-"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
+"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
+"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
+"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4233,9 +4207,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
-"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
-"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
+"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4243,8 +4216,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
-"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
+"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4297,9 +4270,7 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
-"പരിശോധിക്കുക."
+msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4370,9 +4341,7 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr ""
-"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
-"തിരഞ്ഞെടുക്കുക."
+msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4404,8 +4373,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം "
-"സെർവർ ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
+"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം സെർവർ "
+"ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4423,8 +4392,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
-"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
+"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4605,9 +4574,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
-"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
-"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
+"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
+"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4617,10 +4586,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
-"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
-"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
-"ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
+"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
+"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4629,8 +4597,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
-"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
+"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4639,10 +4607,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
-"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
-"ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
+"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4701,9 +4668,7 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4720,8 +4685,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
-"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
+"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4739,8 +4704,7 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
-"ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4753,8 +4717,7 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4816,10 +4779,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
+"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4830,10 +4792,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
-"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
-"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
-"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
+"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
+"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4902,8 +4863,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
-"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
+"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4911,8 +4872,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
-"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
+"മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5113,8 +5074,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
-"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
+"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5385,9 +5346,7 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
-"ഇല്ലാതാക്കുക."
+msgstr "സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5570,9 +5529,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ "
-"› Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി "
-"വീണ്ടും ശ്രമിക്കുക."
+"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5630,9 +5588,7 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
-"ശ്രമിക്കു."
+msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5739,8 +5695,7 @@ msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
 msgstr ""
-"ലിങ്ക് തുറക്കുന്ന ആർക്കും കാണാനും സംരക്ഷിക്കാനും കഴിയുന്ന ചാറ്റിന്റെ ഒരു "
-"പകർപ്പ് സൃഷ്ടിക്കുന്നു."
+"ലിങ്ക് തുറക്കുന്ന ആർക്കും കാണാനും സംരക്ഷിക്കാനും കഴിയുന്ന ചാറ്റിന്റെ ഒരു പകർപ്പ് സൃഷ്ടിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5749,8 +5704,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
-"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് തുറക്കുന്ന ആർക്കും അത് കാണാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5995,9 +5950,7 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr ""
-"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6279,9 +6232,7 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കണോ?"
+msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6316,9 +6267,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് "
-"തങ്ങളുടെ ചാറ്റുകളിലേക്ക് സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം "
-"പകർപ്പ് ഉണ്ടായിരിക്കും."
+"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് തങ്ങളുടെ ചാറ്റുകളിലേക്ക് "
+"സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം പകർപ്പ് ഉണ്ടായിരിക്കും."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6415,8 +6365,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6434,9 +6384,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
-"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
-"ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
+"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6566,6 +6515,12 @@ msgid "Dislike source"
 msgstr "ഉറവിടം ഇഷ്ടമല്ല"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "നിരസിക്കുക"
@@ -6676,6 +6631,12 @@ msgid "Djibouti"
 msgstr "ജിബൂട്ടി"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6723,9 +6684,7 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
-"ചെയ്യുക%4$s"
+msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6763,8 +6722,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
-"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6890,8 +6849,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
-"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6900,8 +6859,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
-"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
+"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6922,8 +6881,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
-"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
+"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6932,8 +6891,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
-"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
+"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7003,9 +6962,7 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7067,10 +7024,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
-"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
-"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
-"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
+"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
+"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7080,9 +7036,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
-"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
+"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7091,16 +7047,14 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
-"മികച്ചത്!"
+msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7110,9 +7064,8 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
-"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
-"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
+"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7127,8 +7080,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
-"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
+"വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7143,8 +7096,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
-"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
+"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7165,9 +7118,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
-"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
+"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7178,12 +7131,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
-"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
-"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
-"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
-"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
-"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
+"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
+"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
+"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
+"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7198,16 +7150,15 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
-"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
+"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
-"പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7215,16 +7166,14 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
-"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
+"പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr ""
-"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
-"പിന്തുണയ്ക്കുന്നു."
+msgstr "Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7243,8 +7192,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
-"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
+"DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7254,10 +7203,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
-"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
-"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
-"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
+"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
+"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7285,12 +7233,11 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
-"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
-"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
-"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
-"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
-"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
+"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
+"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -7300,10 +7247,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
-"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
-"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
+"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7312,10 +7258,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
-"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
-"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
+"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7327,13 +7272,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
-"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
-"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
+"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
+"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
+"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
+"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
+"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7347,16 +7291,14 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
-"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
-"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
-"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
-"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
-"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
-"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
-"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
+"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
+"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
+"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -7375,8 +7317,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
-"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
+"ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7385,8 +7327,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7395,8 +7337,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
-"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
+"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7405,8 +7347,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7415,8 +7357,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
-"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
+"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7580,9 +7522,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
-"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
-"അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
+"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7590,8 +7531,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
+"യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7600,8 +7541,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
-"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
+"%2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7610,9 +7551,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
-"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
-"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
+"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
+"DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7624,13 +7565,12 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
-"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
-"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
-"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
-"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
-"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
+"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
+"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
+"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
+"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
+"അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7650,9 +7590,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
-"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
+"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7744,11 +7683,10 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
-"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
-"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
-"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
-"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
+"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
+"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
+"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7825,8 +7763,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
-"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7887,9 +7825,7 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7966,8 +7902,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
-"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
+"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -8012,9 +7948,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
-"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
-"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
+"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8039,8 +7974,7 @@ msgstr "എൻക്രിപ്റ്റ് ചെയ്ത മോഡൽ"
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted. Not even DuckDuckGo can read your chat."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു. DuckDuckGo-ക്ക് പോലും നിങ്ങളുടെ ചാറ്റ് "
-"വായിക്കാൻ കഴിയില്ല."
+"എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു. DuckDuckGo-ക്ക് പോലും നിങ്ങളുടെ ചാറ്റ് വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8107,8 +8041,7 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
-"ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8194,8 +8127,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
-"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
+"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8221,8 +8154,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
-"%5$sഅപരനാമം %6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
+"%6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8263,8 +8196,7 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
-"മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8324,9 +8256,7 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
-"ഉൽപ്പന്നങ്ങൾ."
+msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8414,9 +8344,7 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
-"വിശദീകരിക്കുക."
+msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8568,6 +8496,12 @@ msgid "Fast"
 msgstr "വേഗതയുള്ളത്"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8612,8 +8546,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8622,9 +8556,8 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
-"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
-"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
+"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8632,8 +8565,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
-"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
+"ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8722,16 +8655,15 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
+"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
-"%1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8773,8 +8705,7 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8812,8 +8743,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
-"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
+"അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8877,9 +8808,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
-"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
-"വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
+"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8897,6 +8827,12 @@ msgstr "ഫോളോ-അപ്പ് ചോദ്യം"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "ഫോളോ-അപ്പുകൾ സ്വകാര്യമായി തുടരുന്നു."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9002,9 +8938,7 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
-"ആവശ്യമില്ല."
+msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9034,9 +8968,7 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കില്ല."
+msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9117,9 +9049,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
-"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
-"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
+"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9405,14 +9337,15 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity "
-"Theft Restoration എന്നിവയും."
+"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity Theft "
+"Restoration എന്നിവയും."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+msgstr ""
+"DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9498,8 +9431,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, "
-"കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, കൂടാതെ "
+"Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9508,8 +9441,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft "
-"Restoration നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft Restoration "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9518,9 +9451,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
-"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
-"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
+"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9531,8 +9463,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
-"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
+"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9576,9 +9508,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI "
-"മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ "
-"നേടൂ."
+"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ "
+"ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9587,8 +9518,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information "
-"Removal, കൂടാതെ Identity Theft Restoration."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information Removal, "
+"കൂടാതെ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9596,15 +9527,14 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft "
-"Restoration എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration "
+"എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
-"സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9700,8 +9630,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
+"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9736,8 +9666,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9746,8 +9676,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
+"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
+"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9762,8 +9692,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
-"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
+"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9840,6 +9770,12 @@ msgstr "നല്ല ഡിസൈൻ"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "മികച്ച സ്വകാര്യതാ നയം"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10029,9 +9965,7 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
-"നയിക്കുക."
+msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10231,9 +10165,7 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
-"സഹായിക്കൂ"
+msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10291,9 +10223,7 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
-"സഹായിക്കൂ!"
+msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10468,8 +10398,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
-"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
+"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10496,9 +10426,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
-"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
+"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10512,8 +10441,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
-"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
+"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10563,8 +10492,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
-"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10679,9 +10608,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr ""
-"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
-"ആഗ്രഹിക്കുന്നത്?"
+msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10714,8 +10641,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
-"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
+"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10822,9 +10749,7 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr ""
-"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
-"സാധിക്കുമോ?"
+msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10839,16 +10764,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
-"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
+"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
-"എനിക്ക് ആവശ്യമാണ്"
+msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10877,9 +10800,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
-"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
-"എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
+"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10889,9 +10811,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
-"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
-"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
+"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
+"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10906,8 +10828,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
-"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
+"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10916,9 +10838,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
-"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
-"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
+"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10927,17 +10848,16 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
-"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
+"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
-"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
+"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10947,8 +10867,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
-"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
+"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10956,8 +10876,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
-"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
+"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10995,6 +10915,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "ഇമേജ് പ്രോംപ്റ്റുകൾ Duck.ai %1$s പാലിക്കണം."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11086,8 +11012,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
-"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
+"മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11100,8 +11026,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
-"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
+"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -11112,8 +11038,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
-"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11128,9 +11054,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
-"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
-"പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
+"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11467,8 +11392,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
-"പ്രശസ്തി സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
+"സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11512,17 +11437,15 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr ""
-"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
-"നൽകുന്നു."
+msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
-"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
+"കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11541,10 +11464,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
-"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
-"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
-"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
+"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
+"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
+"ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11553,8 +11476,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
-"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
+"വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11627,8 +11550,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും "
-"സ്വകാര്യമായി സൂക്ഷിക്കുക."
+"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും സ്വകാര്യമായി "
+"സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11942,9 +11865,7 @@ msgstr "പങ്കിട്ട ചാറ്റുകൾ എങ്ങനെ പ
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr ""
-"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
-"മനസ്സിലാക്കുക"
+msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11986,9 +11907,7 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
-"അറിയുക."
+msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12051,8 +11970,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
-"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ മാറാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12110,9 +12029,7 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr ""
-"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
-"പരിമിതപ്പെടുത്തുന്നു"
+msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -12167,8 +12084,7 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
-"ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12280,8 +12196,7 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
-"ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12468,8 +12383,7 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
-"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12834,9 +12748,7 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13620,11 +13532,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
-"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
+"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
+"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -14470,8 +14381,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
+"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14480,9 +14391,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് "
-"സ്കാൻ ചെയ്യുക:"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
+"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് സ്കാൻ ചെയ്യുക:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14491,9 +14401,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. "
-"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
+"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14521,9 +14431,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
-"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
-"ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
+"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14566,8 +14475,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
-"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14621,8 +14530,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
+"ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14643,8 +14552,7 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
-"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14801,9 +14709,7 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
-"തിരഞ്ഞെടുക്കുക..."
+msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14904,9 +14810,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
-"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
+"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14920,9 +14825,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI "
-"ചാറ്റുകളും കൂടുതൽ പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ."
+"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI ചാറ്റുകളും കൂടുതൽ "
+"പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു സബ്‌സ്‌ക്രിപ്‌ഷൻ."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14930,8 +14834,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
-"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
+"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14939,9 +14843,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
-"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
-"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
+"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
+"ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15194,9 +15098,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
-"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
+"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15352,9 +15255,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ "
-"സൈറ്റുകളിൽ അത് കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ "
-"പ്രവർത്തിക്കുന്നു."
+"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ അത് "
+"കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15425,10 +15327,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
-"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
-"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
-"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
+"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
+"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15437,10 +15338,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
-"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
-"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
+"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
+"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15450,10 +15351,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
-"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
-"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
-"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
+"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
+"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15486,8 +15386,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15496,8 +15396,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
-"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15506,8 +15406,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
-"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
+"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15520,8 +15420,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
-"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15610,8 +15510,7 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
-"ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15620,24 +15519,23 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
-"പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
-"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
+"(ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15658,8 +15556,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
-"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
+"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15668,9 +15566,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15679,9 +15576,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
-"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
-"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
+"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15834,8 +15730,7 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15894,12 +15789,17 @@ msgid "Poor formatting"
 msgstr "മോശം ഫോർമാറ്റിംഗ്"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16408,9 +16308,7 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
-"നിർദേശിക്കുക."
+msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16428,9 +16326,7 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
-"സംരക്ഷിക്കുക."
+msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16461,8 +16357,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
-"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
+"വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16692,16 +16588,14 @@ msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
-"പരിധിയിലെത്തുന്നു. %1$s"
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിലെത്തുന്നു. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
-"ഉപയോഗിക്കുന്നു. %1$s"
+msgstr "റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16751,8 +16645,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16761,8 +16655,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
-"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
+"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16772,10 +16666,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
-"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
-"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
-"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
+"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
+"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16917,8 +16810,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
-"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
+"ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -17059,9 +16952,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
-"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
-"ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
+"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17169,9 +17061,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17179,9 +17070,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
-"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
-"സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
+"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17245,10 +17135,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
-"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
-"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
-"അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
+"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17256,8 +17145,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
-"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
+"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17266,10 +17155,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
-"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
-"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
-"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
+"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
+"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17361,10 +17249,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
-"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
+"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17373,9 +17260,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17385,11 +17272,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
-"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
-"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
-"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
+"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
+"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
+"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17466,8 +17352,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
-"കൈകാര്യം ചെയ്യാൻ കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17816,17 +17702,16 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
-"പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17834,8 +17719,7 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
-"ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17981,17 +17865,13 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക."
+msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17999,8 +17879,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18009,8 +17889,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
-"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
+"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -18029,16 +17909,15 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
-"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
+"അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
-"ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18100,14 +17979,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
-"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
-"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
-"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
-"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
-"ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
+"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
+"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
+"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
+"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -18115,8 +17992,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
-"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
+"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -18125,10 +18002,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
-"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
+"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
+"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18249,8 +18125,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
-"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
+"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18269,9 +18145,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
-"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
-"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
+"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
+"തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18279,8 +18155,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
-"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
+"ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18292,11 +18168,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
-"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
-"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
-"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
-"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
+"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -18392,8 +18267,7 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
-"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18402,9 +18276,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18413,9 +18286,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18424,9 +18296,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
-"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
+"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18435,17 +18306,15 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
-"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
-"ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18454,9 +18323,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
-"ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
+"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18601,38 +18469,34 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
-"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
+"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
-"ക്ലിക്ക് ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
-"ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18644,9 +18508,7 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%4$sഅനുവദിക്കുക%3$s"
+msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18659,8 +18521,7 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18671,17 +18532,13 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr ""
-"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -18689,8 +18546,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18698,8 +18555,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
-"എന്നും തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18764,16 +18621,14 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
+"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
-"%3$sഅനുവദിക്കുക%4$s"
+msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18846,8 +18701,7 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
-"വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18891,9 +18745,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
-"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
-"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
+"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
+"ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -19016,8 +18870,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
-"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
+"ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -19099,9 +18953,7 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
-"സഹായിക്കുക!"
+msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19128,9 +18980,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
-"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
-"വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
+"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19232,8 +19083,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
-"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
+"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19282,9 +19133,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം "
-"സംരക്ഷിക്കൂ. സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ "
-"ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
+"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം സംരക്ഷിക്കൂ. "
+"സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19410,9 +19260,7 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
-"%1$sഓഫാക്കാം%2$s.)"
+msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19595,9 +19443,7 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
-"കാണിക്കുക."
+msgstr "Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19652,9 +19498,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
+"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19662,9 +19507,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
-"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
-"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
+"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
+"ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19675,8 +19520,7 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
-"ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19693,23 +19537,21 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
-"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19817,16 +19659,12 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
-"പ്രവർത്തിക്കുന്നു."
+msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
-"മറയ്ക്കും"
+msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19986,8 +19824,7 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
-"വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20018,8 +19855,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
-"രീതിയിൽ വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
+"വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20058,8 +19895,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
-"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
+"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -20068,16 +19905,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
-"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
-"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
+"ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -20086,16 +19923,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
+"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20150,8 +19986,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
-"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20356,9 +20192,7 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
-"അറിവുള്ളവരായും തുടരുക."
+msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20408,9 +20242,7 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
-"പ്രതിരോധിക്കുക."
+msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20505,8 +20337,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
+"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20575,8 +20407,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
-"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
+"നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20912,9 +20744,7 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
-"അയയ്ക്കും"
+msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20968,9 +20798,7 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
-"കഴിയില്ല."
+msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20979,8 +20807,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup നിങ്ങളുടെ കൂടുതൽ ചാറ്റുകൾ സംരക്ഷിക്കുകയും അവയെ നിങ്ങളുടെ എല്ലാ "
-"ഉപകരണങ്ങളിലും ഉടനീളം സമന്വയിപ്പിക്കുകയും ചെയ്യുന്നു."
+"Sync & Backup നിങ്ങളുടെ കൂടുതൽ ചാറ്റുകൾ സംരക്ഷിക്കുകയും അവയെ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും "
+"ഉടനീളം സമന്വയിപ്പിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21029,27 +20857,25 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
-"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
-"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
-"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
+"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
-"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
-"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
+"തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
+"ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
-"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
-"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
+"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
+"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -21188,9 +21014,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
-"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
-"നേടൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും വേഗത്തിൽ ആക്സസ് "
+"ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21199,9 +21024,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
-"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
-"ഉൾപ്പെടുത്തൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള "
+"ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21224,9 +21048,7 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
-"പങ്കെടുക്കൂ."
+msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21447,10 +21269,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
-"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
-"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
-"ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
+"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
+"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21459,8 +21280,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
-"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
+"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21469,8 +21290,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"DuckDuckGo അജ്ഞാതമാക്കിയ സ്വകാര്യ തിരയലും AI ചാറ്റും തമ്മിൽ വേഗത്തിൽ മാറാൻ "
-"Duck.ai ടോഗിൾ അനുവദിക്കുന്നു."
+"DuckDuckGo അജ്ഞാതമാക്കിയ സ്വകാര്യ തിരയലും AI ചാറ്റും തമ്മിൽ വേഗത്തിൽ മാറാൻ Duck.ai "
+"ടോഗിൾ അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21500,17 +21321,15 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
-"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
+"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
-"ഇല്ലാതാക്കും."
+msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21583,9 +21402,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
-"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
+"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21600,8 +21419,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
-"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
+"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21620,10 +21439,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
-"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
-"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
-"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
+"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
+"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
+"ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21669,8 +21488,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
-"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21700,9 +21519,7 @@ msgstr "ഈ ആഴ്ച"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr ""
-"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
-"ചെയ്യും."
+msgstr "ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21711,9 +21528,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
-"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21723,9 +21540,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21734,9 +21551,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
+"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21746,9 +21562,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
-"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
+"വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21765,9 +21581,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ "
-"ഉപകരണത്തിന് ഇനി കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ "
-"ലഭ്യമാകും."
+"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ ഉപകരണത്തിന് ഇനി "
+"കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21799,9 +21614,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
-"അറ്റാച്ചുചെയ്യുക"
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21809,9 +21622,7 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr ""
-"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
-"ചെയ്യുക."
+msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21843,8 +21654,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21852,8 +21662,7 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
-"ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21881,8 +21690,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
-"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ ഇതിന്റെ മെനു (മൂന്ന് "
+"ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21891,8 +21700,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
-"Button ഉപയോഗിക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21913,8 +21721,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
-"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
+"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21923,8 +21731,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
-"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
+"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21961,9 +21769,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
-"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
-"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
+"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21972,9 +21779,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21984,10 +21790,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
-"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
-"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
-"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
+"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
+"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
+"ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -22028,9 +21834,7 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
-"ഉപയോഗിക്കുന്നില്ല."
+msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22040,10 +21844,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
-"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
-"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
-"ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
+"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
+"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -22052,8 +21855,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
-"ഇത് പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
+"പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -22072,8 +21875,7 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
-"പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22170,9 +21972,7 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr ""
-"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
-"ചേർക്കാൻ:"
+msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -22195,8 +21995,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
-"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
+"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22206,10 +22006,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
-"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
-"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
-"ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
+"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
+"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22218,8 +22017,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
-"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
+"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22227,8 +22026,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
-"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
+"അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -22259,8 +22058,8 @@ msgstr ""
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
-"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ ഇത് "
+"പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22321,6 +22120,12 @@ msgstr "ഈ ഉറവിടത്തിൽ നിന്ന് വളരെ അ�
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "വളരെ മന്ദഗതിയാണ്"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22434,8 +22239,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
-"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
+"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22483,8 +22288,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22493,8 +22298,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
-"ഞാൻ എങ്ങനെ എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
+"എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22742,8 +22547,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
-"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22763,6 +22568,12 @@ msgstr "ഓരോ മോഡലിലും പരീക്ഷണം നടത്
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "കുറച്ച് കീവേഡുകൾ പരീക്ഷിക്കുക."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22808,9 +22619,7 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
-"പലതും."
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22943,8 +22752,7 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
-"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22978,9 +22786,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22989,9 +22796,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
-"%3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
+"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -23192,9 +22998,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
-"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
-"കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
+"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23292,17 +23097,13 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -23328,8 +23129,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
-"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -23337,22 +23138,21 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
-"ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
-"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23363,32 +23163,30 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
-"ക്ലിക്ക് ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
-"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
-"തിരഞ്ഞെടുക്കുക"
+msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23466,8 +23264,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
-"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23489,8 +23287,7 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
-"അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23521,9 +23318,7 @@ msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
-"ചെയ്യുക"
+msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23531,9 +23326,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
-"ചെയ്യുക. %1$s"
+msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23631,8 +23424,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
-"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
+"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23757,16 +23550,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
-"ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23862,9 +23654,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
-"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
-"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
+"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
+"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23877,8 +23669,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
-"search ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
+"ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23921,8 +23713,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23930,8 +23722,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
-"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
+"ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -24055,9 +23847,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai-യിൽ നിന്ന് പങ്കിട്ട ഒരു സംഭാഷണം കാണൂ - DuckDuckGo-യുടെ സൗജന്യവും "
-"സ്വകാര്യവുമായ AI ചാറ്റ്. നിങ്ങളുടെ സ്വന്തം ചാറ്റുകളിലേക്ക് ഇത് സംരക്ഷിച്ച് "
-"സ്വകാര്യമായി തുടരൂ."
+"Duck.ai-യിൽ നിന്ന് പങ്കിട്ട ഒരു സംഭാഷണം കാണൂ - DuckDuckGo-യുടെ സൗജന്യവും സ്വകാര്യവുമായ "
+"AI ചാറ്റ്. നിങ്ങളുടെ സ്വന്തം ചാറ്റുകളിലേക്ക് ഇത് സംരക്ഷിച്ച് സ്വകാര്യമായി തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -24092,8 +23883,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -24102,8 +23893,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
-"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
+"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -24112,8 +23903,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. Yelp-ന്റെ "
-"പരസ്യ ശൃംഖലയാണ് പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. Yelp-ന്റെ പരസ്യ ശൃംഖലയാണ് "
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -24125,8 +23916,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -24135,8 +23926,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
-"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
+"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -24145,8 +23936,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
-"നിർദേശങ്ങൾ പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
+"പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24161,9 +23952,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
-"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
+"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -24173,10 +23964,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
+"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
+"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -24186,10 +23976,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
-"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
-"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
-"തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
+"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
+"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -24199,10 +23988,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
-"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
-"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
-"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24255,8 +24043,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24406,9 +24194,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
-"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
-"Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
+"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24428,11 +24215,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
-"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
-"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
-"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
-"ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
+"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
+"യാതൊരു ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24445,8 +24231,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
-"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
+"അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24458,10 +24244,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
-"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24473,18 +24258,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
-"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
-"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
-"കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
+"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
+"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
-"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
+"ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24492,8 +24276,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
-"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
+"വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24504,16 +24288,13 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
-"സംഭരിക്കുന്നില്ല."
+msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
-"ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24525,8 +24306,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
-"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
+"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24540,9 +24321,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
-"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
-"ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
+"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24551,9 +24331,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
-"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
-"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
+"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24564,9 +24343,7 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
-"നയം."
+msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24595,8 +24372,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
-"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
+"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24622,8 +24399,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ "
-"കണ്ടെത്തി നീക്കം ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
+"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ കണ്ടെത്തി നീക്കം "
+"ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24632,8 +24409,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
-"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
+"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24650,9 +24427,7 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
-"ശ്രമിക്കൂ."
+msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24660,8 +24435,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
-"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
+"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24670,9 +24445,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
-"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
-"മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
+"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24681,24 +24455,20 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി "
-"സ്കാൻ ചെയ്യുകയും, ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി "
-"നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി സ്കാൻ ചെയ്യുകയും, "
+"ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
-"ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
-"തടയുന്നു."
+msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24714,16 +24484,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
-"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
-"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
+"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
+"ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
-"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24732,9 +24501,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ "
-"സൈറ്റുകളിൽ സ്കാൻ ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ "
-"പ്രവർത്തിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ സ്കാൻ "
+"ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ പ്രവർത്തിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24744,8 +24512,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
-"ദയവായി %1$s-നെ സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
+"സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24755,8 +24523,7 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
-"മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24771,8 +24538,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
-"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
+"പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24781,8 +24548,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
-"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
+"ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24890,9 +24657,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
-"തുടരാം."
+msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24906,9 +24671,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24917,9 +24681,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
-"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
+"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
+"ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24929,17 +24693,16 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
-"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
-"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
+"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
-"ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25007,8 +24770,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
-"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
+"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -25023,8 +24786,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
-"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -25045,8 +24808,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
-"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
+"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -25071,12 +24834,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
-"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
-"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
-"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
-"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
-"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
+"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
+"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
+"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
+"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25162,8 +24924,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
-"എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25314,8 +25075,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
-"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
+"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25391,8 +25152,7 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
-"സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25418,8 +25178,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
-"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
+"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25443,8 +25203,7 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
-"എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25485,8 +25244,7 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
-"അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25624,9 +25382,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
-"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
-"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25635,8 +25393,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ %1$s വരെ "
-"ഈ ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ %1$s വരെ ഈ ഉപകരണത്തിൽ "
+"സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25644,8 +25402,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
-"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകൾ ഈ "
-"ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകൾ ഈ ഉപകരണത്തിൽ "
+"സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25660,9 +25418,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും "
-"അതിലേറെയും നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് "
-"പ്രവർത്തിക്കുന്നു."
+"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും അതിലേറെയും "
+"നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25911,8 +25668,7 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
-"വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25932,8 +25688,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25942,8 +25698,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
-"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
+"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25957,8 +25713,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
+"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25967,22 +25723,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
-"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
+"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
-"ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
-"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
+"ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25996,8 +25751,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
-"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
+"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -26018,8 +25773,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
-"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
+"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -26049,8 +25804,7 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
-"തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26114,8 +25868,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
-"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
+"അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -26151,9 +25905,7 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr ""
-"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
-"സൂക്ഷിക്കാം."
+msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -26181,8 +25933,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
+"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -26191,9 +25943,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
-"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
-"ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
+"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -26215,9 +25966,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
-"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
-"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
+"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -26227,9 +25978,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
-"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
-"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
+"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -26243,8 +25994,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
-"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
+"ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -26259,9 +26010,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
-"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
-"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
+"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -26274,8 +26024,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
-"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
+"നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26325,8 +26075,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
-"ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26353,9 +26103,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
-"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
-"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
+"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26366,8 +26115,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26381,9 +26130,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
-"YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
+"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26404,18 +26152,14 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ "
-"ലഭ്യമാകും:"
+msgstr "നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ "
-"സമന്വയിപ്പിക്കപ്പെടുന്നു."
+msgstr "നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സമന്വയിപ്പിക്കപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26447,8 +26191,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26458,9 +26202,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26470,9 +26214,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
-"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
+"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
+"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26488,9 +26232,7 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു."
+msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26499,8 +26241,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
-"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
+"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26508,8 +26250,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
-"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
+"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26518,8 +26260,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
-"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26532,16 +26274,15 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26567,8 +26308,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26576,8 +26317,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26592,9 +26333,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
-"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
+"പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26603,8 +26344,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
-"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
+"നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26652,8 +26393,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26682,11 +26423,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
-"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
-"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
-"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
+"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
+"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
+"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26701,10 +26441,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
-"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
-"കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
+"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
+"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26718,8 +26457,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
-"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
+"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26751,9 +26490,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
-"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
-"പ്രവർത്തനക്ഷമമാക്കുക."
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
+"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26762,9 +26500,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
-"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
-"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
+"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
+"അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26792,9 +26530,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
-"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
-"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
+"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26803,8 +26540,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
-"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26813,8 +26550,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
-"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
+"സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26823,8 +26560,7 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26839,8 +26575,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
-"നാളെ ഈ ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
+"തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -27149,8 +26885,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
-"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
+"പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ml_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ml_IN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ml_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -190,8 +190,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -201,8 +202,9 @@ msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
-"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ DuckDuckGo "
-"സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"Pro-യുടെ ഒപ്പം മാത്രമേ %1$s ലഭ്യമാകൂ. ചാറ്റ് തുടരാൻ ഈ ബ്രൗസറിൽ നിങ്ങളുടെ "
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ വീണ്ടും അപ്‌ഗ്രേഡ് ചെയ്യുക, അല്ലെങ്കിൽ Plus "
+"അല്ലെങ്കിൽ സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -218,8 +220,9 @@ msgid ""
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
 msgstr ""
-"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് തുടരാൻ, നിങ്ങളുടെ "
-"സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ മോഡലിലേക്ക് മാറുക."
+"%1$s DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷനോടൊപ്പം മാത്രമേ ലഭ്യമാകൂ. ഈ ബ്രൗസറിൽ ചാറ്റ് "
+"തുടരാൻ, നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
+"മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -228,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും "
-"ശ്രമിക്കുക."
+"%1$s താൽക്കാലികമായി ലഭ്യമല്ല. ദയവായി മറ്റൊരു മോഡലിലേക്ക് മാറുക അല്ലെങ്കിൽ "
+"പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -312,7 +315,8 @@ msgstr "%1$s റാങ്കിംഗുകൾ ഇതുവരെ ലഭ്യ�
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
 msgstr ""
-"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ എത്തുന്നു. %2$s"
+"%1$s അടിസ്ഥാന മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധികളിൽ "
+"എത്തുന്നു. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -333,9 +337,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് പോലും "
-"നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് അവരുടെ സെർവറുകളിൽ "
-"സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
+"%1$s ഒരു വിശ്വസനീയമായ നിർവഹണ അന്തരീക്ഷത്തിൽ പ്രവർത്തിക്കുന്നു. മോഡൽ ദാതാവിന് "
+"പോലും നിങ്ങളുടെ പ്രോംപ്റ്റുകളോ മോഡലിന്റെ പ്രതികരണങ്ങളോ കാണാനോ ഈ ചാറ്റ് "
+"അവരുടെ സെർവറുകളിൽ സംരക്ഷിക്കാനോ കഴിയില്ല എന്നാണ്."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -421,8 +425,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ ചാറ്റ് "
-"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s %2$s ദിവസങ്ങൾക്കുള്ളിൽ (%3$s) Duck.ai ഉപേക്ഷിച്ച് പോകും. അതിനുശേഷം, ഈ "
+"ചാറ്റ് തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -433,8 +437,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് തുടരുന്നതിന് "
-"നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
+"%1$s 1 ദിവസം കൊണ്ട് Duck.ai വിടുന്നതായിരിക്കും (%2$s). അതിനുശേഷം, ഈ ചാറ്റ് "
+"തുടരുന്നതിന് നിങ്ങൾക്ക് മോഡലുകൾ മാറ്റാം."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -447,8 +451,8 @@ msgstr "%1$s വാക്കുകൾ"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, തുടർന്ന് "
-"%6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sചേർക്കുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sഅനുവദിക്കുക%5$s ചെക്ക് ചെയ്യുക, "
+"തുടർന്ന് %6$sശരി%7$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -456,8 +460,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s "
-"ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഅനുവദിക്കുക%3$s ക്ലിക്ക് ചെയ്യുക%4$sചേർക്കുക%5$s ക്ലിക്ക് "
+"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s ശരിയിടുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -467,8 +471,9 @@ msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
 msgstr ""
-"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s ക്ലിക്ക് "
-"ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s ക്ലിക്ക് ചെയ്യുക"
+"%1$s%2$sഇൻസ്റ്റാളേഷനിലേക്ക് തുടരുക%3$s ക്ലിക്ക് ചെയ്യുക %4$sചേർക്കുക%5$s "
+"ക്ലിക്ക് ചെയ്യുക%6$sഅനുവദിക്കുക%7$s അടയാളപ്പെടുത്തുക, തുടർന്ന് %8$sശരി%9$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -477,8 +482,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ "
-"കരുതുന്നുണ്ടെങ്കിൽ."
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ അമർത്തുക%2$s, ഈ തിരയലിന് ഫലങ്ങൾ "
+"ഉണ്ടായിരിക്കണമെന്ന് നിങ്ങൾ കരുതുന്നുണ്ടെങ്കിൽ."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -497,7 +502,8 @@ msgstr "%1$sകൂടുതലറിയുക%2$s ."
 msgctxt "precise_user_location"
 msgid "%sLearn how we keep your location private%s."
 msgstr ""
-"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക%2$s."
+"%1$sനിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക%2$s."
 
 # smartling.placeholder_format=C
 #. The text between the two placeholders becomes a link to a help page about recovery codes. %s are the opening and closing link tags; keep the words Learn more between them.
@@ -512,16 +518,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"DuckDuckGo-യുടെ സെർവറിൽ ചാറ്റുകൾ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു എന്നതിനെക്കുറിച്ച് "
-"%1$sകൂടുതൽ അറിയുക%2$s."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ എങ്ങനെ സ്വകാര്യമായി സൂക്ഷിക്കപ്പെടുന്നു "
+"എന്നതിനെക്കുറിച്ച് %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -534,7 +540,8 @@ msgstr "ഹോം സ്ക്രീനിൽ DuckDuckGo ആപ്പ് ഐക�
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s വീണ്ടും ശ്രമിക്കുക."
+"%1$sക്ഷമിക്കണം!%2$s%3$sഎന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി %4$sപുതുക്കി%5$s "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -892,7 +899,9 @@ msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ�
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
-msgstr "6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"6 മണിക്കൂർ ഉപയോഗ പരിധി കഴിഞ്ഞു. നിങ്ങളുടെ ദൈനംദിന പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -946,8 +955,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. നിങ്ങളുടെ കണക്ഷൻ "
-"പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
+"ഒരു നെറ്റ്‌വർക്ക് പ്രശ്‌നം Search Assist ഉത്തരം സൃഷ്ടിക്കുന്നതിനെ തടയുന്നു. "
+"നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -1005,10 +1014,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത മറയ്ക്കും. %1$sduckduckgo.com/"
-"aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ "
-"കഴിയും."
+"3കക്ഷി AI Chat മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ AI Chat നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ AI Chat സവിശേഷത "
+"മറയ്ക്കും. %1$sduckduckgo.com/aichat%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് "
+"ചെയ്യുമ്പോഴും നിങ്ങൾക്ക് AI Chat ആക്സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1069,10 +1078,11 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് പിന്തുണയ്ക്കുന്നില്ല. "
-"എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി %1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും "
-"പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് "
-"മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ നിലവിൽ ഫോളോ-അപ്പ് ചോദ്യങ്ങളെ നേരിട്ട് "
+"പിന്തുണയ്ക്കുന്നില്ല. എന്നിരുന്നാലും, ഞങ്ങൾ ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്കായി "
+"%1$sDuck.ai%2$s വാഗ്ദാനം ചെയ്യുകയും പലപ്പോഴും ലിങ്ക് ചെയ്യുകയും ചെയ്യുന്നു, "
+"ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1269,8 +1279,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു സൗജന്യ "
-"മോഡലിലേക്ക് മാറുക."
+"ചാറ്റ് തുടരാൻ നിങ്ങളുടെ %1$s ഈ ബ്രൗസറിൽ വീണ്ടും സജീവമാക്കുക, അല്ലെങ്കിൽ ഒരു "
+"സൗജന്യ മോഡലിലേക്ക് മാറുക."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1306,8 +1316,8 @@ msgstr "പരസ്യം"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ നിങ്ങളെ "
-"തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
+"%1$s-ൻ്റെ പരസ്യ നെറ്റ്വർക്കുകൾ ആണ് പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത്, അവ "
+"നിങ്ങളെ തിരിച്ചറിയാൻ ഉപയോഗിക്കപ്പെടാറില്ല."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1315,8 +1325,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ "
-"ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
+"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1387,8 +1397,8 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ചേർക്കുക"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy Essentials "
-"ചേർക്കുക:"
+"ഒരു ഡൗൺ ലോഡിനൊപ്പം സൗജന്യമായി നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo Privacy "
+"Essentials ചേർക്കുക:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1665,8 +1675,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിൽ "
-"എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിൽ എത്തിച്ചേരാൻ കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1675,8 +1685,8 @@ msgctxt ""
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
 msgstr ""
-"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ കഴിഞ്ഞേക്കാം. "
-"%1$s"
+"നൂതന മോഡലുകൾക്ക് മറ്റ് മോഡലുകളേക്കാൾ 2-5 മടങ്ങ് വേഗത്തിൽ പരിധികൾ ഉപയോഗിക്കാൻ "
+"കഴിഞ്ഞേക്കാം. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1712,15 +1722,17 @@ msgstr "ആഫ്രികാൻസ്"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"ഇത് ഡൗൺലോഡ് ചെയ്ത് തുറന്ന ശേഷം %1$sഇൻസ്റ്റാൾ ചെയ്യുക%2$s എന്നതിൽ ക്ലിക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
 msgstr ""
-"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് ഡബിൾ ക്ലിക്ക് "
-"ചെയ്യുക"
+"അത് ഡൗൺലോഡ് ചെയ്ത ശേഷം, എക്സ്റ്റൻഷൻ ഫയൽ കണ്ടെത്തി, ഇൻസ്റ്റാൾ ചെയ്യാൻ അത് "
+"ഡബിൾ ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1856,8 +1868,9 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ DuckDuckGo "
-"അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല"
+"എല്ലാ ചാറ്റുകളും DuckDuckGo അജ്ഞാതമാക്കുന്നു, കൂടാതെ നിങ്ങളുടെ സംഭാഷണങ്ങൾ "
+"DuckDuckGo അല്ലെങ്കിൽ മോഡൽ ദാതാക്കൾ ചാറ്റ് മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1896,8 +1909,8 @@ msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
 msgstr ""
-"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ ദാതാക്കളെയും "
-"അനുവദിക്കില്ല."
+"നിങ്ങളുടെ സംഭാഷണങ്ങൾ ഉപയോഗിച്ച് അവരുടെ AI പരിശീലിപ്പിക്കാൻ എല്ലാ മോഡൽ "
+"ദാതാക്കളെയും അനുവദിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1912,8 +1925,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും (ഉദാഹരണത്തിന്, "
-"നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
+"AI ദാതാവിന് ഒരു ചാറ്റ് അയയ്ക്കുന്നതിന് മുമ്പ് എല്ലാ വ്യക്തിഗത മെറ്റാഡാറ്റയും "
+"(ഉദാഹരണത്തിന്, നിങ്ങളുടെ IP വിലാസം) നീക്കംചെയ്യപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1952,7 +1965,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ ആക്സസ് അനുവദിക്കുക."
+"വോയ്സ് ചാറ്റ് ഉപയോഗിക്കാൻ സിസ്റ്റം ക്രമീകരണങ്ങളിൽ DuckDuckGo മൈക്രോഫോൺ "
+"ആക്സസ് അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1984,10 +1998,11 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ %1$s-നെ "
-"അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച "
-"ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ "
-"ദൃശ്യപരത പൂജ്യം ആണ്%4$s."
+"പ്രസക്തമായ പ്രോംപ്റ്റുകൾക്കുള്ള പ്രതികരണങ്ങൾ മെച്ചപ്പെടുത്താൻ വെബിൽ തിരയാൻ "
+"%1$s-നെ അനുവദിക്കുന്നു. പരിമിതമായ ഡാറ്റ നിലനിർത്തൽ ഉള്ള ഒരു സെർച്ച് "
+"എഞ്ചിനിലേക്ക് മാത്രമേ AI സൃഷ്ടിച്ച ചോദ്യങ്ങൾ അയയ്ക്കൂ. %2$s ഉള്ള "
+"പ്രോംപ്റ്റുകൾക്കും പ്രതികരണങ്ങൾക്കും ഇപ്പോഴും %3$sദാതാവിന്റെ ദൃശ്യപരത പൂജ്യം "
+"ആണ്%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2134,8 +2149,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2144,8 +2159,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI മോഡലുകളിലേക്കുള്ള "
-"അജ്ഞാത ആക്സസ്."
+"%1$s, %2$s, കൂടാതെ ഓപ്പൺ സോഴ്സ് %3$s, %4$s ഉൾപ്പെടെയുള്ള ജനപ്രിയ AI "
+"മോഡലുകളിലേക്കുള്ള അജ്ഞാത ആക്സസ്."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2159,8 +2174,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്നു. ഇത് "
-"എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
+"വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്നു. ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കുക, "
+"അല്ലെങ്കിൽ പൂർണ്ണമായും പ്രവർത്തനരഹിതമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2335,8 +2351,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ "
-"ചാറ്റുകളും ഇല്ലാതാക്കും."
+"ചരിത്രം പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? ഇത് പിൻ ചെയ്ത "
+"ചാറ്റുകൾ ഉൾപ്പെടെ എല്ലാ ചാറ്റുകളും ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2345,8 +2361,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് ചെയ്ത സമീപകാല "
-"ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
+"സമീപകാല ചാറ്റുകൾ പ്രവർത്തനരഹിതമാക്കണമെന്ന് നിങ്ങൾക്ക് ഉറപ്പാണോ? നിലവിൽ സേവ് "
+"ചെയ്ത സമീപകാല ചാറ്റുകളും ഇത് ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2384,8 +2400,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം അനുസരിച്ച്, ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല. ഈ സ്വകാര്യതാ പരിരക്ഷ എല്ലാം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ സംഭവിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2527,13 +2544,15 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ ഉത്തരങ്ങൾ അജ്ഞാതമായി "
-"സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലും ഇല്ല (തിരയൽ ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
-"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ചിലപ്പോൾ "
-"(വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ "
-"തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. "
-"(ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
+"പ്രസക്തമായ വെബ് ഉള്ളടക്കം സംഗ്രഹിച്ച് ചില തിരയലുകൾക്ക് AI സഹായത്തോടെ "
+"ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കാൻ Assist-ന് കഴിയും. Assist എത്ര തവണ "
+"പ്രത്യക്ഷപ്പെടണമെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും ഇല്ല (തിരയൽ "
+"ഫലങ്ങളിൽ നിന്ന് Assist UI പൂർണ്ണമായും നീക്കം ചെയ്യുന്നു), ആവശ്യാനുസരണം "
+"(നിങ്ങൾ Assist ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ മാത്രമേ AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ "
+"കാണിക്കൂ), ഇടയ്ക്കിടെ (വിശാലമായ തിരയൽ ശ്രേണികളിൽ കൂടുതൽ പതിവായി "
+"കാണിക്കുന്നു). ഇപ്പോൾ, AI സഹായിക്കുന്ന ഉത്തരങ്ങൾ യു.എസ്. (ഇംഗ്ലീഷ്) മേഖലയിൽ "
+"മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2545,13 +2564,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
-"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ %1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് "
-"പ്രധാനമാണ്."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ് Assist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി AI സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2577,8 +2597,9 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ കണക്ഷൻ "
-"എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും ചെയ്യുന്നു."
+"കഫേയിലോ വിമാനത്താവളത്തിലോ ഹോട്ടലിലോ ആയിരിക്കുമ്പോൾ, DuckDuckGo VPN നിങ്ങളുടെ "
+"കണക്ഷൻ എൻക്രിപ്റ്റ് ചെയ്യുകയും Wi-Fi-യിൽ നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുകയും "
+"ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2694,15 +2715,16 @@ msgstr "സ്വയമേവയുള്ള-ഉത്തരം"
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. അപാകതകൾ "
+"അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
 msgstr ""
-"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. പ്രതികരണങ്ങളിൽ അപാകതകൾ "
-"അടങ്ങിയിരിക്കാം."
+"ലിസ്റ്റ് ചെയ്ത ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കി യാന്ത്രികമായി സൃഷ്ടിച്ചത്. "
+"പ്രതികരണങ്ങളിൽ അപാകതകൾ അടങ്ങിയിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2727,9 +2749,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി തിരയാനും ചില "
-"സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ "
-"മാത്രമേ Assist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ Assist കാണിക്കുന്നു. Assist-ന് അജ്ഞാതമായി "
+"തിരയാനും ചില സെർച്ചുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. "
+"ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ Assist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2738,16 +2760,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് അജ്ഞാതമായി "
-"തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് "
-"പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
+"പ്രസക്തമായ തിരയലുകൾക്കായി സ്വയമേവ DuckAssist കാണിക്കുന്നു. DuckAssist-ന് "
+"അജ്ഞാതമായി തിരയാനും ചില തിരയലുകൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
+"കഴിയും. ഇപ്പോൾ, ഇംഗ്ലീഷ് പ്രദേശങ്ങളിൽ മാത്രമേ DuckAssist ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
 msgstr ""
-"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ സ്വയമേവ പ്ലേ ചെയ്യുക."
+"വീഡിയോ ഫലങ്ങളിൽ ഹോവർ ചെയ്യുമ്പോൾ ചെറുതും നിശബ്‌ദവുമായ വീഡിയോ പ്രിവ്യൂകൾ "
+"സ്വയമേവ പ്ലേ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2779,7 +2802,9 @@ msgstr "ശരാശരി വോളിയം"
 #. Warning text shown below the chat input when the user has attached files, advising them not to upload files from untrusted sources.
 msgctxt "Disclaimer below chat input in Duck.ai when files are attached"
 msgid "Avoid uploading files from sources you don't trust."
-msgstr "നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് ഒഴിവാക്കുക."
+msgstr ""
+"നിങ്ങൾ വിശ്വസിക്കാത്ത ഉറവിടങ്ങളിൽ നിന്ന് ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുന്നത് "
+"ഒഴിവാക്കുക."
 
 # smartling.placeholder_format=C
 #. Indicates the Win-Loss record of a team when playing away
@@ -2947,8 +2972,9 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ "
-"എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo "
+"നിങ്ങളുടെ സംഭാഷണം അജ്ഞാതമാക്കും."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2961,6 +2987,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"ഈ റിപ്പോർട്ട് സൂക്ഷിക്കുന്നതിന് മുമ്പ്, DuckDuckGo അപ്‌ലോഡ് ചെയ്ത ഫയലുകളും "
+"സൃഷ്ടിച്ച ചിത്രങ്ങളും നീക്കം ചെയ്യുകയും, പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, "
+"തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII നീക്കം ചെയ്തുകൊണ്ട് നിങ്ങളുടെ "
+"സംഭാഷണം അജ്ഞാതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3090,8 +3120,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ വഴി "
-"കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
+"ഉപദ്രവകരമായ സൈറ്റുകൾ തടയുക, നിങ്ങളുടെ IP വിലാസം മറയ്ക്കുക, കൂടാതെ ഞങ്ങളുടെ "
+"സബ്സ്ക്രിപ്ഷൻ വഴി കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3351,18 +3381,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"ഞങ്ങൾ സ്വകാര്യത പരിരക്ഷണം ചേർക്കുമ്പോൾ പതിവുപോലെ ബ്രൗസ് ചെയ്യുക. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, "
-"ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ "
-"ഒരുമിച്ചുചേർത്തു."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. ഞങ്ങളുടെ "
+"തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ എന്നിവ ഒറ്റ %1$s%2$s "
+"വിപുലീകരണത്തിലേക്ക്%3$s ഞങ്ങൾ ഒരുമിച്ചുചേർത്തു."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3370,9 +3400,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. %1$sപ്രധാന "
-"ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ "
-"മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
+"സാധാരണപോലെ ബ്രൗസ് ചെയ്യുക, ബാക്കി കാര്യങ്ങൾ ഞങ്ങൾ നോക്കിക്കൊള്ളാം. "
+"%1$sപ്രധാന ബ്രൗസറുകൾക്കായുള്ള%2$s private search, ട്രാക്കർ ബ്ലോക്കിംഗ്, "
+"സൈറ്റ് എൻക്രിപ്ഷൻ എന്നിവ മൊത്തത്തിൽ ഒറ്റ ഡൗൺലോഡിൽ നേടുക."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3458,7 +3488,9 @@ msgstr "'%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നി�
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "By clicking “%s,” you accept Duck.ai’s %s and %s."
-msgstr "“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം അംഗീകരിക്കുന്നു."
+msgstr ""
+"“%1$s” ക്ലിക്ക് ചെയ്യുന്നതിലൂടെ നീ Duck.ai-യുടെ %2$s ഉം %3$s ഉം "
+"അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3479,10 +3511,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), ക്രമീകരണം "
-"സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ "
-"ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി "
-"തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
+"സ്വതവേ, വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലാണ് (നിങ്ങളുടെ ബ്രൗസറിൽ), "
+"ക്രമീകരണം സൂക്ഷിച്ചിരിക്കുന്നത്. നിങ്ങളുടെ ക്രമീകരണം കൂടുതൽ സ്ഥിരമായ ഒരു "
+"വിധത്തിൽ സംഭരിക്കാൻ (ക്ലൗഡിലെ ഒരു റിമോട്ട് സെർവറിൽ), നിങ്ങൾക്ക് അജ്ഞാത "
+"Cloud Save ഉപയോഗിക്കാൻ കഴിയും. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
+"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും "
 "നിങ്ങളുടെ ബ്രൗസറിൽ നിന്ന് പുറത്തുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -3491,8 +3524,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ ശബ്ദ ഡാറ്റ "
-"OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
+"ഡിക്ടേഷന്‍ പ്രവര്‍ത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ ശബ്ദ ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3501,9 +3535,9 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി നിങ്ങളുടെ വോയ്സ് "
-"ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s "
-"കാണൂ."
+"വോയ്സ് ചാറ്റ് പ്രവർത്തനക്ഷമമാക്കുന്നതിലൂടെ, ഈ സവിശേഷത ഉപയോഗിക്കുന്നതിനായി "
+"നിങ്ങളുടെ വോയ്സ് ഡാറ്റ OpenAI-ലേക്ക് അയയ്ക്കുന്നതിന് നിങ്ങൾ സമ്മതം നൽകുന്നു. "
+"ആരംഭിക്കുന്നതിന് മുമ്പ് ഞങ്ങളുടെ %1$s കാണൂ."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3539,8 +3573,8 @@ msgstr "കാമറൂൺ"
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
 msgstr ""
-"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ പാചകക്കുറിപ്പുകൾ "
-"സൃഷ്ടിക്കാൻ കഴിയുമോ?"
+"കോഴിയിറച്ചി, ബ്രോക്കോളി, അരി എന്നിവ ഉപയോഗിച്ച് നിങ്ങൾക്ക് ഏതാനും ലളിതമായ "
+"പാചകക്കുറിപ്പുകൾ സൃഷ്ടിക്കാൻ കഴിയുമോ?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3856,7 +3890,8 @@ msgstr "ഫലങ്ങളുടെ URL-കൾ എങ്ങനെ പ്രദ�
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
 msgstr ""
-"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ പെരുമാറ്റവും മാറുന്നു"
+"നിങ്ങൾ സ്ക്രോൾ ചെയ്യുമ്പോൾ ശീർഷകം എങ്ങനെ പ്രദർശിപ്പിക്കുന്നു എന്നതും അതിന്റെ "
+"പെരുമാറ്റവും മാറുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3875,13 +3910,17 @@ msgstr "മുഴുവൻ സൈറ്റിലും പശ്ചാത്ത�
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം മാറ്റുന്നു"
+msgstr ""
+"ഹോവർ, മൊഡ്യൂളുകൾ, ഡ്രോപ്പ്ഡൗൺ മെനുകൾ എന്നിവയിലെ ഫലങ്ങളുടെ പശ്ചാത്തല നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
 msgctxt "settings"
 msgid "Changes the background color when hovering over a result"
-msgstr "ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം മാറ്റുന്നു"
+msgstr ""
+"ഫലങ്ങളുടെ മുകളില്‍ കൂടി മൗസ് ചലിപ്പിക്കുമ്പോള്‍ പശ്ചാത്തലത്തിന്റെ നിറം "
+"മാറ്റുന്നു"
 
 # smartling.placeholder_format=C
 #. Description of a setting managing the color of search result snippet text.
@@ -4004,10 +4043,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ ചാറ്റ് (Duck.ai "
-"സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. "
-"ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. "
-"എന്നിരുന്നാലും, %1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
+"നിങ്ങൾക്ക് മൂന്നാം കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ "
+"ചാറ്റ് (Duck.ai സേവനം വഴി) നിങ്ങളെ അനുവദിക്കുന്നു, ഇത് OpenAI, Anthropic "
+"തുടങ്ങിയ മോഡലുകളെ പിന്തുണയ്ക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo "
+"Search-ൽ ചാറ്റ് ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, "
+"%1$shttps://duck.ai%2$s സന്ദർശിച്ച് ഈ ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോഴും "
 "നിങ്ങൾക്ക് ചാറ്റ് ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
@@ -4064,8 +4104,8 @@ msgstr "സ്വകാര്യമായി ചാറ്റ് ചെയ്യ�
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ തന്നെയുള്ള Duck.ai ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4073,8 +4113,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും സ്വകാര്യമായി ചാറ്റ് "
-"ചെയ്യുക."
+"ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിലെ Duck.ai സൈഡ്‌ബാർ ഉപയോഗിച്ച് ഏത് വെബ്‌സൈറ്റിലും "
+"സ്വകാര്യമായി ചാറ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4156,8 +4196,8 @@ msgid ""
 "Nobody but you can see your data, not even us."
 msgstr ""
 "ചാറ്റുകൾ DuckDuckGo-യുടെ സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സുരക്ഷിതമായി "
-"സംഭരിച്ചിരിക്കുന്നു. നിങ്ങൾക്കല്ലാതെ മറ്റാർക്കും നിങ്ങളുടെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് "
-"പോലും."
+"സംഭരിച്ചിരിക്കുന്നു. നിങ്ങൾക്കല്ലാതെ മറ്റാർക്കും നിങ്ങളുടെ ഡാറ്റ കാണാൻ "
+"കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4166,9 +4206,9 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത "
-"ചാറ്റുകൾ നീക്കം ചെയ്യും."
+"ചാറ്റുകൾ DuckDuckGo സെർവറുകളിലോ വിദൂര സെർവറുകളിലോ സംഭരിക്കുന്നതിന് പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിക്കുന്നു. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്ത ചാറ്റുകൾ നീക്കം ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4180,11 +4220,13 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും "
-"അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് "
-"നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും "
-"പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
+"ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിക്കപ്പെടുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4207,8 +4249,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ അപ്‌ലോഡ് ചെയ്യുന്ന "
-"എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് അജ്ഞാതമായി പരിശോധിക്കുന്നു."
+"%1$s ഉപയോഗിച്ചുള്ള ചാറ്റുകൾക്ക് ദാതാവിന്റെ ദൃശ്യപരതയില്ല, എന്നാൽ Duck.ai-ൽ "
+"അപ്‌ലോഡ് ചെയ്യുന്ന എല്ലാ ഫയലുകളും %2$s-നായി ഒരു ഉള്ളടക്ക മോഡറേഷൻ ദാതാവ് "
+"അജ്ഞാതമായി പരിശോധിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4216,8 +4259,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. സമന്വയം പുനരാരംഭിക്കാൻ "
-"സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
+"അറ്റാച്ചുമെന്റുകളുള്ള ചാറ്റുകൾ സമന്വയിപ്പിക്കുന്നത് നിർത്തിയിരിക്കുന്നു. "
+"സമന്വയം പുനരാരംഭിക്കാൻ സംഭരണ സ്ഥലം ശൂന്യമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4270,7 +4313,9 @@ msgstr "സ്പെല്ലിംഗ് പരിശോധിക്കുക"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് പരിശോധിക്കുക."
+msgstr ""
+"ഈ തടസ്സത്തിനെക്കുറിച്ചുള്ള അപ്ഡേറ്റുകൾക്കായി DuckDuckGo സബ് റെഡ്ഡിറ്റ് "
+"പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4341,7 +4386,9 @@ msgstr "%1$s , %2$s എന്നിവ ഉൾപ്പെടെ AI മോഡല�
 # smartling.placeholder_format=C
 #. As in 'Choose to keep DuckDuckGo as your default search engine'. Placeholders are for markup, you can ignore them.
 msgid "Choose %skeep it%s to continue protecting your privacy."
-msgstr "നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s തിരഞ്ഞെടുക്കുക."
+msgstr ""
+"നിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നത് തുടരാൻ %1$sനിലനിർത്തുക%2$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -4373,8 +4420,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം സെർവർ "
-"ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
+"ഉപദ്രവകരമായ സൈറ്റുകളെയും തട്ടിപ്പുകളെയും തടയാൻ ലോകമെമ്പാടുമുള്ള 40-ലധികം "
+"സെർവർ ലൊക്കേഷനുകളിൽ നിന്ന് തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4392,8 +4439,8 @@ msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
 msgstr ""
-"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് ആപ്പ് "
-"ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
+"നിങ്ങൾക്ക് ഒരു ലൊക്കേഷൻ തിരയൽ ഫലത്തിനായി നിർദ്ദേശങ്ങൾ ആവശ്യമുള്ളപ്പോൾ ഏത് "
+"ആപ്പ് ഉപയോഗിക്കണമെന്ന് തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4574,9 +4621,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ നടന്ന ചാറ്റുകൾ "
-"അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി "
-"ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് ചാറ്റുകൾ ഇല്ലാതാക്കും. ചില ബ്രൗസറുകൾ അടുത്തിടെ "
+"നടന്ന ചാറ്റുകൾ അനിശ്ചിതകാലം സൂക്ഷിക്കുകയോ AI Chat ഉപയോഗം ഇല്ലാത്ത 7 "
+"ദിവസങ്ങൾക്ക് ശേഷം യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്തേക്കാം."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4586,9 +4633,10 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ Duck.ai "
-"ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ "
-"ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ ആശ്രയിച്ചിരിക്കുന്നു."
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് സമീപകാല ചാറ്റുകൾ ഇല്ലാതാക്കും. സമീപകാല ചാറ്റുകൾ "
+"Duck.ai ഉപയോഗിക്കാതെ 7 ദിവസത്തിനുശേഷം അനിശ്ചിതകാലം സൂക്ഷിക്കപ്പെടുകയോ "
+"യാന്ത്രികമായി ഇല്ലാതാക്കുകയോ ചെയ്യാം. നിങ്ങളുടെ ബ്രൗസറിനെ "
+"ആശ്രയിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4597,8 +4645,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് "
-"ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
+"ബ്രൗസർ ഡാറ്റ മായ്ക്കുന്നത് നിങ്ങൾ തടഞ്ഞ സൈറ്റുകളെ റീസെറ്റ് ചെയ്യും. "
+"നിങ്ങളുടെ ബ്ലോക്ക് ലിസ്റ്റ് ശാശ്വതമായി ഞങ്ങളുടെ സൗജന്യ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4607,9 +4655,10 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ %1$sDuck.ai%2$s "
-"വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
-"പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI ചാറ്റ് സേവനം."
+"ഒരു വിഷയത്തിൽ കൂടുതൽ ആഴത്തിൽ പോകാൻ \"കൂടുതൽ\" ക്ലിക്ക് ചെയ്യുക, കൂടാതെ "
+"%1$sDuck.ai%2$s വഴി ഫോളോ-അപ്പ് ചോദ്യങ്ങൾ ചോദിക്കൂ OpenAI, Anthropic "
+"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഞങ്ങളുടെ സ്വകാര്യ AI "
+"ചാറ്റ് സേവനം."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4668,7 +4717,9 @@ msgstr "DuckDuckGo എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ച�
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo Safari എക്സ്റ്റൻഷൻ ഡൗൺലോഡ് ചെയ്യാൻ %1$sതുറക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4685,8 +4736,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ വലതുവശത്തുള്ള "
-"%3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
+"മുകളിലെ മെനുവിലെ %1$sSafari%2$s ക്ലിക്ക് ചെയ്യുക (Windows-ൽ, മുകളിൽ "
+"വലതുവശത്തുള്ള %3$sഗിയേഴ്സ് ഐക്കൺ%4$s ക്ലിക്ക് ചെയ്യുക)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4704,7 +4755,8 @@ msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sക്രമീകരണം%
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
 msgstr ""
-"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി ക്ലിക്ക് ചെയ്യുക%4$s."
+"%1$sനിലവിലുള്ള പേജുകൾ ഉപയോഗിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %3$sശരി "
+"ക്ലിക്ക് ചെയ്യുക%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4717,7 +4769,8 @@ msgstr "%1$sഉവ്വ്%2$s ക്ലിക്ക് ചെയ്യുക"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് ചെയ്യുക."
+"(മുകളിൽ വലത്), Chrome ടൂൾബാറിലെ %1$sക്രമീകരണം/ഹാംബർഗർ ഐക്കൺ %2$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4779,9 +4832,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s "
-"ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎൻ്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ തിരയൽ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4792,9 +4846,10 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. ഇത് ക്ലൗഡിൽ നിന്ന് "
-"ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/"
-"ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
+"%1$sഎന്റെ ഡാറ്റ ഇല്ലാതാക്കുക%2$s ക്ലിക്ക് ചെയ്യുക അല്ലെങ്കിൽ ടാപ്പ് ചെയ്യുക. "
+"ഇത് ക്ലൗഡിൽ നിന്ന് ഡാറ്റ നീക്കംചെയ്യുന്നു, എന്നാൽ നിങ്ങൾ %3$sഎല്ലാ "
+"ക്രമീകരണവും പുനഃക്രമീകരിക്കുക%4$s ക്ലിക്ക്/ടാപ്പ് ചെയ്യുന്നതുവരെ ഇത് "
+"നിങ്ങളുടെ ബ്രൗസറിൽ തുടരും."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4863,8 +4918,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ "
-"ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
+"%1$sവിലാസ ബാറിൽ ഉപയോഗിച്ചിരിക്കുന്ന തിരയൽ എഞ്ചിന്%2$s സമീപമുള്ള ഡ്രോപ്പ്ഡൗൺ "
+"മെനുവിൽ ക്ലിക്ക് ചെയ്ത്, %3$sDuckDuckGo%4$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4872,8 +4927,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ ബ്രൗസറിന്റെ "
-"മുകളിൽ വലത് കോണിലായിരിക്കും."
+"Ad blocker എക്സ്റ്റൻഷന്റെ ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക. ഇത് സാധാരണയായി നിങ്ങളുടെ "
+"ബ്രൗസറിന്റെ മുകളിൽ വലത് കോണിലായിരിക്കും."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5074,8 +5129,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി സംരക്ഷിക്കാൻ അനുവദിക്കും. "
-"ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
+"Cloud Save പാസ്‌ഫ്രെയ്സ് നൽകുക വഴി നിങ്ങളുടെ ക്രമീകരണം സ്ഥിരമായി "
+"സംരക്ഷിക്കാൻ അനുവദിക്കും. ഇത് തീർത്തും ഓപ്ഷണല്‍ ആണ്."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5346,7 +5401,9 @@ msgstr "പരസ്യങ്ങൾ തടയുന്നത് തുടരു�
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ ഇല്ലാതാക്കുക."
+msgstr ""
+"സമീപകാല ചാറ്റുകൾ ഇവിടെ തുടരുക. അല്ലെങ്കിൽ Fire Button ഉപയോഗിച്ച് അവ "
+"ഇല്ലാതാക്കുക."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5529,8 +5586,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ › Sync & "
-"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി വീണ്ടും ശ്രമിക്കുക."
+"മറ്റൊരു ഉപകരണത്തിൽ നിന്ന് കോഡ് പകർത്തുക. %1$sDuck.ai ക്രമീകരണങ്ങൾ › ചാറ്റുകൾ "
+"› Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%2$s എന്നതിലേക്ക് പോയി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5588,7 +5646,9 @@ msgstr "കോസ്റ്റാ റിക്ക"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും ശ്രമിക്കു."
+msgstr ""
+"നിങ്ങളുടെ റിക്കവറി കോഡ് ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി ഇത് അടച്ച് വീണ്ടും "
+"ശ്രമിക്കു."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5695,7 +5755,8 @@ msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
 msgstr ""
-"ലിങ്ക് തുറക്കുന്ന ആർക്കും കാണാനും സംരക്ഷിക്കാനും കഴിയുന്ന ചാറ്റിന്റെ ഒരു പകർപ്പ് സൃഷ്ടിക്കുന്നു."
+"ലിങ്ക് തുറക്കുന്ന ആർക്കും കാണാനും സംരക്ഷിക്കാനും കഴിയുന്ന ചാറ്റിന്റെ ഒരു "
+"പകർപ്പ് സൃഷ്ടിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5704,8 +5765,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് തുറക്കുന്ന ആർക്കും അത് കാണാൻ "
-"കഴിയും."
+"ഒരു ലിങ്ക് നിർമ്മിക്കുന്നത് ചാറ്റിന്റെ ഒരു പകർപ്പ് ഉണ്ടാക്കുന്നു, അത് "
+"തുറക്കുന്ന ആർക്കും അത് കാണാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5950,7 +6011,9 @@ msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞ
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
-msgstr "ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"ദൈനംദിന ഉപയോഗ പരിധി കവിഞ്ഞു. നിങ്ങൾക്ക് പ്രതിവാര പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6232,7 +6295,9 @@ msgstr "സംഭരണ സ്ഥലം ശൂന്യമാക്കാൻ ഏ
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കണോ?"
+msgstr ""
+"സ്റ്റോറേജ് ഒഴിവാക്കാൻ അറ്റാച്ച്മെന്റുകളുള്ള ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കണോ?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6267,8 +6332,9 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് തങ്ങളുടെ ചാറ്റുകളിലേക്ക് "
-"സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം പകർപ്പ് ഉണ്ടായിരിക്കും."
+"ഒരു ലിങ്ക് ഇല്ലാതാക്കുന്നത് അത് പ്രവർത്തിക്കുന്നത് തടയുന്നു. ഇത് തുറന്ന് "
+"തങ്ങളുടെ ചാറ്റുകളിലേക്ക് സംഭാഷണം ചേർത്ത ആളുകളുടെ പക്കൽ അവരുടെ സ്വന്തം "
+"പകർപ്പ് ഉണ്ടായിരിക്കും."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6365,8 +6431,8 @@ msgstr "Duck.ai-യിലെ ഡിക്റ്റേഷൻ"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിക്കാറില്ല."
+"ഡിക്റ്റേഷൻ നമ്മൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, മാത്രമല്ല AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6384,8 +6450,9 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ ഉപയോഗിക്കുന്നു, "
-"അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് ചെയ്യാൻ സാധിക്കും."
+"നിങ്ങളുടെ സംസാരം ടെക്സ്റ്റാക്കി മാറ്റുന്നതിനായി ഡിക്റ്റേഷൻ ഒരു OpenAI മോഡൽ "
+"ഉപയോഗിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് ടൈപ്പ് ചെയ്യാതെ തന്നെ Duck.ai-യിൽ ചാറ്റ് "
+"ചെയ്യാൻ സാധിക്കും."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6518,7 +6585,7 @@ msgstr "ഉറവിടം ഇഷ്ടമല്ല"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "ദൃശ്യ ശൈലി ഇഷ്ടപ്പെട്ടില്ല"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6634,7 +6701,7 @@ msgstr "ജിബൂട്ടി"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "നിർദ്ദേശങ്ങൾ പാലിക്കുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6684,7 +6751,9 @@ msgstr "പട്ടികയിൽ DuckDuckGo കാണുന്നില്ല
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് ചെയ്യുക%4$s"
+msgstr ""
+"അത് കാണുന്നില്ലേ? %1$s%2$s%3$sവീണ്ടും ഡൗൺലോഡ് ചെയ്യാൻ ഇവിടെ ക്ലിക്ക് "
+"ചെയ്യുക%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6722,8 +6791,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI ചിത്രങ്ങൾ "
-"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
+"AI വേണ്ടേ? %1$snoai.duckduckgo.com%2$s AI ഫീച്ചറുകളൊന്നും നൽകുന്നില്ല, AI "
+"ചിത്രങ്ങൾ ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കിയിരിക്കുന്നു. %3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6849,8 +6918,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടറിന് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"സീലിംഗ് ഫാൻ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു "
+"വെണ്ടറിന് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6859,8 +6928,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് "
-"സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
+"വീട്ടിലെ റഫ്രിജറേറ്റർ അറ്റകുറ്റപ്പണി സേവനങ്ങൾക്കായി ഒരു ക്വൊട്ടേഷൻ "
+"അഭ്യർത്ഥിച്ച് ഒരു വെണ്ടർക്ക് സംക്ഷിപ്തവും വിശദവുമായ ഒരു ഇമെയിൽ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6881,8 +6950,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ പോസ്റ്റിന് കുറച്ച് "
-"ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
+"എന്റെ വരാനിരിക്കുന്ന പാർട്ടിയിലേക്ക് ആളുകളെ ക്ഷണിക്കുന്ന ഒരു സോഷ്യൽ മീഡിയ "
+"പോസ്റ്റിന് കുറച്ച് ഓപ്ഷനുകൾ ഡ്രാഫ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6891,8 +6960,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു പോസ്റ്റിന്റെ "
-"തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
+"ടീം സഹകരണം വർദ്ധിപ്പിക്കുന്നതിനുള്ള തന്ത്രങ്ങളെക്കുറിച്ച് ഞാൻ എഴുതുന്ന ഒരു "
+"പോസ്റ്റിന്റെ തലക്കെട്ടിനായി കുറച്ച് ഓപ്ഷനുകൾ തയ്യാറാക്കുക."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6962,7 +7031,9 @@ msgstr "നിങ്ങളുടെ ഫോട്ടോകളോ PDF ഫയലു
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ അനുവദിക്കുന്നു"
+msgstr ""
+"ലക്ഷ്യമിട്ടുള്ള പരസ്യങ്ങളില്ലാതെ YouTube കാണാൻ Duck Player നിങ്ങളെ "
+"അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7024,9 +7095,10 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് ഉത്തരം നൽകാൻ "
-"സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ നിങ്ങൾ "
-"തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
+"നിങ്ങൾ കാണുന്ന പേജിനെക്കുറിച്ചുള്ള ചോദ്യങ്ങൾക്ക് ഇപ്പോൾ Duck.ai-യ്ക്ക് "
+"ഉത്തരം നൽകാൻ സഹായിക്കാനാവും. ക്രമീകരണങ്ങളിൽ പേജുകൾ സ്വയമേവ അറ്റാച്ച് ചെയ്യാൻ "
+"നിങ്ങൾ തിരഞ്ഞെടുക്കുന്നില്ലെങ്കിൽ മാത്രമേ അത് അറ്റാച്ചുചെയ്യുമ്പോൾ പേജ് "
+"ഉള്ളടക്കം ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7036,9 +7108,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. "
-"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ "
-"ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ സംരക്ഷിക്കാനായി Duck.ai-ക്ക് ലോക്കൽ സ്റ്റോറേജ് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുകയോ ഏതെങ്കിലും "
+"എക്സ്റ്റൻഷനുകൾ പ്രവർത്തനരഹിതമാക്കുകയോ ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7047,14 +7119,16 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ Duck.ai എത്തിച്ചേർന്നു. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും മികച്ചത്!"
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ DuckDuckGo ബ്രൗസറിൽ Duck.ai ആണ് ഏറ്റവും "
+"മികച്ചത്!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7064,8 +7138,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ നിയന്ത്രണം തിരികെ "
-"നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
+"Duck.ai നിർമ്മിച്ചത് DuckDuckGo ആണ്. തങ്ങളുടെ സ്വകാര്യ വിവരങ്ങളുടെ "
+"നിയന്ത്രണം തിരികെ നേടാൻ ആഗ്രഹിക്കുന്ന ഏതൊരാൾക്കും വേണ്ടിയുള്ള ഒരു സ്വതന്ത്ര "
+"ഓൺലൈൻ സംരക്ഷണ കമ്പനിയാണ് ഞങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7080,8 +7155,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ എളുപ്പമുള്ള ഒരു "
-"വിലാസം ലഭിക്കും: https://duck.ai"
+"Duck.ai ഇപ്പോഴും ഒരു DuckDuckGo ഉൽപ്പന്നമാണ്, പക്ഷേ ഇനി വെബിൽ ഓർമ്മിക്കാൻ "
+"എളുപ്പമുള്ള ഒരു വിലാസം ലഭിക്കും: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7096,8 +7171,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s അജ്ഞാത കോഡ് "
-"%2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"Duck.ai താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ %1$s "
+"അജ്ഞാത കോഡ് %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7118,9 +7193,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും "
-"%1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
+"ജനപ്രിയ AI മോഡലുകളുമായി സ്വകാര്യമായി ചാറ്റ് ചെയ്യാൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഇത് പ്രവർത്തനരഹിതമാക്കുന്നത് Duck.ai ബട്ടണുകളും ലിങ്കുകളും "
+"മറയ്ക്കും, എന്നാൽ നിങ്ങൾക്ക് ഇപ്പോഴും %1$sduck.ai%2$s സന്ദർശിക്കാം നേരിട്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7131,11 +7206,12 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം കക്ഷി AI ചാറ്റ് "
-"മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ അനുവദിക്കുന്നു. ഈ ക്രമീകരണം "
-"ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ "
-"ക്രമീകരണം ഓഫ് ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai "
-"ആക്സസ് ചെയ്യാൻ കഴിയും. നേരിട്ട്."
+"OpenAI, Anthropic, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകൾ ഉൾപ്പെടെ മൂന്നാം "
+"കക്ഷി AI ചാറ്റ് മോഡലുകളുമായി അജ്ഞാത സംഭാഷണങ്ങൾ നടത്താൻ Duck.ai നിങ്ങളെ "
+"അനുവദിക്കുന്നു. ഈ ക്രമീകരണം ഓഫാക്കുന്നത് DuckDuckGo Search-ലെ Duck.ai "
+"ബട്ടണുകളും ലിങ്കുകളും മറയ്ക്കും. എന്നിരുന്നാലും, ഈ ക്രമീകരണം ഓഫ് "
+"ആയിരിക്കുമ്പോൾ %1$shttps://duck.ai%2$s സന്ദർശിച്ച് നിങ്ങൾക്ക് Duck.ai ആക്സസ് "
+"ചെയ്യാൻ കഴിയും. നേരിട്ട്."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7150,15 +7226,16 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. നിങ്ങൾക്ക് ഇപ്പോഴും "
-"പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
+"Duck.ai-ക്ക് നിങ്ങളുടെ അടുത്തിടെ നടന്ന ചാറ്റുകൾ നഷ്ടപ്പെട്ടിരിക്കാം. "
+"നിങ്ങൾക്ക് ഇപ്പോഴും പതിവുപോലെ Duck.ai ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
 msgstr ""
-"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് പരീക്ഷിച്ചു നോക്കൂ!"
+"Duck.ai-ക്ക് ഇപ്പോൾ PDF-കൾ വായിക്കാനും വിശകലനം ചെയ്യാനും കഴിയും. ഒന്ന് "
+"പരീക്ഷിച്ചു നോക്കൂ!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7166,14 +7243,16 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ കൃത്യതയ്ക്കായി "
-"പരിശോധിച്ചിട്ടുമില്ല."
+"Duck.ai പ്രതികരണങ്ങൾ പ്രത്യേക ഉറവിടങ്ങളെ അടിസ്ഥാനമാക്കിയുള്ളതല്ല, അല്ലെങ്കിൽ "
+"കൃത്യതയ്ക്കായി പരിശോധിച്ചിട്ടുമില്ല."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Duck.ai supports models from Anthropic, OpenAI, and others."
-msgstr "Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai പിന്തുണയ്ക്കുന്നു."
+msgstr ""
+"Anthropic, OpenAI, കൂടാതെ മറ്റുള്ളവയിൽ നിന്നുമുള്ള മോഡലുകളെ Duck.ai "
+"പിന്തുണയ്ക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Title shown when native app needs to reload for service update.
@@ -7192,8 +7271,8 @@ msgstr "Duck.ai അപ്ഗ്രേഡ് ചെയ്തു!"
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
 msgstr ""
-"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും സൗജന്യവുമായ "
-"DuckDuckGo ആപ്പിലാണ്!"
+"Duck.ai ഏറ്റവും മികച്ച രീതിയിൽ പ്രവർത്തിക്കുന്നത് ഞങ്ങളുടെ സ്വകാര്യവും "
+"സൗജന്യവുമായ DuckDuckGo ആപ്പിലാണ്!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7203,9 +7282,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത AI ചാറ്റ്, "
-"സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI "
-"മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
+"Duck.ai, DuckDuckGo AI, സ്വകാര്യ AI ചാറ്റ്ബോട്ട്, സൗജന്യ AI ചാറ്റ്, അജ്ഞാത "
+"AI ചാറ്റ്, സൈൻ അപ്പ് ആവശ്യമില്ലാത്ത AI ചാറ്റ്, OpenAI, ആന്ത്രോപിക്, ലാമ, "
+"മിസ്ട്രൽ, ഓപ്പൺ സോഴ്‌സ് AI മോഡലുകൾ, സ്വകാര്യത കേന്ദ്രീകരിച്ചുള്ള AI, "
+"അക്കൗണ്ടില്ലാത്ത AI ചാറ്റ്"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7233,11 +7313,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ സംഗ്രഹിക്കാനും "
-"കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: "
-"ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-"
-"ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ "
-"പ്രസക്തമാകുമ്പോൾ മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
+"DuckAssist-ന് അജ്ഞാതമായി തിരയാനും ചില search-കൾക്ക് മറുപടിയായി വിവരങ്ങൾ "
+"സംഗ്രഹിക്കാനും കഴിയും. DuckAssist എത്ര തവണ ദൃശ്യമാകാൻ ആഗ്രഹിക്കുന്നുവെന്ന് "
+"നിങ്ങൾക്ക് തിരഞ്ഞെടുക്കാം: ഒരിക്കലുമില്ല (Search ഫലങ്ങളിൽ നിന്ന് DuckAssist "
+"UI പൂർണ്ണമായും നീക്കംചെയ്യുന്നു), ഓൺ-ഡിമാൻഡ് (നിങ്ങൾ അസിസ്റ്റ് ബട്ടൺ "
+"ക്ലിക്ക് ചെയ്താൽ മാത്രം കാണിക്കുന്നു), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ "
+"മാത്രം കാണിക്കുക), ഇടയ്ക്കിടെ (വിശാലമായ Search-കളിൽ കൂടുതൽ പതിവായി "
 "കാണിക്കുന്നു). ഇപ്പോൾ, DuckAssist യുഎസ് (ഇംഗ്ലീഷ്) മേഖലയിൽ മാത്രമേ ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
@@ -7247,9 +7328,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"%1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic തുടങ്ങിയവയിൽ "
-"നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ %1$sDuckDuckGo AI Chat%2$s വാഗ്ദാനം ചെയ്യുന്നു, ഇത് "
+"OpenAI, Anthropic തുടങ്ങിയവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന "
+"ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7258,9 +7340,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, എന്നിരുന്നാലും, ഞങ്ങൾ "
-"DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം ചെയ്യുന്നു, ഇത് OpenAI, Anthropic "
-"എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
+"DuckAssist-ന് ഫോളോ-അപ്പ് ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാൻ കഴിയില്ല, "
+"എന്നിരുന്നാലും, ഞങ്ങൾ DuckDuckGo %1$sAI Chat%2$s എന്നിവയും വാഗ്ദാനം "
+"ചെയ്യുന്നു, ഇത് OpenAI, Anthropic എന്നിവയിൽ നിന്നുള്ള ചാറ്റ് മോഡലുകളെ "
+"പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI-പിന്തുണയുള്ള ചാറ്റ് സേവനമാണ്."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7272,12 +7355,13 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ അന്വേഷണങ്ങൾക്ക് "
-"അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി "
-"വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം "
-"സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ "
-"പ്രതികരണങ്ങൾ നിലവിൽ വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും "
-"കൃത്യത പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
+"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇതിനായി, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി വിക്കിപീഡിയയെയും അനുബന്ധ സൈറ്റുകളെയും സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് ആ വിവരങ്ങളുടെ സംഗ്രഹം സൃഷ്ടിക്കാൻ AI-പിന്തുണയുള്ള സ്വാഭാവിക ഭാഷാ "
+"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. അതിന്റെ പ്രതികരണങ്ങൾ നിലവിൽ "
+"വിക്കിപീഡിയയെയും അനുബന്ധ ഉള്ളടക്കത്തെയും അടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും കൃത്യത "
+"പരിശോധിച്ചിട്ടില്ലെന്നതും ശ്രദ്ധിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7291,14 +7375,16 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് തിരയൽ "
-"അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ "
-"ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ "
-"അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ "
-"സാങ്കേതികവിദ്യ ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ രണ്ടോ "
-"ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ "
-"നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് "
-"പ്രതികരണങ്ങൾ സ്വയം സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
+"ഞങ്ങളുടെ തിരയൽ ഫലങ്ങളിലെ ഒരു പുതിയ ഓപ്ഷണൽ സവിശേഷതയാണ് DuckAssist, അതിന് "
+"തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കാൻ കഴിയും. ഇത് "
+"ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് കണ്ടെത്തിയ പ്രസക്തമായ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി ഒരു ഹ്രസ്വമായ ഉത്തരം "
+"സൃഷ്ടിക്കുന്നതിന് AI- പിന്തുണയ്ക്കുന്ന സ്വഭാവിക ഭാഷ സാങ്കേതികവിദ്യ "
+"ഉപയോഗിക്കുകയും ചെയ്യുന്നു. DuckAssist പ്രതികരണങ്ങൾ എല്ലായ്പ്പോഴും ഒന്നോ "
+"രണ്ടോ ഉറവിടങ്ങളിലേക്ക് നേരിട്ട് ലിങ്ക് ചെയ്യുന്നു, ഉത്തരം എവിടെ നിന്ന് "
+"വന്നുവെന്ന് ഉദ്ധരിക്കുന്നു, അതിനാൽ നിങ്ങൾക്ക് എളുപ്പത്തിൽ കൂടുതൽ വിശദമായ "
+"വിവരങ്ങൾ നേടാനാവും. ഉദ്ധരിച്ച ഉറവിടങ്ങളിൽ നിന്ന് പ്രതികരണങ്ങൾ സ്വയം "
+"സൃഷ്ടിക്കപ്പെട്ടതാണെന്നും%2$s വെബ് ക്രൗളിങ്ങിനെ "
 "%1$sഅടിസ്ഥാനമാക്കിയുള്ളതാണെന്നും ഓർമ്മിക്കേണ്ടത് പ്രധാനമാണ്."
 
 # smartling.placeholder_format=C
@@ -7317,8 +7403,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. ദയവായി നാളെ ഈ "
-"ചാറ്റ് തുടരുക."
+"DuckDuckGo AI Chat ഒരു ദിവസത്തേക്ക് പരമാവധി മെസേജുകള് എത്തിയിട്ടുണ്ട്. "
+"ദയവായി നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7327,8 +7413,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7337,8 +7423,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു സ്വകാര്യ AI "
-"പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
+"നിലവിൽ %1$sന്റെ %2$s, %3$sന്റെ %4$s ചാറ്റ് മോഡലുകളെ പിന്തുണയ്ക്കുന്ന ഒരു "
+"സ്വകാര്യ AI പ്രവർത്തിപ്പിക്കുന്ന ചാറ്റ് സേവനമാണ് DuckDuckGo AI Chat."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7347,8 +7433,8 @@ msgid ""
 "DuckDuckGo AI Chat is in Beta, it may display inaccurate or offensive "
 "information."
 msgstr ""
-"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
-"പ്രദർശിപ്പിച്ചേക്കാം."
+"DuckDuckGo AI Chat ബീറ്റയിലാണുള്ളത്, ഇത് കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
+"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat making it unavailable, and asking the user to send an email with a specific code if the error persists. E.g. 'DuckDuckGo AI Chat is temporarily unavailable. If this persists, please email this anonymous code abcdefg12345 to aichat-error@duckduckgo.com'
@@ -7357,8 +7443,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി ഈ "
-"അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
+"DuckDuckGo AI Chat താൽക്കാലികമായി ലഭ്യമല്ല. ഇത് നിലനിൽക്കുകയാണെങ്കിൽ, ദയവായി "
+"ഈ അജ്ഞാത കോഡ് %1$s %2$s എന്നതിലേക്ക് ഇമെയിൽ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7522,8 +7608,9 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ പോലുള്ള PII "
-"സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ അജ്ഞാതമാക്കുന്നു."
+"പേരുകൾ, ഇമെയിൽ വിലാസങ്ങൾ, ഫോൺ നമ്പറുകൾ, തിരിച്ചറിയൽ മെറ്റാഡാറ്റ എന്നിവ "
+"പോലുള്ള PII സ്വയമേവ നീക്കം ചെയ്തുകൊണ്ട് DuckDuckGo ഈ റിപ്പോർട്ടുകൾ "
+"അജ്ഞാതമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7531,8 +7618,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ Duck.ai-"
-"യുടെ %2$s സമ്മതിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ Duck.ai-യുടെ %2$s സമ്മതിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7541,8 +7628,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, നിങ്ങൾ ഞങ്ങളുടെ "
-"%2$s-നെ അംഗീകരിക്കുന്നു."
+"DuckDuckGo നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കുന്നു. '%1$s' ക്ലിക്ക് ചെയ്യുക വഴി, "
+"നിങ്ങൾ ഞങ്ങളുടെ %2$s-നെ അംഗീകരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7551,9 +7638,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന Google, Facebook പോലുള്ള "
-"കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ "
-"DuckDuckGo തടയുന്നു."
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ ഇടയ്ക്കിടെ നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ ശ്രമിക്കുന്ന "
+"Google, Facebook പോലുള്ള കമ്പനികളിൽ നിന്നുള്ള ട്രാക്കറുകൾ ഉൾപ്പെടെ, നിങ്ങൾ "
+"സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിലെ ട്രാക്കറുകളെ DuckDuckGo തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7565,12 +7652,13 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ "
-"ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് "
-"ഞങ്ങൾക്ക് അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് ഉപയോഗിക്കുന്നു, "
-"തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ "
-"സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ "
-"അറിയുക%2$s."
+"ഡിസൈൻ പ്രകാരം DuckDuckGo സ്വകാര്യമാണ്. നിങ്ങൾ ലൊക്കേഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ, നിങ്ങളുടെ ലോക്കൽ ഉപകരണത്തിൽ മാത്രം അത് "
+"സംഭരിക്കപ്പെടുന്നു. നിങ്ങൾ തിരയുമ്പോൾ, നിങ്ങളുടെ ഉപകരണം അത് ഞങ്ങൾക്ക് "
+"അയയ്ക്കുന്നു, ആ തിരയലിനായുള്ള ഫലങ്ങൾ മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ അത് "
+"ഉപയോഗിക്കുന്നു, തുടർന്ന് നിങ്ങൾ അജ്ഞാതമായി തുടരുന്ന തരത്തിൽ ഞങ്ങൾ അത് ഉടനടി "
+"ഉപേക്ഷിച്ചുകളയുന്നു. %1$sനിങ്ങളുടെ സ്വകാര്യത പരിരക്ഷിക്കുന്നതിന് ഞങ്ങൾ ഈ "
+"സാങ്കേതികവിദ്യ രൂപകൽപ്പന ചെയ്തത് എങ്ങനെയെന്ന് കൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7590,8 +7678,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് കൂടുതൽ ബന്ധമുള്ള, "
-"മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"നിങ്ങളുടെ ഏകദേശ ലൊക്കേഷൻ മാത്രമേ DuckDuckGo ഉപയോഗിക്കുകയുള്ളൂ. നിങ്ങൾക്ക് "
+"കൂടുതൽ ബന്ധമുള്ള, മികച്ച ഫലങ്ങൾ നൽകാൻ ഞങ്ങൾ ചെയ്യേണ്ടത് അതുമാത്രമാണ്. "
+"%1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7683,10 +7772,11 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo സെർവറുകളിൽ നിന്ന് "
-"ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ "
-"നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 "
-"അക്ഷരങ്ങളെങ്കിലും ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
+"ഓരോ തവണയും നിങ്ങൾ ഒരു പാസ്‌ഫ്രെയ്സ് നിർദേശം ആവശ്യപ്പെടുമ്പോൾ, DuckDuckGo "
+"സെർവറുകളിൽ നിന്ന് ക്രമരഹിതമായ പദങ്ങളുടെ ഒരു നീണ്ട പട്ടിക ഞങ്ങൾക്ക് ലഭിക്കും. "
+"പിന്നീട്, ബ്രൗസറിൽ, ആ പട്ടികയിൽ നിന്നും ഞങ്ങൾ 4-5 ക്രമരഹിതമായ പദങ്ങൾ "
+"തിരഞ്ഞെടുത്തുകൊണ്ട്, പാസ്‌ഫ്രെയ്സിന് കുറഞ്ഞത് 18-20 അക്ഷരങ്ങളെങ്കിലും "
+"ദൈർഘ്യമുണ്ടെന്ന് ഉറപ്പാക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7763,8 +7853,8 @@ msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
 msgstr ""
-"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും പുതിയത് സൃഷ്ടിക്കുകയും "
-"ചെയ്യും."
+"നിങ്ങളുടെ സന്ദേശം എഡിറ്റ് ചെയ്യുന്നത് ചുവടെയുള്ള പ്രതികരണം നീക്കംചെയ്യുകയും "
+"പുതിയത് സൃഷ്ടിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7825,7 +7915,9 @@ msgstr "AI സവിശേഷതകൾ പ്രവർത്തനക്ഷമ�
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save പ്രവർത്തനക്ഷമമാക്കുക."
+msgstr ""
+"നിങ്ങളുടെ നിലവിലുള്ള പാസ്‌ഫ്രെയ്സ് ഉപയോഗിച്ച് Cloud Save "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -7902,8 +7994,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് എപ്പോൾ "
-"വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"കൂടുതൽ കൃത്യമായ ഫലങ്ങൾക്കായി അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുക. പിന്നീട് "
+"എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7948,8 +8040,9 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, പക്ഷേ അപ്പോഴും നിങ്ങളുടെ "
-"തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
+"അജ്ഞാത ലൊക്കേഷൻ പ്രവർത്തനക്ഷമമാക്കുന്നത് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ നൽകുന്നു, "
+"പക്ഷേ അപ്പോഴും നിങ്ങളുടെ തിരയലുകളും കൃത്യമായ ലൊക്കേഷനും DuckDuckGo-യിലേക്ക് "
+"സ്വകാര്യമായി സൂക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7974,7 +8067,8 @@ msgstr "എൻക്രിപ്റ്റ് ചെയ്ത മോഡൽ"
 msgctxt "Share modal info bullet about encryption"
 msgid "Encrypted. Not even DuckDuckGo can read your chat."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു. DuckDuckGo-ക്ക് പോലും നിങ്ങളുടെ ചാറ്റ് വായിക്കാൻ കഴിയില്ല."
+"എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നു. DuckDuckGo-ക്ക് പോലും നിങ്ങളുടെ ചാറ്റ് "
+"വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -8041,7 +8135,8 @@ msgstr "Duck.ai ആസ്വദിക്കുകയാണോ?"
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
 msgstr ""
-"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' ക്രമീകരണത്തിനായി %1$s'അനുവദിക്കുക'%2$s തിരഞ്ഞെടുത്തിട്ടുണ്ടെന്ന് "
+"ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8127,8 +8222,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് ചെയ്യുക. ഇത് "
-"നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
+"ഒരു പുതിയ പാസ്‌ഫ്രെയ്സ് നൽകിയിട്ട്, %1$sക്രമീകരണം സംരക്ഷിക്കുക%2$s ക്ലിക്ക് "
+"ചെയ്യുക. ഇത് നിങ്ങളുടെ പുതിയ പാസ്‌ഫ്രെയ്സിന് കീഴിൽ ഡാറ്റ രക്ഷിക്കും."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8154,8 +8249,8 @@ msgstr "ടെക്‌സ്റ്റ് നൽകുക"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: %5$sഅപരനാമം "
-"%6$s: ഡി%7$s"
+"ഇനിപ്പറയുന്ന വിശദാംശങ്ങൾ നൽകുക: %1$s പേര് %2$s: DuckDuckGo%3$sURL%4$s: "
+"%5$sഅപരനാമം %6$s: ഡി%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8196,7 +8291,8 @@ msgstr "ഇക്വറ്റോറിയൽ ഗിനിയ"
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
 msgstr ""
-"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ മായ്ക്കുക %1$s%2$s"
+"ഞങ്ങളുടെ Fire Button ഉപയോഗിച്ച് ഒറ്റ ഫ്ലാഷിൽ നിങ്ങളുടെ ബ്രൗസിംഗ് ഡാറ്റ "
+"മായ്ക്കുക %1$s%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8256,7 +8352,9 @@ msgstr "മാപ്പ് വികസിപ്പിക്കുക"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത ഉൽപ്പന്നങ്ങൾ."
+msgstr ""
+"സ്വകാര്യതയെ ശരിക്കും ശ്രദ്ധിക്കുന്നവർക്കായി വിദഗ്ദ്ധമായി രൂപകൽപ്പന ചെയ്ത "
+"ഉൽപ്പന്നങ്ങൾ."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8344,7 +8442,9 @@ msgstr "ഇത് ലളിതമായി വിശദീകരിക്കു�
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും വിശദീകരിക്കുക."
+msgstr ""
+"ഈ റിപ്പോസിറ്ററി എന്താണ് ചെയ്യുന്നതെന്നും അത് എങ്ങനെ ഉപയോഗിക്കണമെന്നും "
+"വിശദീകരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8499,7 +8599,7 @@ msgstr "വേഗതയുള്ളത്"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "വേഗത്തിലുള്ള ചിത്രം സൃഷ്ടിക്കൽ"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8546,8 +8646,8 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു."
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8556,8 +8656,9 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് "
-"സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
+"നിങ്ങളുടേത് പോലുള്ള ഫീഡ്ബാക്ക് ഞങ്ങളുടെ ഉൽപ്പന്ന അപ്ഡേറ്റുകളെയും "
+"മെച്ചപ്പെടുത്തലുകളെയും നേരിട്ട് സ്വാധീനിക്കുന്നു. നിങ്ങൾ പങ്കിട്ട പ്രശ്നവും "
+"പരിഹരിക്കാൻ ഞങ്ങൾക്ക് കഴിയുമെന്ന് പ്രതീക്ഷിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8565,8 +8666,8 @@ msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
 msgstr ""
-"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ സൈറ്റിലേക്കു പകർത്തി "
-"ഒട്ടിക്കുക"
+"ഇഷ്ട പ്രകാരം താഴെയുള്ള ക്രമീകരണം ക്രമപ്പെടുത്തുക. തുടർന്ന് കോഡ് താങ്കളുടെ "
+"സൈറ്റിലേക്കു പകർത്തി ഒട്ടിക്കുക"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8655,15 +8756,16 @@ msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
 msgstr ""
-"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് ഫിൽട്ടർ ചെയ്ത് "
-"ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"AI ഉപയോഗിച്ച് നിർമ്മിച്ച ചിത്രങ്ങൾ, ചിത്രങ്ങൾ തിരയുന്നതിൻ്റെ ഫലത്തിൽ നിന്ന് "
+"ഫിൽട്ടർ ചെയ്ത് ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. %1$sകൂടുതലറിയുക%2$s"
+"ഇമേജ് തിരയൽ ഫലങ്ങളിൽ നിന്ന് അറിയപ്പെടുന്ന AI സ്പാം സൈറ്റുകൾ ഒഴിവാക്കുന്നു. "
+"%1$sകൂടുതലറിയുക%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8705,7 +8807,8 @@ msgstr "<b>%1$s</b> നിങ്ങളുടെ ഡൗൺലോഡുകൾ ഫ�
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
 msgstr ""
-"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"പ്രദർശിപ്പിച്ച പട്ടികയിൽ DuckDuckGo കണ്ടെത്തി %1$sഡിഫോൾട്ട് ആക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8743,8 +8846,8 @@ msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
 msgstr ""
-"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും സുരക്ഷിതവും "
-"അജ്ഞാതവുമാണ്."
+"നിങ്ങളോട് അടുത്തുള്ള ഫലങ്ങൾ കണ്ടെത്തുക. %1$sനിങ്ങളുടെ ലൊക്കേഷൻ സ്വകാര്യവും "
+"സുരക്ഷിതവും അജ്ഞാതവുമാണ്."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8808,8 +8911,9 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു മെനു ഓപ്ഷൻ "
-"തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി വന്നേക്കാം."
+"DuckDuckGo-യ്ക്കായി Ad blocker ഓഫാക്കാൻ നിർദ്ദേശങ്ങൾ പിന്തുടരുക. നിങ്ങൾ ഒരു "
+"മെനു ഓപ്ഷൻ തിരഞ്ഞെടുക്കുകയോ ഒരു ബട്ടൺ ക്ലിക്ക് ചെയ്യുകയോ ചെയ്യേണ്ടി "
+"വന്നേക്കാം."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8832,7 +8936,7 @@ msgstr "ഫോളോ-അപ്പുകൾ സ്വകാര്യമായി 
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "നിർദ്ദേശങ്ങൾ പാലിച്ചു"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8938,7 +9042,9 @@ msgstr "സൗജന്യവും സ്വകാര്യവുമായ ച�
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് ആവശ്യമില്ല."
+msgstr ""
+"സൗജന്യവും സ്വകാര്യവുമായ ചാറ്റുകൾ, ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു. അക്കൗണ്ട് "
+"ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8968,7 +9074,9 @@ msgstr "പങ്കിടലും വാണിജ്യപരമായി ഉ�
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+msgstr ""
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കി സ്ഥലം ശൂന്യമാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ "
+"ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9049,9 +9157,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; <strong>അപ്ഡേറ്റുകൾ "
-"പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് ഇൻസ്റ്റാൾ ചെയ്യുക</strong> "
-"തിരഞ്ഞെടുക്കുക."
+"Mac-ലെ ആപ്പ് മെനു ബാറിൽ നിന്ന്, <strong>DuckDuckGo</strong> &gt; "
+"<strong>അപ്ഡേറ്റുകൾ പരിശോധിക്കുക...</strong>, തുടർന്ന് <strong>അപ്ഡേറ്റ് "
+"ഇൻസ്റ്റാൾ ചെയ്യുക</strong> തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9337,15 +9445,14 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity Theft "
-"Restoration എന്നിവയും."
+"DuckDuckGo VPN, നൂതന Duck.ai എന്നിവ നേടൂ, Personal Info Removal, Identity "
+"Theft Restoration എന്നിവയും."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
+msgstr "DuckDuckGo VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9431,8 +9538,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, കൂടാതെ "
-"Identity Theft Restoration എന്നിവ നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണൽ അഡ്വാൻസ്ഡ് AI ചാറ്റ്, Personal Info Removal, "
+"കൂടാതെ Identity Theft Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9441,8 +9548,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft Restoration "
-"നേടൂ."
+"വേഗതയേറിയ, നോ-ലോഗ് VPN, ഓപ്ഷണലായ നൂതന AI ചാറ്റ്, കൂടാതെ Identity Theft "
+"Restoration നേടൂ."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9451,8 +9558,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo-യിലേക്ക് "
-"സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന "
+"DuckDuckGo-യിലേക്ക് സബ്സ്ക്രൈബ് ചെയ്തുകൊണ്ട് Duck.ai-ലെ നൂതന AI "
+"മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9463,8 +9571,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo സബ്സ്ക്രിപ്ഷൻ "
-"ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
+"ഞങ്ങളുടെ VPN-ഉം മറ്റ് പ്രീമിയം സ്വകാര്യതാ പരിരക്ഷകളും ഉൾപ്പെടുന്ന DuckDuckGo "
+"സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് Duck.ai-ലെ നൂതന AI മോഡലുകളിലേക്ക് ആക്സസ് നേടുക."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9508,8 +9616,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ "
-"ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ വേഗതയേറിയ നോ-ലോഗ് VPN, ഉയർന്ന ചാറ്റ് പരിധികളുള്ള നൂതന AI "
+"മോഡലുകളിലേക്കുള്ള ഓപ്ഷണൽ ആക്‌സസ്, കൂടാതെ കൂടുതൽ പ്രീമിയം പരിരക്ഷകൾ എന്നിവ "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9518,8 +9627,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information Removal, "
-"കൂടാതെ Identity Theft Restoration."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai നേടൂ, Personal Information "
+"Removal, കൂടാതെ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9527,14 +9636,15 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft Restoration "
-"എന്നിവ നേടൂ."
+"ഞങ്ങളുടെ സുരക്ഷിതമായ, നോ-ലോഗ് VPN, നൂതന Duck.ai, കൂടാതെ Identity Theft "
+"Restoration എന്നിവ നേടൂ."
 
 # smartling.placeholder_format=C
 msgid ""
 "Get seamless privacy protection on your browser for free with one download:"
 msgstr ""
-"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ സൗജന്യമായി നേടുക:"
+"ഒറ്റ ഡൗൺലോഡിൽ നിങ്ങളുടെ ബ്രൗസറിൽ തടസ്സമില്ലാത്ത സ്വകാര്യതാ പരിരക്ഷ "
+"സൗജന്യമായി നേടുക:"
 
 # smartling.placeholder_format=C
 #. Text of a button that will install the DuckDuckGo app when clicked
@@ -9630,8 +9740,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
-"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക › "
-"ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
+"എന്നതിലേക്ക് പോയി, %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
+"സമന്വയിപ്പിക്കുക › ടെക്സ്റ്റ് കോഡ് പകർത്തുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9666,8 +9776,8 @@ msgid ""
 msgstr ""
 "നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s "
 "എന്നതിലേക്ക് പോയി %3$sചാറ്റുകൾ › Sync & Backup › മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ "
-"ചെയ്യുക."
+"സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9676,8 +9786,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
+"മറ്റൊരു ഉപകരണത്തിലെ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോവുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9692,8 +9802,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് പോയി "
-"\"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
+"%1$sക്രമീകരണം > സ്വകാര്യതയും സുരക്ഷയും > ലൊക്കേഷൻ സേവനങ്ങൾ%2$sഎന്നതിലേക്ക് "
+"പോയി \"ലൊക്കേഷൻ സേവനങ്ങൾ\" ഓണാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9775,7 +9885,7 @@ msgstr "മികച്ച സ്വകാര്യതാ നയം"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "നല്ല ദൃശ്യ ശൈലി"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -9965,7 +10075,9 @@ msgstr "ഗ്വാട്ടിമാല"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ നയിക്കുക."
+msgstr ""
+"ഒരു വിൻഡോ വൈപ്പർ മാറ്റിസ്ഥാപിക്കുന്നതിനുള്ള അടിസ്ഥാന ഘട്ടങ്ങളിലൂടെ എന്നെ "
+"നയിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10165,7 +10277,9 @@ msgstr "DuckDuckGo മെച്ചപ്പെടുത്താൻ ഞങ്ങ
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ സഹായിക്കൂ"
+msgstr ""
+"നിങ്ങളുടെ ഫീഡ്ബാക്ക് ഉപയോഗിച്ച് DuckDuckGo തിരയലുകൾ മെച്ചപ്പെടുത്താൻ ഞങ്ങളെ "
+"സഹായിക്കൂ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10223,7 +10337,9 @@ msgstr "Duck ഭാഗത്ത് ചേരാൻ നിങ്ങളുടെ �
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ സഹായിക്കൂ!"
+msgstr ""
+"നിങ്ങളുടെ സുഹൃത്തുക്കളെയും കുടുംബാംഗങ്ങളെയും അവരുടെ സ്വകാര്യത വീണ്ടെടുക്കാൻ "
+"സഹായിക്കൂ!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10398,8 +10514,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search Assist "
-"ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
+"പ്രധാനപ്പെട്ട വിവരങ്ങൾ വേഗത്തിൽ കണ്ടെത്താൻ നിങ്ങളെ സഹായിക്കുന്നതിന് Search "
+"Assist ഉത്തരങ്ങളിൽ പ്രധാന വസ്തുതകൾ എടുത്തുകാണിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10426,8 +10542,9 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ %1$sമടങ്ങുക%2$s "
-"അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് ക്ലിക്ക് ചെയ്യുക"
+"DuckDuckGo പട്ടികയിലേക്ക് %3$sസംരക്ഷിക്കാൻ നിങ്ങളുടെ കീബോർഡിൽ "
+"%1$sമടങ്ങുക%2$s അമർത്തുക. %4$sതുടർന്ന് %5$sഡിഫോൾട്ട് ആക്കുക%6$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10441,8 +10558,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, നിങ്ങൾക്ക് "
-"ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
+"ഹോൾഡ് ഓൺ! ഇത് തിരികെ മാറ്റുന്നത് DuckDuckGo വിപുലീകരണം പ്രവർത്തനരഹിതമാക്കും, "
+"നിങ്ങൾക്ക് ഞങ്ങളുടെ സ്വകാര്യതാ പരിരക്ഷണം നഷ്‌ടമാകും."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10492,8 +10609,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ ശൃംഖലയാണ്, നിങ്ങളെ "
-"പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
+"ഹോട്ടൽ പരസ്യ ക്ലിക്കുകൾ കൈകാര്യം ചെയ്യുന്നത് ട്രിപ്പ് അഡ്വൈസറിന്റെ പരസ്യ "
+"ശൃംഖലയാണ്, നിങ്ങളെ പ്രൊഫൈൽ ചെയ്യുന്നതിനായി അവ ഉപയോഗിക്കപ്പെടുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10608,7 +10725,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 #. Header for the assist settings modal where the user can choose how often they want AI-assisted answers to appear.
 msgctxt "duckassist"
 msgid "How much do you want AI-assisted answers to appear?"
-msgstr "നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് ആഗ്രഹിക്കുന്നത്?"
+msgstr ""
+"നിങ്ങൾ എത്രത്തോളം AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ദൃശ്യമാകണമെന്നാണ് "
+"ആഗ്രഹിക്കുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
@@ -10641,8 +10760,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ തന്ത്രപൂർവ്വം "
-"സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
+"അവരുടെ നിരന്തരമായ പെൻസിൽ ടാപ്പിംഗിനെക്കുറിച്ച് ഒരു സഹപ്രവർത്തകനെ എങ്ങനെ "
+"തന്ത്രപൂർവ്വം സമീപിക്കണം, ഞാൻ എന്താണ് പറയേണ്ടത്?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10749,7 +10868,9 @@ msgstr "കൂടുതൽ വിൽപ്പനക്കാരിൽ നിന�
 #. Header above text explaining that passwords can't be recovered.
 msgctxt "cloudsave"
 msgid "I forgot my passphrase. Can you recover it?"
-msgstr "എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ സാധിക്കുമോ?"
+msgstr ""
+"എന്റെ പാസ്‌ഫ്രെയ്സ് മറന്നു പോയി, നിങ്ങള്‍ക്ക് അത് വീണ്ടെടുക്കുവാന്‍ "
+"സാധിക്കുമോ?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user hits a chat limit.
@@ -10764,14 +10885,16 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് "
-"ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
+"കാറ്റിൻ്റെ പേര് എന്ന പുസ്തകം എനിക്കിഷ്ടമാണ്. മറ്റു ചില നല്ല "
+"പുസ്തകങ്ങൾ/പരമ്പരകൾ ഏതൊക്കെയാണ് ഏറ്റവും ഇഷ്ടപ്പെടുന്നത്, എന്തുകൊണ്ട്?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ എനിക്ക് ആവശ്യമാണ്"
+msgstr ""
+"ചാറ്റ് എങ്ങനെ ഉപയോഗിക്കാം എന്നതിനെക്കുറിച്ചുള്ള കൂടുതൽ സഹായം/വിവരങ്ങൾ "
+"എനിക്ക് ആവശ്യമാണ്"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10800,8 +10923,9 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > പുനഃക്രമീകരിക്കുക > "
-"'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s എന്നതിലേക്ക് പോകുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, %1$sക്രമീകരണം > പൊതുവായത് > "
+"പുനഃക്രമീകരിക്കുക > 'ലൊക്കേഷനും സ്വകാര്യതയും പുനഃക്രമീകരിക്കുക'%2$s "
+"എന്നതിലേക്ക് പോകുക."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10811,9 +10935,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക %1$s⋮ > മെനു > "
-"ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് "
-"അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
+"ബ്രൗസർ ലൊക്കേഷൻ തുടർന്നും ലഭ്യമല്ലെങ്കിൽ, നിങ്ങളുടെ ബ്രൗസറിൽ ഇതിലേക്ക് പോകുക "
+"%1$s⋮ > മെനു > ക്രമീകരണം > സൈറ്റ് ക്രമീകരണം > ലൊക്കേഷൻ%2$s, തുടർന്ന് "
+"DuckDuckGo-യ്ക്ക് ലൊക്കേഷൻ ആക്സസ് അനുവദനീയമാണെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10828,8 +10952,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ എഞ്ചിനുകളുടെ%4$s "
-"പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
+"നിങ്ങൾ %1$sDuckDuckGo%2$s കാണുന്നില്ലെങ്കിൽ നിങ്ങൾ അത് %3$sമറ്റ് തിരയൽ "
+"എഞ്ചിനുകളുടെ%4$s പട്ടികയിലേക്ക് ചേർക്കേണ്ടതുണ്ട്"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10838,8 +10962,9 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് "
-"ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് %1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
+"ഞങ്ങളുടെ ചാറ്റ് ദാതാക്കളെക്കുറിച്ചോ ഏതെങ്കിലും പ്രത്യേക ചാറ്റ് "
+"പ്രതികരണത്തെക്കുറിച്ചോ നിങ്ങൾക്ക് ആശങ്കയുണ്ടെങ്കിൽ, നിങ്ങൾക്ക് നേരിട്ട് "
+"%1$s, %2$s പിന്തുണാ പേജുകളിലേക്കും ബന്ധപ്പെടാം."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10848,16 +10973,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ "
-"ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ സംരക്ഷിച്ച "
+"ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് ആവശ്യമായി വരും. ഈ കോഡ് നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"ഒരു ടെക്സ്റ്റ് ഫയലായി സംരക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, %1$sDuckDuckGo "
-"പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
+"നിങ്ങൾ ഇപ്പോഴും ഞങ്ങളെ പിന്തുണയ്ക്കാൻ ആഗ്രഹിക്കുന്നുണ്ടെങ്കിൽ, "
+"%1$sDuckDuckGo പ്രചരിപ്പിക്കുന്നതിനായി സഹായിക്കുക%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10867,8 +10993,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ %1$s "
-"അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
+"JavaScript ഇല്ലാതെ DuckDuckGo ഉപയോഗിക്കാൻ താൽപ്പര്യപ്പെടുന്നെങ്കിൽ, ഞങ്ങളുടെ "
+"%1$s അല്ലെങ്കിൽ %2$s പതിപ്പുകൾ ഉപയോഗിക്കുക."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10876,8 +11002,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും അടുത്തുള്ള ഹോം പേജ് "
-"തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
+"നിങ്ങൾ ആഗ്രഹിക്കുന്നെങ്കിൽ, അടുത്ത പുതിയ ജാലകങ്ങൾക്കും പുതിയ ടാബുകൾക്കും "
+"അടുത്തുള്ള ഹോം പേജ് തിരഞ്ഞെടുക്കുക (ഇതിൽ തുറക്കുക)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10920,7 +11046,7 @@ msgstr "ഇമേജ് പ്രോംപ്റ്റുകൾ Duck.ai %1$s പ
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "ചിത്രത്തിന്റെ ഗുണനിലവാരം"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11012,8 +11138,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് ഫലത്തിന്റെ വ്യക്തത "
-"മെച്ചപ്പെടുത്തുന്നു"
+"അപ്‌ഡേറ്റ് ചെയ്‌ത URL ഫോർമാറ്റ്, പ്ലേസ്‌മെന്റ്, നിറം എന്നിവ ഉപയോഗിച്ച് "
+"ഫലത്തിന്റെ വ്യക്തത മെച്ചപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11026,8 +11152,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ ക്ലിക്കുകൾ "
-"റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
+"ചില പഴയ ബ്രൗസറുകളിൽ തിരയൽ ചോർച്ച തടയുന്നതിന് ഞങ്ങളുടെ സെർവറിലൂടെ നിങ്ങളുടെ "
+"ക്ലിക്കുകൾ റീഡയറക്റ്റ് ചെയ്യേണ്ടത് ആവശ്യമാണ്. %1$sകൂടുതൽ അറിയുക%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -11038,8 +11164,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, തുടർന്ന് \"മറ്റൊരു "
-"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
+"DuckDuckGo ബ്രൗസറിൽ, ക്രമീകരണങ്ങൾ › Sync & Backup എന്നതിലേക്ക് പോയി, "
+"തുടർന്ന് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11054,8 +11180,9 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക "
-"എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി പരിശോധിക്കാവുന്നതാണ്."
+"സുതാര്യതയ്ക്കു വേണ്ടി ഈ ഡാറ്റകള്‍ എൻക്രിപ്റ്റ് ചെയ്തിട്ടില്ല: ഏതു തരം "
+"വിവരങ്ങളാണ് ഞങ്ങള്‍ ശേഖരിക്കുക എന്നത് നിങ്ങൾക്ക് വ്യക്തമായി "
+"പരിശോധിക്കാവുന്നതാണ്."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11392,8 +11519,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ പ്രശസ്തി "
-"സംഗ്രഹിക്കുക."
+"ഈ സ്ഥലം നല്ലതാണോ? അവലോകനങ്ങളെയും റേറ്റിംഗുകളെയും അടിസ്ഥാനമാക്കി ഇതിന്റെ "
+"പ്രശസ്തി സംഗ്രഹിക്കുക."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11437,15 +11564,17 @@ msgstr "ഇതിന് ഏതാനും നിമിഷങ്ങൾ എടു
 #. Body text of a card that promotes installing the DuckDuckGo desktop browser.
 msgctxt "new tab page"
 msgid "It's fast, free, and gives you even more online protection."
-msgstr "ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും നൽകുന്നു."
+msgstr ""
+"ഇത് വേഗതയേറിയതും സൗജന്യവുമാണ്, കൂടാതെ നിങ്ങൾക്ക് കൂടുതൽ ഓൺലൈൻ സുരക്ഷയും "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
 msgstr ""
-"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) ചോദിക്കുന്നതിൽ "
-"കുഴപ്പമില്ല"
+"DuckDuckGo ഉപയോഗിച്ച എന്റെ അനുഭവത്തെക്കുറിച്ച് എന്നോട് (വളരെ അപൂർവമായി) "
+"ചോദിക്കുന്നതിൽ കുഴപ്പമില്ല"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11464,10 +11593,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, Microsoft-ന്റെ "
-"പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് "
-"നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം "
-"ലഭിക്കുന്നില്ല."
+"ഇനങ്ങൾ നിങ്ങളുടെ തിരയൽ പദങ്ങളുടെ പ്രസക്തിയെ അടിസ്ഥാനമാക്കി റാങ്ക് ചെയ്ത്, "
+"Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്ക് വഴി ഡെലിവറി ചെയ്യുന്നു. ക്ലിക്കുകൾ "
+"നേരിട്ട് മർച്ചന്റ് ലാൻഡിംഗ് പേജുകളിലേക്ക് നയിക്കുന്നു, പരസ്യങ്ങളിൽ നിന്ന് "
+"വ്യത്യസ്തമായി ഈ ഫലങ്ങൾക്കായി DuckDuckGo-യ്ക്ക് പ്രതിഫലം ലഭിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11476,8 +11605,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 വാക്കുകൾ ഓർമിക്കുവാൻ, "
-"വളരെ അധികം സുരക്ഷിതവും."
+"10 ക്രമരഹിത പദങ്ങളും സംഖ്യകളും ഓര്‍മിക്കുന്നതിനെക്കാൾ എളുപ്പമാണ് 4-5 "
+"വാക്കുകൾ ഓർമിക്കുവാൻ, വളരെ അധികം സുരക്ഷിതവും."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11550,8 +11679,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും സ്വകാര്യമായി "
-"സൂക്ഷിക്കുക."
+"ഒരേസമയം 5 ഉപകരണങ്ങളിൽ വരെ നിങ്ങളുടെ എല്ലാ ആപ്പുകളും ഓൺലൈൻ പ്രവർത്തനങ്ങളും "
+"സ്വകാര്യമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -11865,7 +11994,9 @@ msgstr "പങ്കിട്ട ചാറ്റുകൾ എങ്ങനെ പ
 #. Description of a page with more information about how anonymous location works.
 msgctxt "precise_user_location"
 msgid "Learn how we keep your location private"
-msgstr "നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് മനസ്സിലാക്കുക"
+msgstr ""
+"നിങ്ങളുടെ ലൊക്കേഷൻ ഞങ്ങൾ സ്വകാര്യമായി സൂക്ഷിക്കുന്നത് എങ്ങനെയെന്ന് "
+"മനസ്സിലാക്കുക"
 
 # smartling.placeholder_format=C
 #. Link text in the Usage section of Duck.ai settings that opens a help page explaining Duck.ai usage limits.
@@ -11907,7 +12038,9 @@ msgstr "ഇത് എങ്ങനെ പ്രവർത്തിക്കുന�
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് അറിയുക."
+msgstr ""
+"ഓൺലൈൻ ട്രാക്കിംഗ് കുറയ്ക്കുന്നത് പ്രധാനമായിരിക്കുന്നത് എന്തുകൊണ്ടാണെന്ന് "
+"അറിയുക."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11970,8 +12103,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ മാറാൻ നിങ്ങളെ "
-"അനുവദിക്കുന്നു"
+"Duck.ai-ലേക്ക് തിരയൽ ചോദ്യങ്ങളും പ്രോംപ്റ്റുകളും സമർപ്പിക്കുന്നത് തമ്മിൽ "
+"മാറാൻ നിങ്ങളെ അനുവദിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12029,7 +12162,9 @@ msgstr "ഈ ചാറ്റിനായി പരിമിതമായ ഡാറ
 #. Description of a setting managing the length of search result snippet text.
 msgctxt "settings"
 msgid "Limits the amount of descriptive content shown for results"
-msgstr "ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് പരിമിതപ്പെടുത്തുന്നു"
+msgstr ""
+"ഫലങ്ങൾക്കായി കാണിക്കുന്ന വിവരണാത്മക ഉള്ളടക്കത്തിന്റെ അളവ് "
+"പരിമിതപ്പെടുത്തുന്നു"
 
 # smartling.placeholder_format=C
 #. i.e. a type of image comprised of lines without gradiations in shade or hue
@@ -12084,7 +12219,8 @@ msgstr "ലിങ്കുകൾ:"
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
 msgstr ""
-"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ ലിസ്റ്റ് ചെയ്യുക."
+"ഇതിന് എനിക്ക് ആവശ്യമായ ഉപകരണങ്ങൾ, സാമഗ്രികൾ, അല്ലെങ്കിൽ മുൻകൂർ ആവശ്യകതകൾ "
+"ലിസ്റ്റ് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12196,7 +12332,8 @@ msgstr "സ്ക്രോൾ ചെയ്യുമ്പോൾ കൂടുത�
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
 msgstr ""
-"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ ലോഡ് ചെയ്യുന്നു"
+"സ്ക്രോൾ ചെയ്യുമ്പോൾ ഇമേജുകൾ, വീഡിയോകൾ, ഷോപ്പിംഗ് എന്നിവയിൽ കൂടുതൽ ഫലങ്ങൾ "
+"ലോഡ് ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12383,7 +12520,8 @@ msgstr "എല്ലാ വാക്കുകളും അക്ഷരത്ത�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
+"%1$s\"ഇതിനെ എന്റെ ഡിഫോൾട്ട് തിരയല്‍ ദാതാവാക്കുക\"%2$s എന്നത് "
+"തിരഞ്ഞെടുത്തുവെന്ന് ഉറപ്പാക്കുക"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12748,7 +12886,9 @@ msgstr "മൈക്രോനേഷ്യ"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"മൈക്രോഫോൺ പ്രവേശനം നിഷേധിച്ചു. മൈക്രോഫോൺ ആക്‌സസ് അനുവദിച്ച് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -13532,10 +13672,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു "
-"DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് "
-"വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ "
-"ഇല്ലാതാക്കുകയും പുതിയ പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
+"പുതിയ പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും. ചാറ്റ് ചരിത്രം "
+"പ്രവർത്തനരഹിതമാക്കുന്നത് പിൻ ചെയ്‌ത ചാറ്റുകൾ ഇല്ലാതാക്കുകയും പുതിയ "
+"പ്രോംപ്റ്റുകളുടെയും പ്രതികരണങ്ങളുടെയും താൽക്കാലിക സ്റ്റോറേജ് "
 "പ്രവർത്തനരഹിതമാക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
@@ -14381,8 +14522,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$sഎന്നതിലേക്ക് പോകുക"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14391,8 +14532,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് സ്കാൻ ചെയ്യുക:"
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോയി ഈ കോഡ് "
+"സ്കാൻ ചെയ്യുക:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14401,9 +14543,9 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & Backup › "
-"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
-"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"മറ്റൊരു ഉപകരണത്തിൽ %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s › %3$sചാറ്റുകൾ › Sync & "
+"Backup › മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%4$s എന്നതിലേക്ക് പോകുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14431,8 +14573,9 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ കൂടുതൽ പേജുകളുണ്ട്. %1$s "
-"അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് ചെയ്യുക."
+"അറ്റാച്ച് ചെയ്തിരിക്കുന്ന ഫയലുകളിൽ ഒന്നിൽ ഞങ്ങൾ പിന്തുണയ്ക്കുന്നതിനേക്കാൾ "
+"കൂടുതൽ പേജുകളുണ്ട്. %1$s അല്ലെങ്കിൽ അതിൽ കുറവ് പേജുകളുള്ള ഫയലുകൾ അപ്‌ലോഡ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14475,8 +14618,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത പിശകുണ്ടായി. പിന്നീട് "
-"വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം! ഈ ടെക്‌സ്റ്റ് വിവർത്തനം ചെയ്യുന്ന സമയത്ത് ഒരു അപ്രതീക്ഷിത "
+"പിശകുണ്ടായി. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14530,8 +14673,8 @@ msgstr "%1$s വെബ്‌സൈറ്റ് തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
 msgstr ""
-"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s "
-"ഉറപ്പാക്കുക"
+"%1$s'ലൊക്കേഷൻ'%2$s തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%3$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%4$s ഉറപ്പാക്കുക"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14552,7 +14695,8 @@ msgstr "%1$sക്രമീകരണം%2$s തുറക്കുക"
 msgctxt "precise_user_location"
 msgid "Open 'Location', and ensure location is %senabled%s."
 msgstr ""
-"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ %1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
+"'ലൊക്കേഷൻ' തുറക്കുക, തുടര്‍ന്ന് ലൊക്കേഷൻ "
+"%1$sപ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന്%2$s ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -14709,7 +14853,9 @@ msgstr "How Duck.ai വർക്ക്സ് പാനൽ തുറക്കു�
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s തിരഞ്ഞെടുക്കുക..."
+msgstr ""
+"Safari മെനു തുറന്ന് %1$sDuckDuckGo എന്നതിനായുള്ള ക്രമീകരണങ്ങൾ%2$s "
+"തിരഞ്ഞെടുക്കുക..."
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -14810,8 +14956,9 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ നിങ്ങളുടെ "
-"തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല — കാലഘട്ടം"
+"നിങ്ങൾ സ്വകാര്യ ബ്രൗസിംഗ് മോഡിൽ ആയിരിക്കുമ്പോൾ പോലും മറ്റ് തിരയൽ എഞ്ചിനുകൾ "
+"നിങ്ങളുടെ തിരയലുകളെ ട്രാക്ക് ചെയ്യുന്നു. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് "
+"ചെയ്യുന്നില്ല — കാലഘട്ടം"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14825,8 +14972,9 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI ചാറ്റുകളും കൂടുതൽ "
-"പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു സബ്‌സ്‌ക്രിപ്‌ഷൻ."
+"ഞങ്ങളുടെ വേഗതയേറിയ, നോ-ലോഗ് VPN-നൊപ്പം ഉയർന്ന പരിധികളുള്ള മികച്ച AI "
+"ചാറ്റുകളും കൂടുതൽ പ്രീമിയം പരിരക്ഷകളും ലഭിക്കുന്നു. എല്ലാം ഉൾപ്പെട്ട ഒരു "
+"സബ്‌സ്‌ക്രിപ്‌ഷൻ."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14834,8 +14982,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും ശേഖരിക്കുകയോ "
-"പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
+"ഞങ്ങളുടെ സ്വകാര്യത നയം ലളിതമാണ്: ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങളിൽ ഒന്നും "
+"ശേഖരിക്കുകയോ പങ്കുവയ്ക്കുകയോ ചെയ്യില്ല."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14843,9 +14991,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ ഉൾപ്പെടുത്തി "
-"മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, Android%2$s എന്നിവയിൽ "
-"ലഭ്യമാണ്."
+"ഞങ്ങളുടെ തിരയൽ എഞ്ചിൻ, ട്രാക്കർ ബ്ലോക്കർ, എൻക്രിപ്ഷൻ എൻഫോഴ്സർ തുടങ്ങിയവ "
+"ഉൾപ്പെടുത്തി മൊബൈലിനായുള്ള ഞങ്ങളുടെ സ്വകാര്യ ബ്രൗസർ ലഭിക്കുന്നു. %1$siOS, "
+"Android%2$s എന്നിവയിൽ ലഭ്യമാണ്."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15098,8 +15246,9 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും വിവരങ്ങൾ ഞങ്ങൾ "
-"ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ ഐപി വിലാസം, ബ്രൗസർ ഫിംഗർപ്രിന്റ് അല്ലെങ്കിൽ മറ്റേതെങ്കിലും "
+"വിവരങ്ങൾ ഞങ്ങൾ ഫയലുമായി ബന്ധപ്പെടുത്താത്തതിനാൽ പാസ്‌ഫ്രെയ്സുകൾ വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15255,8 +15404,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ അത് "
-"കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ പ്രവർത്തിക്കുന്നു."
+"Personal Information Removal നിങ്ങളുടെ വിവരങ്ങൾ വിൽക്കുന്ന ഡാറ്റ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ അത് കണ്ടെത്തുന്നു. തുടർന്ന് അത് നിങ്ങൾക്കായി നീക്കം ചെയ്യാൻ ഞങ്ങൾ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15327,9 +15477,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI സഹായമുള്ള ഉത്തരങ്ങൾ "
-"സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. "
-"അവ ഓഫാക്കാനും Assist ബട്ടൺ മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് AI "
+"സഹായമുള്ള ഉത്തരങ്ങൾ സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും "
+"പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. അവ ഓഫാക്കാനും Assist ബട്ടൺ "
+"മറയ്ക്കാനും %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15338,10 +15489,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ "
-"സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist "
-"ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച "
+"ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഈ സവിശേഷത എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്ന് "
+"ക്രമീകരിക്കാനോ ഓഫ് ചെയ്യാനോ, %1$sDuckAssist ക്രമീകരണങ്ങൾ%2$sസന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15351,9 +15502,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് DuckAssist സ്വയമേവ "
-"പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് "
-"ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"നിങ്ങളുടെ തിരയൽ ഒരു ചോദ്യമായും സമ്പൂർണ്ണ വാക്യമായും ആവിഷ്കരിക്കുന്നത് "
+"DuckAssist സ്വയമേവ പ്രത്യക്ഷപ്പെടാൻ കൂടുതൽ സാധ്യതയുണ്ടാക്കുകയും പലപ്പോഴും "
+"മികച്ച ഉത്തരങ്ങൾ നൽകുകയും ചെയ്യുന്നു. ഇത് ഓഫാക്കാനും അസിസ്റ്റ് ബട്ടൺ "
+"മറയ്ക്കാനും %1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15386,8 +15538,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistra തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15396,8 +15548,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് ചെയ്യാൻ "
-"തിരഞ്ഞെടുക്കുക."
+"GPT-5 mini, Claude Haiku 4.5, Mistral,   തുടങ്ങിയ ജനപ്രിയ AI-കളുമായി ചാറ്റ് "
+"ചെയ്യാൻ തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15406,8 +15558,8 @@ msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
 msgstr ""
-"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ ആപ്പുകൾക്ക് "
-"DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
+"നിന്റെ ലക്ഷ്യസ്ഥാനത്തേക്ക് നാവിഗേറ്റ് ചെയ്യാൻ ഒരു സേവനം തിരഞ്ഞെടുക്കൂ. ബാഹ്യ "
+"ആപ്പുകൾക്ക് DuckDuckGo സംരക്ഷണങ്ങൾ ലഭ്യമല്ല."
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15420,8 +15572,8 @@ msgstr "ഒരു നിർദിഷ്ട പ്രശ്നം തിരഞ്
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ നിർദ്ദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ തിരഞ്ഞെടുക്കുക, DuckDuckGo-ൽ പരസ്യങ്ങൾ അനുവദിക്കാൻ "
+"നിർദ്ദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15510,7 +15662,8 @@ msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
 msgstr ""
-"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന ചലഞ്ച് പൂർത്തിയാക്കുക."
+"ഈ പ്രോംപ്റ്റ് നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന "
+"ചലഞ്ച് പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15519,23 +15672,24 @@ msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
 msgstr ""
-"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി പൂർത്തിയാക്കുക."
+"ഈ തിരയൽ നടത്തിയത് ഒരു മനുഷ്യനാണെന്ന് സ്ഥിരീകരിക്കാൻ ഇനിപ്പറയുന്ന വെല്ലുവിളി "
+"പൂർത്തിയാക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
 msgstr ""
-"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി വിശദീകരിക്കുക. "
-"(ഓപ്ഷണൽ)"
+"ചാറ്റ് പ്രതികരണം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് ദയവായി "
+"വിശദീകരിക്കുക. (ഓപ്ഷണൽ)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15556,8 +15710,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് നിങ്ങളുടെ നിലവിലെ "
-"ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
+"ദയവായി ശ്രദ്ധിക്കുക: ഏതെങ്കിലും മോഡലുമായി ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുന്നത് "
+"നിങ്ങളുടെ നിലവിലെ ചാറ്റ് സെഷൻ ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15566,8 +15720,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15576,8 +15731,9 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത വിവരങ്ങൾ നീക്കം ചെയ്തത്) "
-"ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
+"നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രശ്നമുള്ള ഔട്ട്പുട്ടും (ഏതെങ്കിലും വ്യക്തിഗത "
+"വിവരങ്ങൾ നീക്കം ചെയ്തത്) ഒട്ടിക്കുക, കൂടാതെ ഉള്ളടക്കം നിയമവിരുദ്ധമോ ദോഷകരമോ "
+"ആകുന്നത് എന്തുകൊണ്ടെന്ന് വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15730,7 +15886,8 @@ msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
 msgstr ""
-"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കുകയില്ല."
+"കൂടാതെ, Duck Player-ൽ നിങ്ങൾ കാണുന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കുകയില്ല."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15792,14 +15949,15 @@ msgstr "മോശം ഫോർമാറ്റിംഗ്"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "മോശം ചിത്ര നിലവാരം"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
 msgstr ""
-"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു."
+"ജനപ്രിയ AI മോഡലുകൾ ലഭ്യമാണ്. അക്കൗണ്ട് ആവശ്യമില്ല. ചാറ്റുകൾ ഞങ്ങൾ "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16308,7 +16466,9 @@ msgstr "എന്നെ പ്രോംപ്റ്റ് ചെയ്യു�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് നിർദേശിക്കുക."
+msgstr ""
+"സമീപത്തുള്ള ഫലങ്ങൾക്കായി എന്റെ ഏകദേശ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ എന്നോട് "
+"നിർദേശിക്കുക."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16326,7 +16486,9 @@ msgstr "നിങ്ങൾ തിരയുകയും ബ്രൗസ് ചെ
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ സംരക്ഷിക്കുക."
+msgstr ""
+"തിരയുമ്പോഴും, ബ്രൗസ് ചെയ്യുമ്പോഴും, AI ഉപയോഗിക്കുമ്പോഴും നിങ്ങളുടെ ഡാറ്റ "
+"സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16357,8 +16519,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. [നിങ്ങളുടെ സ്വന്തം "
-"വാചകം ഇവിടെ ചേർക്കുക.]"
+"ഇനിപ്പറയുന്ന വാചകം കൂടുതൽ സംക്ഷിപ്തമാക്കാൻ കുറച്ച് നിർദ്ദേശങ്ങൾ നൽകുക. "
+"[നിങ്ങളുടെ സ്വന്തം വാചകം ഇവിടെ ചേർക്കുക.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16588,14 +16750,16 @@ msgstr "സങ്കീർണ്ണമായ ചോദ്യങ്ങൾക്�
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
 msgstr ""
-"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ പരിധിയിലെത്തുന്നു. "
-"%1$s"
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ 2 മുതൽ 5 മടങ്ങ് വരെ വേഗത്തിൽ ഉപയോഗ "
+"പരിധിയിലെത്തുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ ഉപയോഗിക്കുന്നു. %1$s"
+msgstr ""
+"റീസണിംഗ് കൂടുതൽ സമഗ്രമാണ്, എന്നാൽ പരിധികൾ 2-5 മടങ്ങ് വേഗത്തിൽ "
+"ഉപയോഗിക്കുന്നു. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16645,8 +16809,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുകൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16655,8 +16819,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം നിങ്ങളുടെ "
-"ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
+"സമീപകാല ചാറ്റുകൾ DuckDuckGo സെർവറുൾക്കോ മറ്റ് വിദൂര സെർവറുകൾക്കോ പകരം "
+"നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16666,9 +16830,10 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ പ്രോംപ്റ്റുകളും "
-"പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ "
-"സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
+"സമീപകാല ചാറ്റുകൾ നിങ്ങളുടെ ഉപകരണത്തിൽ തന്നെ സംഭരിച്ചിരിക്കുന്നു. പുതിയ "
+"പ്രോംപ്റ്റുകളും പ്രതികരണങ്ങളും അയച്ചതിനുശേഷം എൻക്രിപ്റ്റ് ചെയ്ത് "
+"താൽക്കാലികമായി ഒരു DuckDuckGo സെർവറിൽ സംഭരിക്കും, ഇത് നിങ്ങളുടെ ഇന്റർനെറ്റ് "
+"കണക്ഷൻ നഷ്ടപ്പെട്ടാൽ ഒരു ചാറ്റ് വീണ്ടെടുക്കാൻ സഹായിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16810,8 +16975,8 @@ msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
 msgstr ""
-"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ വലുപ്പം കുറയ്ക്കുകയും "
-"ചെയ്യുന്നു"
+"ഫലങ്ങളിലും ചുറ്റുമുള്ള അധിക ഇടം കുറയ്ക്കുകയും ഫലമായുള്ള ശീർഷക ടെക്സ്റ്റിന്റെ "
+"വലുപ്പം കുറയ്ക്കുകയും ചെയ്യുന്നു"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16952,8 +17117,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ ബ്രൗസറിലെ "
-"&quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് ചെയ്യുക."
+"നിർദ്ദേശങ്ങൾ പാലിച്ച് DuckDuckGo വീണ്ടും ലോഡ് ചെയ്യുക, അല്ലെങ്കിൽ നിങ്ങളുടെ "
+"ബ്രൗസറിലെ &quot;റിഫ്രഷ്&quot; അല്ലെങ്കിൽ &quot;റീലോഡ്&quot; ബട്ടൺ ക്ലിക്ക് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17061,8 +17227,9 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്‌ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17070,8 +17237,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ പ്രതികരണമായി ഉത്തരങ്ങൾ "
-"സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും സ്വയമേവ പ്രദർശിപ്പിക്കും."
+"\"ചോദിക്കുക\" ബട്ടൺ നീക്കം ചെയ്യുന്നതിനാൽ പ്രസക്തമായ തിരയലുകളുടെ "
+"പ്രതികരണമായി ഉത്തരങ്ങൾ സ്വയമേവ ദൃശ്യമാകും. കാഷെ ചെയ്ത ഉത്തരങ്ങൾ എപ്പോഴും "
+"സ്വയമേവ പ്രദർശിപ്പിക്കും."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17135,9 +17303,10 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അവ "
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ "
-"അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് അയയ്ക്കാറുണ്ട്."
+"റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്, ഞങ്ങളുടെ തിരയൽ സേവനം മെച്ചപ്പെടുത്താൻ "
+"സഹായിക്കുന്നതിന് അവ DuckDuckGo-ലേക്ക് അയയ്ക്കുന്നു. അവരുടെ സേവനങ്ങൾ "
+"മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കും %1$s-ലേക്ക് "
+"അയയ്ക്കാറുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17145,8 +17314,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ "
-"തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയയ്ക്കുന്ന റിപ്പോർട്ടുകൾ അജ്ഞാതമാണ്. നിങ്ങളുടെ "
+"ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17155,9 +17324,10 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് വിവർത്തനം "
-"ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ "
-"വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
+"DuckDuckGo-ലേക്ക് അയച്ച റിപ്പോർട്ടുകളിൽ ഈ പേജ് ലോഡിനിടെ നിങ്ങൾ ഞങ്ങളോട് "
+"വിവർത്തനം ചെയ്യാൻ ആവശ്യപ്പെട്ട എല്ലാ വാചകങ്ങളും ഉൾപ്പെടുന്നു, അവ "
+"അജ്ഞാതവുമാണ്. നിങ്ങളുടെ ഫീഡ്ബാക്കിൽ വ്യക്തിപരമോ തിരിച്ചറിയുന്നതോ ആയ "
+"വിവരങ്ങളൊന്നും ഉൾപ്പെടുത്തരുത്."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17249,9 +17419,10 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. AI- "
-"സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. AI- സഹായത്തോടെയുള്ള ഉത്തരങ്ങൾ ഞങ്ങളുടെ %1$sസേവന "
+"നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17260,9 +17431,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist "
-"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. DuckAssist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17272,10 +17443,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, സാമ്പത്തിക, "
-"നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് "
-"ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search "
-"Assist ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
+"പ്രതികരണങ്ങൾ വിദ്യാഭ്യാസ ആവശ്യങ്ങൾക്കായി മാത്രമാണ്, അവ മെഡിക്കൽ, നിയമ, "
+"സാമ്പത്തിക, നിക്ഷേപം അല്ലെങ്കിൽ മറ്റ് പ്രൊഫഷണൽ ഉപദേശങ്ങൾ എന്ന നിലയിൽ "
+"ഉദ്ദേശിച്ചിട്ടില്ല. അവ വെബ് ഉള്ളടക്കത്തെ അടിസ്ഥാനമാക്കി "
+"സൃഷ്ടിക്കപ്പെട്ടതാണ്, കൂടാതെ കൃത്യതയില്ലായ്മകൾ ഉണ്ടാകാം. Search Assist "
+"ഞങ്ങളുടെ %1$sസേവന നിബന്ധനകൾക്ക്%2$s വിധേയമാണ്."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17352,8 +17524,8 @@ msgstr "ബ്ലോക്ക് ചെയ്‌ത സൈറ്റുകളി�
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
 msgstr ""
-"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ കൈകാര്യം ചെയ്യാൻ "
-"കഴിയും."
+"ഫലങ്ങളിൽ നിങ്ങളുടെ തടഞ്ഞ സൈറ്റുകൾ ഉൾപ്പെടുന്നില്ല, അവ നിങ്ങളുടെ %1$s-ൽ "
+"കൈകാര്യം ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17702,16 +17874,17 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഏറ്റവും പുതിയ "
-"ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ പ്രാദേശികമായി സംരക്ഷിക്കുക."
+"എൻക്രിപ്റ്റ് ചെയ്ത സ്റ്റോറേജ് ഉപയോഗിച്ച് കൂടുതൽ എന്ന ഓപ്ഷൻ ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ നിങ്ങളുടെ ഉപകരണത്തിൽ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ പ്രാദേശികമായി "
-"സംരക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണത്തിൽ നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ 30 എണ്ണം വരെ "
+"പ്രാദേശികമായി സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17719,7 +17892,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai ചാറ്റുകൾ സംരക്ഷിക്കുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ഉപകരണങ്ങൾക്കിടയിൽ Duck.ai "
+"ചാറ്റുകൾ സംരക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17865,13 +18039,17 @@ msgstr "സ്കോട്ട്ലൻഡ്"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"താഴോട്ട് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+msgstr ""
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിപുലമായ ക്രമീകരണം കാണുക%2$s എന്നത് ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -17879,8 +18057,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17889,8 +18067,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. %3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ "
-"%5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sവിലാസ ബാറിൽ തിരയുക%2$s കണ്ടെത്തുക. "
+"%3$sമാറ്റുക%4$s (അല്ലെങ്കിൽ %5$sപുതിയത് ചേർക്കുക%6$s ക്ലിക്ക് ചെയ്യുക)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17909,15 +18087,16 @@ msgstr "താഴേക്ക് സ്ക്രോൾ ചെയ്ത്, �
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
 msgstr ""
-"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ ഉപയോഗിക്കാൻ "
-"അതിനെ അനുവദിക്കുക."
+"%1$sDuckDuckGo%2$s എന്നതിലേക്ക് താഴേക്ക് സ്ക്രോൾ ചെയ്ത് നിങ്ങളുടെ ലൊക്കേഷൻ "
+"ഉപയോഗിക്കാൻ അതിനെ അനുവദിക്കുക."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
 msgstr ""
-"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s ക്ലിക്ക് ചെയ്യുക."
+"താഴേക്ക് സ്ക്രോൾ ചെയ്ത് %1$sസേവനങ്ങൾ%2$s വിഭാഗം എടുത്ത്, %3$sവിലാസ ബാർ%4$s "
+"ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -17979,12 +18158,14 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. ഇത് ചെയ്യുന്നതിന്, "
-"പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം "
-"സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
-"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ പ്രസക്തമാകുമ്പോൾ), "
-"അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ "
-"ഒരു ഭാഗത്ത് മാത്രമേ Search Assist ലഭ്യമാകൂ."
+"Search Assist തിരയൽ ചോദ്യങ്ങൾക്കുള്ള ഉത്തരങ്ങൾ അജ്ഞാതമായി സൃഷ്ടിക്കുന്നു. "
+"ഇത് ചെയ്യുന്നതിന്, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി ഇത് വെബ് സ്കാൻ ചെയ്യുകയും "
+"തുടർന്ന് AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു. "
+"നിങ്ങൾക്ക് ഇത് എത്ര തവണ പ്രത്യക്ഷപ്പെടണമെന്ന് തിരഞ്ഞെടുക്കാം: ഒരിക്കലും, "
+"ഓൺ-ഡിമാൻഡ് (Assist ക്ലിക്ക് ചെയ്യുമ്പോൾ മാത്രം), ചിലപ്പോൾ (വളരെ "
+"പ്രസക്തമാകുമ്പോൾ), അല്ലെങ്കിൽ പലപ്പോഴും (വിശാലമായ തിരയലുകളിൽ). ഈ സമയത്ത്, "
+"ഇംഗ്ലീഷ് സംസാരിക്കുന്ന പ്രദേശങ്ങളുടെ ഒരു ഭാഗത്ത് മാത്രമേ Search Assist "
+"ലഭ്യമാകൂ."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17992,8 +18173,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search Assist-ന് "
-"കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
+"ഈ ചോദ്യത്തിന് ഉത്തരം സൃഷ്ടിക്കുന്നതിന് വേണ്ടത്ര വിശ്വസനീയമായ വിവരങ്ങൾ Search "
+"Assist-ന് കണ്ടെത്താൻ കഴിഞ്ഞില്ല. മറ്റൊരു തിരയൽ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -18002,9 +18183,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ "
-"സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും "
-"കണ്ടെത്തിയ വിവരങ്ങളെ അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
+"Search Assist എന്നത് തിരയൽ അന്വേഷണങ്ങൾക്ക് അജ്ഞാതമായി ഉത്തരങ്ങൾ "
+"സൃഷ്ടിക്കുന്ന ഒരു ഓപ്ഷണൽ സവിശേഷതയാണ്. ഇത് ചെയ്യാൻ, പ്രസക്തമായ "
+"ഉള്ളടക്കത്തിനായി %1$sവെബ് സ്കാൻ%2$s ചെയ്യുകയും കണ്ടെത്തിയ വിവരങ്ങളെ "
+"അടിസ്ഥാനമാക്കി AI ഉപയോഗിച്ച് ഒരു ഹ്രസ്വമായ ഉത്തരം സൃഷ്ടിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18125,8 +18307,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള തിരയൽ "
-"വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
+"%1$s ഷോർട്ട്കട്ടുകൾ ഉപയോഗിച്ച് മറ്റ് സൈറ്റുകൾ തിരയുക: ”!w ducks” എന്നതിനുള്ള "
+"തിരയൽ വിക്കിപീഡിയയിൽ “ducks” എന്നതിനായി നേരിട്ട് തിരയുന്നതാണ്."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18145,9 +18327,9 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, നിങ്ങളുടെ പ്രിയപ്പെട്ട "
-"ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് "
-"തിരയുക."
+"ഞങ്ങളുടെ ആപ്പ് അല്ലെങ്കിൽ എക്സ്റ്റന്‍ഷന്‍ ഉപയോഗിച്ച് സ്വകാര്യമായി തിരയുക, "
+"നിങ്ങളുടെ പ്രിയപ്പെട്ട ബ്രൗസറിലേക്ക് സ്വകാര്യ വെബ് തിരയൽ ചേർക്കുക, "
+"അല്ലെങ്കിൽ %1$sduckduckgo.com%2$s-ൽ നേരിട്ട് തിരയുക."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18155,8 +18337,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST അഭ്യർത്ഥനകൾ "
-"ഉപയോഗിക്കും)"
+"തിരയൽ അന്വേഷണങ്ങൾ URL-ൽ ഉൾപ്പെടുത്തിയിട്ടുണ്ട് (ഓഫാണെങ്കിൽ തിരയലുകൾ POST "
+"അഭ്യർത്ഥനകൾ ഉപയോഗിക്കും)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18168,10 +18350,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക സംഭരണത്തിലും നിങ്ങളുടെ "
-"ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
-"അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന "
-"വിവരങ്ങളൊന്നും ക്ലൗഡിൽ സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
+"തിരയൽ ക്രമീകരണങ്ങൾ വ്യക്തിഗതമല്ലാത്ത ബ്രൗസർ കുക്കികളിലും പ്രാദേശിക "
+"സംഭരണത്തിലും നിങ്ങളുടെ ബ്രൗസറിലും സൂക്ഷിച്ചിരിക്കുന്നു, എന്നാൽ ക്ലൗഡിലെ ഒരു "
+"വിദൂര സെർവറിൽ നിങ്ങളുടെ ക്രമീകരണങ്ങൾ അജ്ഞാതമായി സൂക്ഷിക്കാൻ Cloud Save "
+"ഉപയോഗിക്കാം. വ്യക്തിപരമായി തിരിച്ചറിയാൻ കഴിയുന്ന വിവരങ്ങളൊന്നും ക്ലൗഡിൽ "
+"സംഭരിക്കപ്പെടില്ല, നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും നിങ്ങളുടെ ബ്രൗസർ "
 "വിട്ടുപോകില്ല."
 
 # smartling.placeholder_format=C
@@ -18267,7 +18450,8 @@ msgstr "രണ്ടാമതൊരു അഭിപ്രായം"
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
 msgstr ""
-"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
+"നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും ചാറ്റുകൾ സുരക്ഷിതമായി സംരക്ഷിക്കുകയും "
+"സമന്വയിപ്പിക്കുകയും ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18276,8 +18460,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18286,8 +18471,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, അവ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18296,8 +18482,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ സുരക്ഷിതമായി "
-"സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് ഞങ്ങളുടെ സെർവറിൽ പരിധിയില്ലാതെ ചാറ്റുകൾ "
+"സുരക്ഷിതമായി സംഭരിച്ച്, സിങ്ക് ചെയ്ത എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18306,15 +18493,17 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ സുരക്ഷിതമായി "
-"സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് ചെയ്യുക."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് നിങ്ങളുടെ ചാറ്റുകൾ ഞങ്ങളുടെ സെർവറിൽ "
+"സുരക്ഷിതമായി സംഭരിക്കുക, നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിൽ നിന്നും അവ ആക്സസ് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18323,8 +18512,9 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി സംഭരിച്ചിരിക്കുന്നു. "
-"നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, ഞങ്ങൾക്ക് പോലും."
+"എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ DuckDuckGo-യുടെ സെർവറിൽ സുരക്ഷിതമായി "
+"സംഭരിച്ചിരിക്കുന്നു. നിനക്കല്ലാതെ മറ്റാർക്കും നിന്റെ ഡാറ്റ കാണാൻ കഴിയില്ല, "
+"ഞങ്ങൾക്ക് പോലും."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18469,34 +18659,38 @@ msgstr "%1$s%2$s%3$s തിരഞ്ഞെടുക്കുക, തുടർന
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
 msgstr ""
-"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് തിരഞ്ഞെടുക്കുക."
+"Safari മെനുവിൽ നിന്ന് %1$s'ഈ വെബ്‌സൈറ്റിനായുള്ള ക്രമീകരണം...'%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം %3$shttps://duckduckgo.com%4$s എന്ന് "
-"ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
+"%1$sഇഷ്ടാനുസൃതമാക്കുക%2$s ഓപ്ഷൻ തിരഞ്ഞെടുത്ത ശേഷം "
+"%3$shttps://duckduckgo.com%4$s എന്ന് ഇൻപുട്ട് ഫീൽഡിൽ എന്റർ ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ ക്ലിക്ക് "
-"ചെയ്യുക!"
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത ശേഷം %3$sഡിഫോൾട്ടായി ചേർക്കുക%4$s എന്നതിൽ "
+"ക്ലിക്ക് ചെയ്യുക!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക"
+msgstr ""
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
 msgstr ""
-"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് %3$sഡിഫോൾട്ടായി സജ്ജീകരിക്കുക%4$s ക്ലിക്ക് "
+"ചെയ്യുക."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18508,7 +18702,9 @@ msgstr "ഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ ഡ്ര
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %4$sഅനുവദിക്കുക%3$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%4$sഅനുവദിക്കുക%3$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18521,7 +18717,8 @@ msgstr "തിരയൽ ദാതാക്കളുടെ പട്ടികയ�
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
 msgstr ""
-"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+"%3$sഡിഫോൾട്ട് തിരയൽ എഞ്ചിൻ%4$s വിഭാഗത്തിന് കീഴിൽ %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18532,13 +18729,17 @@ msgstr "%1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗണിൽ %1$sതിരയൽ എഞ്ചിനുകൾ എഡിറ്റ് ചെയ്യുക...%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sManage add-ons%s from the dropdown menu"
-msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന് %1$sആഡ്-ഓണുകൾ മാനേജ് ചെയ്യുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -18546,8 +18747,8 @@ msgstr "ഡ്രോപ്പ്ഡൗൺ മെനുവിൽ നിന്ന�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sമെനു > ക്രമീകരണം%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18555,8 +18756,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s എന്നും "
-"തിരഞ്ഞെടുക്കുക"
+"(Mac-ൽ) %1$sOpera > മുൻഗണനകൾ%2$s എന്നും (Windows-ൽ) %3$sOpera > ഓപ്ഷനുകൾ%4$s "
+"എന്നും തിരഞ്ഞെടുക്കുക"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18621,14 +18822,16 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ "
-"നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
+"%1$sഈ വെബ് പേജ് നിങ്ങളുടെ ഏക ഹോം പേജായി ഉപയോഗിക്കുക%2$s എന്നത് "
+"തിരഞ്ഞെടുക്കുക (അല്ലെങ്കിൽ നിങ്ങൾ ഇഷ്ടപ്പെടുന്നെങ്കിൽ മറ്റ് ഓപ്ഷനുകളിൽ ഒന്ന്)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് %3$sഅനുവദിക്കുക%4$s"
+msgstr ""
+"ലിസ്റ്റിൽ %1$sനിങ്ങളുടെ ബ്രൗസർ%2$s തിരഞ്ഞെടുത്ത് ലൊക്കേഷൻ ആക്സസ് "
+"%3$sഅനുവദിക്കുക%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18701,7 +18904,8 @@ msgstr "%1$s-ൽ നിന്ന് തിരഞ്ഞെടുത്ത ടെ�
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
 msgstr ""
-"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
+"തിരഞ്ഞെടുത്ത വാചകം വളരെ ദൈർഘ്യമേറിയതാണ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് "
+"വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18745,9 +18949,9 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ സന്ദേശങ്ങളുമായി AI "
-"മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും "
-"ബാധകമാകും."
+"എങ്ങനെ പ്രതികരിക്കണമെന്നതിനെക്കുറിച്ചുള്ള നിർദ്ദേശങ്ങളുള്ള നിങ്ങളുടെ "
+"സന്ദേശങ്ങളുമായി AI മോഡലുകളിലേക്ക് ഒരു പ്രോംപ്റ്റ് അയയ്ക്കുന്നു. ഈ "
+"നിർദ്ദേശങ്ങൾ ഇനി മുതൽ എല്ലാ സംഭാഷണങ്ങൾക്കും ബാധകമാകും."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18870,8 +19074,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് ചരിത്രം ഓണാക്കിയ "
-"ശേഷം Sync & Backup സജ്ജമാക്കുക."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഉപകരണങ്ങളിലുടനീളം സമന്വയിപ്പിച്ച് നിലനിർത്താൻ, ചാറ്റ് "
+"ചരിത്രം ഓണാക്കിയ ശേഷം Sync & Backup സജ്ജമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18953,7 +19157,9 @@ msgstr "പങ്കിടുക"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ സഹായിക്കുക!"
+msgstr ""
+"DuckDuckGo പങ്കിടുക, സുഹൃത്തുക്കളെ അവരുടെ സ്വകാര്യത തിരികെ കൊണ്ടുവരാൻ "
+"സഹായിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -18980,8 +19186,9 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. Duck.ai "
-"ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ വെളിപ്പെടുത്തുകയില്ല."
+"പ്രസക്തി മെച്ചപ്പെടുത്തുന്നതിന് AI മോഡലുകളുമായി ഒരു നഗരതല ലൊക്കേഷൻ പങ്കിടുക. "
+"Duck.ai ഒരിക്കലും നിങ്ങളുടെ കൃത്യമായ ലൊക്കേഷൻ ഞങ്ങൾക്കോ AI മോഡലുകൾക്കോ "
+"വെളിപ്പെടുത്തുകയില്ല."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19083,8 +19290,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക (നിയമവിരുദ്ധവും "
-"ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
+"നിങ്ങളുടെ പ്രോംപ്റ്റും ചാറ്റ് പ്രതികരണവും DuckDuckGo-യുമായി പങ്കിടുക "
+"(നിയമവിരുദ്ധവും ദോഷകരവുമായ റിപ്പോർട്ടിന് ആവശ്യമാണ്)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19133,8 +19340,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം സംരക്ഷിക്കൂ. "
-"സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
+"ഞങ്ങളുടെ നോ-ലോഗ്, വേഗതയേറിയ VPN ഉപയോഗിച്ച് നിങ്ങളുടെ ഓൺലൈൻ പ്രവർത്തനം "
+"സംരക്ഷിക്കൂ. സജ്ജീകരിക്കാൻ ലളിതവും എപ്പോൾ വേണമെങ്കിലും എളുപ്പത്തിൽ ഓൺ "
+"ചെയ്യാനും ഓഫ് ചെയ്യാനും കഴിയുന്നതും."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19260,7 +19468,9 @@ msgstr "DuckAssist <sup>BETA</sup> കാണിക്കുക"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും %1$sഓഫാക്കാം%2$s.)"
+msgstr ""
+"DuckAssist കൂടുതൽ തവണ കാണിക്കുക. (നിങ്ങൾക്ക് ഇത് പൂർണ്ണമായും "
+"%1$sഓഫാക്കാം%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19443,7 +19653,9 @@ msgstr "സൈഡ്ബാർ കാണിക്കുക"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ കാണിക്കുക."
+msgstr ""
+"Duck.ai പരമാവധി പ്രയോജനപ്പെടുത്തുന്നതിനുള്ള ഘട്ടം ഘട്ടമായുള്ള നുറുങ്ങുകൾ "
+"കാണിക്കുക."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19498,8 +19710,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. "
-"ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും സ്വകാര്യമാണെന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയലിന്റെ സ്വകാര്യതയെ ഒരിക്കലും ബാധിക്കില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19507,9 +19720,9 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു ഓർമ്മപ്പെടുത്തൽ "
-"കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും "
-"ബാധിക്കുന്നില്ല."
+"DuckDuckGo-യിലെ തിരയലുകൾ എല്ലായ്പ്പോഴും പരിരക്ഷിക്കപ്പെടുന്നു എന്നുള്ള ഒരു "
+"ഓർമ്മപ്പെടുത്തൽ കാണിക്കുന്നു. ഇത് ഓഫാക്കുന്നത് ഓർമ്മപ്പെടുത്തൽ മറയ്ക്കുന്നു, "
+"കൂടാതെ തിരയൽ പരിരക്ഷയെ ഒരിക്കലും ബാധിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19520,7 +19733,8 @@ msgstr "ഫല പേജ് ഇടവേളകളിൽ തിരശ്ചീന
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
 msgstr ""
-"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള ലിങ്കുകൾ കാണിക്കുന്നു"
+"DuckDuckGo നിങ്ങളുടെ ബ്രൗസറിലേക്ക് കൂട്ടിച്ചേർക്കാനുള്ള നിർദേശങ്ങളിലേക്കുള്ള "
+"ലിങ്കുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19537,21 +19751,23 @@ msgstr "പുതിയ ടാബ് പേജിൽ ഏറ്റവും ക�
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ബ്രൗസറിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്ക് DuckDuckGo ചേർക്കാനുള്ള ഇടയ്ക്കിടെയുള്ള "
+"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് ഇടയ്ക്കിടെയുള്ള "
-"ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
+"DuckDuckGo സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾക്കായി സൈൻ അപ്പ് ചെയ്യുന്നതിന് "
+"ഇടയ്ക്കിടെയുള്ള ഓർമപ്പെടുത്തലുകൾ കാണിക്കുന്നു"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19659,12 +19875,16 @@ msgstr "സൈറ്റുകളുടെ പേരുകൾ"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ പ്രവർത്തിക്കുന്നു."
+msgstr ""
+"സൈറ്റ് തിരയൽ താൽക്കാലികമായി ലഭ്യമല്ല. ഞങ്ങൾ ഒരു പരിഹാരം കണ്ടെത്താൻ "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും മറയ്ക്കും"
+msgstr ""
+"നിങ്ങൾ ബ്ലോക്ക് ചെയ്യുന്ന സൈറ്റുകൾ നിങ്ങളുടെ എല്ലാ തിരയൽ ഫലങ്ങളിൽ നിന്നും "
+"മറയ്ക്കും"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19824,7 +20044,8 @@ msgstr "സെർവറിലേക്ക് സംരക്ഷിക്കു�
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
 msgstr ""
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കുമ്പോൾ എന്തോ കുഴപ്പം സംഭവിച്ചു. ദയവായി "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19855,8 +20076,8 @@ msgstr "ചിലപ്പോൾ"
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
 msgstr ""
-"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു രീതിയിൽ "
-"വിവരിക്കുക."
+"ക്ഷമിക്കണം, എനിക്ക് സഹായിക്കാനാകില്ല, ദയവായി നിങ്ങളുടെ ചിത്രത്തെ മറ്റൊരു "
+"രീതിയിൽ വിവരിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19895,8 +20116,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി മറ്റൊരു ചിത്രമോ "
-"ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
+"ക്ഷമിക്കണം, അപ്‌ലോഡ് ചെയ്ത ചിത്രം പ്രോസസ്സ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി "
+"മറ്റൊരു ചിത്രമോ ഫോർമാറ്റോ പരീക്ഷിച്ചുനോക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19905,16 +20126,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ ചെയ്തതെന്ന് "
-"ഉറപ്പാക്കുക."
+"ക്ഷമിക്കണം, ഈ കോഡ് അസാധുവാണ്. ശരിയായ കോഡ് ആണ് നൽകിയത് അല്ലെങ്കിൽ സ്കാൻ "
+"ചെയ്തതെന്ന് ഉറപ്പാക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. നിങ്ങൾക്ക് Duck.ai-യോട് "
-"ചോദിക്കാൻ ശ്രമിക്കാം."
+"ക്ഷമിക്കണം, ഞങ്ങൾക്ക് കൂടുതൽ മികച്ച ഒരു ഉത്തരം സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല. "
+"നിങ്ങൾക്ക് Duck.ai-യോട് ചോദിക്കാൻ ശ്രമിക്കാം."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19923,15 +20144,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. വീണ്ടും ശ്രമിക്കാൻ "
-"%1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
+"ക്ഷമിക്കണം, ഈ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഞങ്ങൾക്ക് ഒരു പിശക് നേരിട്ടു. "
+"വീണ്ടും ശ്രമിക്കാൻ %1$sഇവിടെ ക്ലിക്ക് ചെയ്യുക%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+"ക്ഷമിക്കണം, നിങ്ങളുടെ ഫീഡ്ബാക്ക് സമർപ്പിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. പിന്നീട് "
+"വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19986,8 +20208,8 @@ msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
 msgstr ""
-"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് തിരഞ്ഞെടുത്ത് വീണ്ടും "
-"ശ്രമിക്കൂ."
+"സംഗ്രഹിക്കാൻ കഴിയാത്തത്ര ദൈർഘ്യമുള്ളതാണ് ഉറവിട ടെക്‌സ്റ്റ്. ദൈർഘ്യം കുറഞ്ഞത് "
+"തിരഞ്ഞെടുത്ത് വീണ്ടും ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20192,7 +20414,9 @@ msgstr "DuckDuckGo-യിൽ തുടരുക"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും അറിവുള്ളവരായും തുടരുക."
+msgstr ""
+"ഞങ്ങളുടെ സ്വകാര്യതാ വാർത്താക്കുറിപ്പുകൾ ഉപയോഗിച്ച് പരിരക്ഷയോടെയും "
+"അറിവുള്ളവരായും തുടരുക."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20242,7 +20466,9 @@ msgstr "സൃഷ്ടിക്കൽ നിർത്തുക"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ പ്രതിരോധിക്കുക."
+msgstr ""
+"മറ്റ് വെബ്‌സൈറ്റുകളിൽ പതിയിരിക്കുന്ന മറയ്ക്കപ്പെട്ട ട്രാക്കറുകൾ "
+"പ്രതിരോധിക്കുക."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20337,8 +20563,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, അല്ലെങ്കിൽ "
-"കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
+"Duck.ai-ൽ ഉയർന്ന പരിധികൾ അൺലോക്ക് ചെയ്യാൻ DuckDuckGo സബ്‌സ്‌ക്രൈബ് ചെയ്യുക, "
+"അല്ലെങ്കിൽ കൂടുതൽ ഇമേജുകൾ സൃഷ്ടിക്കാൻ പിന്നീട് തിരികെ വരിക."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20407,8 +20633,8 @@ msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
 msgstr ""
-"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ എഴുതാൻ ഒരു വാക്യം "
-"നിർദ്ദേശിക്കാമോ?"
+"ഒരു ശസ്ത്രക്രിയയിൽ നിന്ന് സുഖം പ്രാപിക്കുന്ന ഒരാൾക്ക് ഒരു ഗെറ്റ്-വെൽ കാർഡിൽ "
+"എഴുതാൻ ഒരു വാക്യം നിർദ്ദേശിക്കാമോ?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20744,7 +20970,9 @@ msgstr "%1$sഎന്നതിലേക്ക് മാറി"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് അയയ്ക്കും"
+msgstr ""
+"മാറുന്നത് നിങ്ങളുടെ ചാറ്റിനെ ദാതാവിന്റെ ദൃശ്യപരതയില്ലാത്ത ഒരു മോഡലിലേക്ക് "
+"അയയ്ക്കും"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20798,7 +21026,9 @@ msgstr "Sync & Backup പ്രവർത്തനക്ഷമമാക്കി!
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ കഴിയില്ല."
+msgstr ""
+"Sync & Backup ഡാറ്റ 18 മാസത്തെ നിഷ്‌ക്രിയത്വത്തിന് ശേഷം വീണ്ടെടുക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20807,8 +21037,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup നിങ്ങളുടെ കൂടുതൽ ചാറ്റുകൾ സംരക്ഷിക്കുകയും അവയെ നിങ്ങളുടെ എല്ലാ ഉപകരണങ്ങളിലും "
-"ഉടനീളം സമന്വയിപ്പിക്കുകയും ചെയ്യുന്നു."
+"Sync & Backup നിങ്ങളുടെ കൂടുതൽ ചാറ്റുകൾ സംരക്ഷിക്കുകയും അവയെ നിങ്ങളുടെ എല്ലാ "
+"ഉപകരണങ്ങളിലും ഉടനീളം സമന്വയിപ്പിക്കുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20857,25 +21087,27 @@ msgid ""
 msgstr ""
 "വീണ്ടെടുക്കൽ കോഡ് സമന്വയിപ്പിക്കുക\n"
 "\n"
-" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, ഡാറ്റ ഓട്ടോഫിൽ "
-"ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ "
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
+" ഒന്നിലധികം ഉപകരണങ്ങളിലുടനീളം നിങ്ങളുടെ പാസ്‌വേഡുകൾ സമന്വയിപ്പിക്കാനും, "
+"ഡാറ്റ ഓട്ടോഫിൽ ചെയ്യാനും, Duck.ai ചാറ്റുകൾ ഉപയോഗിക്കാനും, ഒരു "
+"ഉപകരണത്തിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെടുകയാണെങ്കിൽ നിങ്ങളുടെ സമന്വയിപ്പിച്ച "
+"ഡാറ്റ വീണ്ടെടുക്കാനും വീണ്ടെടുക്കൽ കോഡ് നിങ്ങളെ അനുവദിക്കുന്നു.\n"
 "\n"
 "ഈ വിവരങ്ങൾ സുരക്ഷിതമായി സൂക്ഷിക്കുക.\n"
-"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ കഴിയും.\n"
+"ഈ കോഡിന് പ്രവേശനം ഉള്ള ആരും നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയും.\n"
 "\n"
 "%1$s\n"
 "\n"
 "ഈ കോഡ് എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്?\n"
 "1. നിങ്ങളുടെ ബ്രൗസറിൽ Duck.ai-ലേക്ക് പോയി Duck.ai സെറ്റിംഗ്സ് തുറക്കുക.\n"
-"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ വീണ്ടെടുക്കുക\" "
-"തിരഞ്ഞെടുക്കുക.\n"
-"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" എന്ന് പറയുന്നിടത്ത് "
-"ഒട്ടിക്കുക.\n"
+"2. \"Sync & Backup\" തിരഞ്ഞെടുക്കുക, തുടർന്ന് \"സമന്വയിപ്പിച്ച ഡാറ്റ "
+"വീണ്ടെടുക്കുക\" തിരഞ്ഞെടുക്കുക.\n"
+"3. മുകളിലുള്ള വീണ്ടെടുക്കൽ കോഡ് പകർത്തി \"നിങ്ങളുടെ കോഡ് ഇവിടെ ഒട്ടിക്കുക\" "
+"എന്ന് പറയുന്നിടത്ത് ഒട്ടിക്കുക.\n"
 "\n"
-"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ 18 "
-"മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് ഇല്ലാതാക്കപ്പെടും, അത് "
-"പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
+"Sync & Backup പ്രവർത്തനക്ഷമമാക്കിയ ഒരു DuckDuckGo ബ്രൗസർ ഉപയോഗിക്കാതെ നിങ്ങൾ "
+"18 മാസത്തിൽ കൂടുതൽ ചെലവഴിച്ചാൽ, നിങ്ങളുടെ ഡാറ്റ സെർവറിൽ നിന്ന് "
+"ഇല്ലാതാക്കപ്പെടും, അത് പുനഃസ്ഥാപിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -21014,8 +21246,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും വേഗത്തിൽ ആക്സസ് "
-"ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് നേടൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെയായിരുന്നാലും "
+"വേഗത്തിൽ ആക്സസ് ചെയ്യുന്നതിന് ഞങ്ങളുടെ സൗജന്യ ആപ്പിൽ ഇത് ബിൽറ്റ് ഇൻ ചെയ്ത് "
+"നേടൂ."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21024,8 +21257,9 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള "
-"ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് ഉൾപ്പെടുത്തൂ."
+"Duck.ai നിങ്ങൾക്കൊപ്പം എല്ലായിടത്തും കൂടെ കരുതൂ. നിങ്ങൾ എവിടെ ബ്രൗസ് "
+"ചെയ്യുമ്പോഴും വേഗത്തിലുള്ള ആക്സസിനായി ഞങ്ങളുടെ സൗജന്യ ബ്രൗസറിൽ ഇത് "
+"ഉൾപ്പെടുത്തൂ."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21048,7 +21282,9 @@ msgstr "നിങ്ങളുടെ സ്വകാര്യ ഡാറ്റയ�
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ പങ്കെടുക്കൂ."
+msgstr ""
+"Duck.ai എങ്ങനെ മെച്ചപ്പെടുത്താമെന്ന് ഞങ്ങളെ അറിയിക്കാൻ ഈ അജ്ഞാത സർവേയിൽ "
+"പങ്കെടുക്കൂ."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21269,9 +21505,10 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ ഒരു മൂന്നാം "
-"കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ "
-"പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ ഉൾപ്പെടുന്നു."
+"നിങ്ങളുടെ ഉപകരണത്തിനും ഈ ലിങ്കിന് പിന്നിലെ വെബ്‌പോജിനുമിടയിൽ അയച്ച വിവരങ്ങൾ "
+"ഒരു മൂന്നാം കക്ഷി തടസ്സപ്പെടുത്താനുള്ള സാധ്യത കൂടുതലാണ് എന്നാണ് ഇതിനർഥം. "
+"അപൂർവ സന്ദർഭങ്ങളിൽ ഇതിൽ പാസ്‍വേഡുകൾ അല്ലെങ്കിൽ പേയ്മെന്റ് വിശദാംശങ്ങൾ "
+"ഉൾപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21280,8 +21517,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ സംരക്ഷിക്കാൻ Cloud Save "
-"ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
+"നിങ്ങളുടെ ക്രമീകരണത്തിൽ വരുത്തുന്ന ഏത് മാറ്റങ്ങളും ക്ലൗഡിൽ സ്വയമേവ "
+"സംരക്ഷിക്കാൻ Cloud Save ബുക്ക്‌മാർക്ക്‌ലെറ്റ് അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21290,8 +21527,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"DuckDuckGo അജ്ഞാതമാക്കിയ സ്വകാര്യ തിരയലും AI ചാറ്റും തമ്മിൽ വേഗത്തിൽ മാറാൻ Duck.ai "
-"ടോഗിൾ അനുവദിക്കുന്നു."
+"DuckDuckGo അജ്ഞാതമാക്കിയ സ്വകാര്യ തിരയലും AI ചാറ്റും തമ്മിൽ വേഗത്തിൽ മാറാൻ "
+"Duck.ai ടോഗിൾ അനുവദിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21321,15 +21558,17 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ "
-"നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
+"എൻക്രിപ്ഷൻ കീ നിങ്ങളുടെ ബ്രൗസറിന്റെ ലോക്കൽ സ്റ്റോറേജിൽ മാത്രമേ "
+"സംരക്ഷിക്കപ്പെടുകയുള്ളൂ, കൂടാതെ നിങ്ങൾക്ക് മാത്രമേ അത് ആക്‌സസ് ചെയ്യാൻ കഴിയൂ."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് ഇല്ലാതാക്കും."
+msgstr ""
+"ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഏതൊരു ഡാറ്റയും 30 ദിവസത്തിനുള്ളിൽ മോഡൽ ദാതാവ് "
+"ഇല്ലാതാക്കും."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21402,9 +21641,9 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക ഡാറ്റ സംഭരണം "
-"പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ "
-"പരിശോധിക്കുക."
+"ഈ ചാറ്റ് പ്രാദേശികമായി സേവ് ചെയ്യുന്നതിൽ ഒരു പിശക് സംഭവിച്ചു. പ്രാദേശിക "
+"ഡാറ്റ സംഭരണം പ്രവർത്തനക്ഷമമാക്കിയിട്ടുണ്ടെന്ന് ഉറപ്പുവരുത്താൻ ദയവായി "
+"നിങ്ങളുടെ ബ്രൗസർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21419,8 +21658,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ വീണ്ടും ശ്രമിക്കുന്നതിന് "
-"മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
+"തിരയൽ ഫലങ്ങൾ പ്രദർശിപ്പിക്കുന്നതിൽ ഇപ്പോഴും ഒരു പിശകുണ്ടായിരുന്നു. നിങ്ങൾ "
+"വീണ്ടും ശ്രമിക്കുന്നതിന് മുമ്പ് ഏതാനും മിനിറ്റ് കാത്തിരിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21439,10 +21678,10 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ എൻക്രിപ്റ്റ് "
-"ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും "
-"നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ "
-"ഉപയോഗിക്കുന്നു."
+"മറഞ്ഞിരിക്കുന്ന ട്രാക്കറുകൾ തടയുന്നതിലൂടെയും സാധ്യമാകുന്നിടത്ത് കണക്ഷനുകൾ "
+"എൻക്രിപ്റ്റ് ചെയ്യുന്നതിലൂടെയും DuckDuckGo-യെ നിങ്ങളുടെ ഡിഫോൾട്ട് തിരയൽ "
+"എഞ്ചിനാക്കി മാറ്റുന്നതിലൂടെയും നിങ്ങൾ സന്ദർശിക്കുന്ന വെബ്‌സൈറ്റുകളിൽ "
+"സ്വകാര്യതാ പരിരക്ഷണം ചേർക്കാൻ ഈ ബ്രൗസർ അനുമതികൾ ഉപയോഗിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21488,8 +21727,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ പതിപ്പിൽ ഒരു പുതിയ "
-"ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
+"ഈ AI മോഡൽ പതിപ്പിനെ ഇനി പിന്തുണയ്ക്കുന്നില്ല. ഈ മോഡലിന്റെ ഏറ്റവും പുതിയ "
+"പതിപ്പിൽ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21519,7 +21758,9 @@ msgstr "ഈ ആഴ്ച"
 #. Info bullet in the Duck.ai share modal explaining the original chat stays private. 'Duck.ai' is a brand name and should not be translated.
 msgctxt "Share modal info bullet about private original chat"
 msgid "This chat stays in Duck.ai and remains private to you."
-msgstr "ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും ചെയ്യും."
+msgstr ""
+"ഈ ചാറ്റ് Duck.ai-യിൽ തന്നെ തുടരുകയും നിങ്ങൾക്ക് സ്വകാര്യമായിരിക്കുകയും "
+"ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21528,9 +21769,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
-"ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് Duck.ai (%1$s) വഴിയാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
+"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം "
+"(കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21540,9 +21781,9 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. "
-"AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് "
-"%2$s കാണുക)."
+"ഒന്നിലധികം ചാറ്റ് മോഡലുകൾ ഉപയോഗിച്ച് Duck.ai (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
+"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21551,8 +21792,9 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI കൃത്യതയില്ലാത്തതോ "
-"കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് %2$s കാണുക)."
+"Duck.ai വോയ്സ് ചാറ്റ് (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം സൃഷ്ടിച്ചത്. AI "
+"കൃത്യതയില്ലാത്തതോ കുറ്റകരമോ ആയ വിവരങ്ങൾ നൽകിയേക്കാം. (കൂടുതൽ വിവരങ്ങൾക്ക് "
+"%2$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21562,9 +21804,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ സംഭാഷണം "
-"സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ "
-"വിവരങ്ങൾക്ക് %4$s കാണുക)."
+"%2$s-ന്റെ %3$s മോഡൽ ഉപയോഗിച്ച് DuckDuckGo AI Chat (%1$s) ഉപയോഗിച്ചാണ് ഈ "
+"സംഭാഷണം സൃഷ്ടിച്ചത്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ വിവരങ്ങൾ "
+"പ്രദർശിപ്പിച്ചേക്കാം (കൂടുതൽ വിവരങ്ങൾക്ക് %4$s കാണുക)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21581,8 +21823,9 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ ഉപകരണത്തിന് ഇനി "
-"കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും."
+"മറ്റ് ഉപകരണങ്ങളിലുള്ള നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ ആക്‌സസ് ചെയ്യാൻ ഈ "
+"ഉപകരണത്തിന് ഇനി കഴിയില്ല. അവസാന %1$s ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21614,7 +21857,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s"
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ചുചെയ്യുക"
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s "
+"അറ്റാച്ചുചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Error message for unsupported file type when multiple types are accepted. First placeholder is a comma-separated list of all accepted types except the last (e.g. PNG, JPG, WebP, GIF). Second placeholder is the last accepted type (e.g. PDF). Full example: This file type is not supported, please attach a PNG, JPG, WebP, GIF or PDF
@@ -21622,7 +21867,9 @@ msgctxt ""
 "Error message when an uploaded file type is not supported, with list ending "
 "in or"
 msgid "This file type is not supported, please attach a %s or %s."
-msgstr "ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് ചെയ്യുക."
+msgstr ""
+"ഈ ഫയൽ തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു %1$s അല്ലെങ്കിൽ %2$s അറ്റാച്ച് "
+"ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to upload an unsupported file type and we know which types are accepted. Placeholder is a single accepted type. E.g. This file type is not supported, please attach a PDF
@@ -21654,7 +21901,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
 msgstr ""
-"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക"
+"ഈ ഇമേജ് തരം പിന്തുണയ്ക്കുന്നില്ല, ദയവായി ഒരു JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
@@ -21662,7 +21910,8 @@ msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
 msgstr ""
-"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF ചേർക്കുക."
+"ഈ ഇമേജ് തരത്തെ പിന്തുണയ്ക്കുന്നില്ല, ദയവായി JPG, PNG, WebP, അല്ലെങ്കിൽ GIF "
+"ചേർക്കുക."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21690,8 +21939,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ ഇതിന്റെ മെനു (മൂന്ന് "
-"ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. നിങ്ങളുടെ ചാറ്റുകളുടെ മുകളിൽ നിലനിർത്താൻ "
+"ഇതിന്റെ മെനു (മൂന്ന് ഡോട്ടുകൾ) തുറന്ന് പിൻ തിരഞ്ഞെടുക്കുക!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21700,7 +21949,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire Button ഉപയോഗിക്കുക!"
+"ഇതൊരു സാമ്പിൾ ചാറ്റ് മാത്രമാണ്. ഇത് ഇല്ലാതാക്കാൻ വശത്തുള്ള മെനുവിലെ Fire "
+"Button ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21721,8 +21971,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ ഇല്ലാതാക്കും. മറ്റ് മോഡൽ "
-"ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഡാറ്റ 30 ദിവസത്തിനുള്ളിൽ "
+"ഇല്ലാതാക്കും. മറ്റ് മോഡൽ ദാതാക്കൾ പൂജ്യം ഡാറ്റ നിലനിർത്തൽ മോഡൽ പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21731,8 +21981,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് മോഡൽ ദാതാക്കൾ ഒരു "
-"പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
+"ഈ മോഡൽ ദാതാവ് ഈ ചാറ്റുമായി ബന്ധപ്പെട്ട ഒരു ഡാറ്റയും സംഭരിക്കുന്നില്ല. മറ്റ് "
+"മോഡൽ ദാതാക്കൾ ഒരു പരിമിത ഡാറ്റ നിലനിർത്തൽ മാതൃക പിന്തുടരുന്നു."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21769,8 +22019,9 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് "
-"സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് ആക്‌സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് നിങ്ങളുടെ ചാറ്റുകൾ DuckDuckGo-യുടെ സുരക്ഷിത സെർവറിൽ എൻഡ്-ടു-എൻഡ് "
+"എൻക്രിപ്ഷൻ ഉപയോഗിച്ച് സംരക്ഷിക്കുന്നു, പിന്നീട് ഏത് ബ്രൗസറിൽ നിന്നും ഇത് "
+"ആക്‌സസ് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21779,8 +22030,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21790,10 +22042,10 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ duckduckgo.com ബ്രൗസർ "
-"ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. "
-"എന്നിരുന്നാലും, %1$s-ൽ AI സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും "
-"ഞങ്ങൾക്ക് ഉണ്ട്."
+"ഈ ക്രമീകരണം നിങ്ങളുടെ ബ്രൗസറിൽ സൂക്ഷിച്ചിരിക്കുന്നു, അതായത് നിങ്ങൾ "
+"duckduckgo.com ബ്രൗസർ ഡാറ്റ മായ്ക്കുകയാണെങ്കിൽ, നിങ്ങൾക്ക് AI സഹായമുള്ള "
+"ഉത്തരങ്ങൾ വീണ്ടും കാണാൻ കഴിയുമെന്നർത്ഥം. എന്നിരുന്നാലും, %1$s-ൽ AI "
+"സഹായത്തോടെ ഉത്തരങ്ങൾ ഒരിക്കലും കാണിക്കാത്ത ഒരു ആരംഭ പേജും ഞങ്ങൾക്ക് ഉണ്ട്."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21834,7 +22086,9 @@ msgstr "ഈ വീഡിയോ ഇതുവരെ ഇവിടെ കാണാ�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) ഉപയോഗിക്കുന്നില്ല."
+msgstr ""
+"ഈ വെബ്‌പേജ് സുരക്ഷിതവും എൻക്രിപ്റ്റ് ചെയ്തതുമായ കണക്ഷൻ (HTTPS) "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21844,9 +22098,10 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും Sync & Backup "
-"വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ "
-"നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് ചെയ്യാൻ കഴിയും."
+"ഇത് ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ എല്ലാ Duck.ai ചാറ്റുകളും ഇല്ലാതാക്കുകയും "
+"Sync & Backup വിച്ഛേദിക്കുകയും ചെയ്യും. Sync & Backup-ലേക്ക് കണക്റ്റ് "
+"ചെയ്തിരിക്കുന്ന മറ്റ് ബ്രൗസറുകളിൽ നിങ്ങൾക്ക് തുടർന്നും ചാറ്റുകൾ ആക്സസ് "
+"ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21855,8 +22110,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. ഇത് "
-"പഴയപടിയാക്കാനാവില്ല."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകളെല്ലാം പിൻ ചെയ്തിട്ടില്ലെങ്കിൽ ഇത് ഇല്ലാതാക്കും. "
+"ഇത് പഴയപടിയാക്കാനാവില്ല."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21875,7 +22130,8 @@ msgstr "ഇത് എല്ലാ ക്രമീകരണവും മായ്
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
 msgstr ""
-"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് പുനഃക്രമീകരിക്കും. തുടരണോ?"
+"ഇത് നിങ്ങളുടെ സംരക്ഷിച്ച ക്രമീകരണം ഡിഫോൾട്ട് മൂല്യങ്ങളിലേക്ക് "
+"പുനഃക്രമീകരിക്കും. തുടരണോ?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21972,7 +22228,9 @@ msgstr "ശീർഷക അടിവര"
 # smartling.placeholder_format=C
 #. Informative header on a list of steps for the user to take to disable their adblocker
 msgid "To allowlist DuckDuckGo in other ad blocker extensions:"
-msgstr "മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ ചേർക്കാൻ:"
+msgstr ""
+"മറ്റ് പരസ്യ ബ്ലോക്കർ എക്സ്റ്ൻഷനുകളിൽ DuckDuckGo-യെ അനുവദിക്കുന്ന ലിസ്റ്ൽ "
+"ചേർക്കാൻ:"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to Duck.ai’s Privacy Policy and Terms of Service'
@@ -21995,8 +22253,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് ചെയ്യേണ്ട റൂട്ട് "
-"തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
+"ദിശകൾ പ്രിന്റ് ചെയ്യാൻ:%1$sമാപ്പിലേക്ക് മടങ്ങുക.%2$sനിങ്ങൾക്ക് പ്രിന്റ് "
+"ചെയ്യേണ്ട റൂട്ട് തിരഞ്ഞെടുക്കുക.%3$sപ്രിന്റ് ഐക്കണിൽ ക്ലിക്ക് ചെയ്യുക.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22006,9 +22264,10 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം സജ്ജമാക്കുമ്പോൾ "
-"സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച "
-"ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് ചെയ്‌തിരിക്കാം."
+"നിങ്ങളുടെ സമന്വയിപ്പിച്ച ഡാറ്റ പുനഃസ്ഥാപിക്കാൻ, നിങ്ങൾ ആദ്യമായി സമന്വയം "
+"സജ്ജമാക്കുമ്പോൾ സംരക്ഷിച്ച വീണ്ടെടുക്കൽ കോഡ് ആവശ്യമാണ്. നിങ്ങൾ സമന്വയം "
+"സജ്ജമാക്കാൻ ആദ്യം ഉപയോഗിച്ച ഉപകരണത്തിൽ ഈ കോഡ് ഒരു PDF ആയി സേവ് "
+"ചെയ്‌തിരിക്കാം."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -22017,8 +22276,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും പുതിയ "
-"പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
+"നിങ്ങളുടെ ചാറ്റ് ചരിത്രം Duck.ai-ലേക്ക് മാറ്റാൻ, DuckDuckGo ബ്രൗസർ ഏറ്റവും "
+"പുതിയ പതിപ്പിലേക്ക് അപ്ഡേറ്റ് ചെയ്ത് വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22026,8 +22285,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ ആക്‌സസ് ചെയ്യാൻ "
-"അനുവദിക്കുക."
+"ഡിക്ടേഷൻ ഉപയോഗിക്കാൻ, നിങ്ങളുടെ ബ്രൗസറിനെ സിസ്റ്റം ക്രമീകരണത്തിൽ മൈക്രോഫോൺ "
+"ആക്‌സസ് ചെയ്യാൻ അനുവദിക്കുക."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -22058,8 +22317,8 @@ msgstr ""
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ ഇത് "
-"പ്രവർത്തനരഹിതമാക്കുക.%3$s"
+"സ്വകാര്യ AI ചാറ്റ് പരീക്ഷിക്കാൻ ടോഗിൾ ചെയ്യുക, അല്ലെങ്കിൽ %1$s %2$s മെനുവിൽ "
+"ഇത് പ്രവർത്തനരഹിതമാക്കുക.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22125,7 +22384,7 @@ msgstr "വളരെ മന്ദഗതിയാണ്"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "ജനറേറ്റ് ചെയ്യാൻ വേഗത വളരെ കുറവാണ്"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22239,8 +22498,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം ബ്ലോക്ക് ചെയ്യുന്നു "
-"എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
+"DuckDuckGo തടഞ്ഞ ട്രാക്കിംഗ് ശ്രമങ്ങൾ ഇവിടെ ദൃശ്യമാകും. ഞങ്ങൾ എത്രയെണ്ണം "
+"ബ്ലോക്ക് ചെയ്യുന്നു എന്നറിയാൻ ബ്രൗസ് ചെയ്യുന്നത് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22288,8 +22547,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22298,8 +22557,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് ഞാൻ എങ്ങനെ "
-"എത്തും?”"
+"ഈ വാചകം ഫ്രഞ്ചിലേക്ക് വിവർത്തനം ചെയ്യുക: “അടുത്തുള്ള സിനിമാ തിയേറ്ററിലേക്ക് "
+"ഞാൻ എങ്ങനെ എത്തും?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22547,8 +22806,8 @@ msgstr "വ്യത്യസ്ത കീവേഡുകൾ പരീക്ഷ�
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
 msgstr ""
-"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ പ്രവർത്തനരഹിതമാക്കാൻ "
-"ശ്രമിക്കുക."
+"കൂടുതൽ ഫലങ്ങൾ കാണാൻ DuckDuckGo-യിൽ നിന്നുള്ള നിങ്ങളുടെ പരസ്യ ബ്ലോക്കർ "
+"പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22573,7 +22832,7 @@ msgstr "കുറച്ച് കീവേഡുകൾ പരീക്ഷിക�
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22619,7 +22878,9 @@ msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ പലതും."
+msgstr ""
+"സൗജന്യമായി പരീക്ഷിക്കൂ! സുരക്ഷിതമായ VPN, വിപുലവും സ്വകാര്യവുമായ AI, അങ്ങനെ "
+"പലതും."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22752,7 +23013,8 @@ msgstr "അടുത്തിടെ ചേർത്തിട്ടുള്ള o
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
 msgstr ""
-"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
+"ആരംഭിക്കുന്നതിന് ഈ പ്രോംപ്റ്റുകൾ പരീക്ഷിക്കുക, അല്ലെങ്കിൽ ചുവടെ നിങ്ങളുടെ "
+"സ്വന്തം പ്രോംപ്റ്റ് നൽകുക"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22786,8 +23048,9 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22796,8 +23059,9 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ ഓർമ്മിക്കാൻ "
-"%1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. %3$sകൂടുതലറിയുക%4$s"
+"AI ഫീച്ചറുകൾ പ്രവർത്തനരഹിതമാക്കാൻ ശ്രമിക്കുകയാണോ? നിങ്ങളുടെ ക്രമീകരണങ്ങൾ "
+"ഓർമ്മിക്കാൻ %1$sDuckDuckGo No AI%2$s സെർച്ച് എക്സ്റ്റൻഷനിലേക്ക് മാറുക. "
+"%3$sകൂടുതലറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22998,8 +23262,9 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് തിരയലിനും ഉത്തരം "
-"കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് കാരണമായേക്കാം."
+"DuckAssist ഉത്തരങ്ങൾ സൃഷ്ടിക്കുമ്പോൾ ടൈപ്പ് ചെയ്യുന്നു. ഇത് ഓഫാക്കുന്നത് "
+"തിരയലിനും ഉത്തരം കാണിക്കുന്നതിനും ഇടയിൽ ഒരു ചെറിയ കാലതാമസത്തിന് "
+"കാരണമായേക്കാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23097,13 +23362,17 @@ msgstr "ഫീഡ് ബാക്ക് അയയ്ക്കുവാൻ സാ
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"വോയ്സ് ചാറ്റിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിയുന്നില്ല, ദയവായി പിന്നീട് വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും ശ്രമിക്കുക."
+msgstr ""
+"നിങ്ങളുടെ മൈക്കിലേക്ക് കണക്റ്റ് ചെയ്യാൻ കഴിഞ്ഞില്ല. ദയവായി വീണ്ടും "
+"ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -23129,8 +23398,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് ക്ലിക്ക് "
-"ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഒരു നിർദിഷ്ട പേജ് തുറക്കുക %4$s എന്നത് "
+"ക്ലിക്ക് ചെയ്യുക, തുടർന്ന് %5$sപേജുകൾ സജ്ജമാക്കുക%6$s ക്ലിക്ക് ചെയ്യുക."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -23138,21 +23407,22 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ ചെയ്യുക: "
-"https://duckduckgo.com"
+"%1$sആരംഭത്തിൽ%2$s എന്നതിന് കീഴിൽ, %3$sഹോംപേജ്%4$s തിരഞ്ഞെടുത്ത് ഇത് എന്റർ "
+"ചെയ്യുക: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
 msgstr ""
-"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ പേജുകൾ%4$s "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇതിൽ തുറക്കുക%2$s എന്നതിന് കീഴിൽ, %3$sഒരു പ്രത്യേക പേജ് അല്ലെങ്കിൽ "
+"പേജുകൾ%4$s തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: https://duckduckgo.com"
+"%1$sആരംഭം > ഹോംപേജ് %2$s എന്നതിന് കീഴിൽ ഇത് എന്റർ ചെയ്യുക: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23163,30 +23433,32 @@ msgstr "%1$sതിരയൽ ക്രമീകരണം%2$s എന്നതി�
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
 msgstr ""
-"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s എന്നത് "
-"തിരഞ്ഞെടുക്കുക"
+"%1$sഇത് സഹിതം വിലാസ ബാറിൽ തിരയുക%2$s എന്നതിന് കീഴിൽ %3$sപുതിയത് ചേർക്കുക%4$s "
+"എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s ക്ലിക്ക് "
-"ചെയ്യുക"
+"%1$sതിരയുക%2$s വിഭാഗത്തിന് കീഴിൽ, %3$sതിരയൽ എഞ്ചിനുകൾ മാനേജ് ചെയ്യുക...%4$s "
+"ക്ലിക്ക് ചെയ്യുക"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
 msgstr ""
-"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ തുറക്കുക%2$s "
-"എന്നത് തിരഞ്ഞെടുക്കുക"
+"ആരംഭത്തിൽ എന്നതിന് കീഴിൽ %1$sഒരു നിർദിഷ്ട പേജ് അല്ലെങ്കിൽ ഒരു കൂട്ടം പേജുകൾ "
+"തുറക്കുക%2$s എന്നത് തിരഞ്ഞെടുക്കുക"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s തിരഞ്ഞെടുക്കുക"
+msgstr ""
+"തിരയൽ എന്നതിന് കീഴിൽ ഡ്രോപ്പ്ഡൗൺ ക്ലിക്ക് ചെയ്ത് %1$sDuckDuckGo%2$s "
+"തിരഞ്ഞെടുക്കുക"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23264,8 +23536,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് പ്ലാനിനേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
+"Pro-യിലേക്ക് അപ്‌ഗ്രേഡ് ചെയ്യുന്നതിലൂടെ %1$s, ഉയർന്ന AI റീസണിംഗ്, പ്ലസ് "
+"പ്ലാനിനേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവ അൺലോക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23287,7 +23559,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും അൺലോക്ക് ചെയ്യുക"
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് നൂതന AI മോഡലുകളും ഉയർന്ന പരിധികളും "
+"അൺലോക്ക് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23318,7 +23591,9 @@ msgstr "നൂതന മോഡലുകൾ അൺലോക്ക് ചെയ്
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് ചെയ്യുക"
+msgstr ""
+"DuckDuckGo സബ്‌സ്‌ക്രിപ്‌ഷൻ ഉപയോഗിച്ച് ദൈർഘ്യമേറിയ വോയ്സ് ചാറ്റുകൾ അൺലോക്ക് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23326,7 +23601,9 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് ചെയ്യുക. %1$s"
+msgstr ""
+"DuckDuckGo സബ്സ്ക്രിപ്ഷൻ ഉപയോഗിച്ച് കൂടുതൽ കഴിവുള്ള AI മോഡലുകൾ അൺലോക്ക് "
+"ചെയ്യുക. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23424,8 +23701,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് ചെയ്യാനും DuckDuckGo "
-"ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
+"Duck.ai-ൽ നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ സജീവമാക്കാനും നൂതന മോഡലുകൾ ആക്സസ് "
+"ചെയ്യാനും DuckDuckGo ബ്രൗസർ അപ്‌ഡേറ്റ് ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23550,15 +23827,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക, "
-"അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന പരിധി അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക, അല്ലെങ്കിൽ കൂടുതൽ ചിത്രങ്ങൾ സൃഷ്ടിക്കാനായി പിന്നീട് മടങ്ങി വരിക."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക"
+"Plus-നേക്കാൾ 2x ഉയർന്ന ഉപയോഗ പരിധികൾ അൺലോക്ക് ചെയ്യാൻ Pro-യിലേക്ക് അപ്ഗ്രേഡ് "
+"ചെയ്യുക"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23654,9 +23932,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, സ്കാമർമാരിൽ "
-"നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. "
-"സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
+"ChatGPT, Claude, മറ്റ് AI-കൾ സ്വകാര്യമായി ഉപയോഗിക്കൂ. ഹാക്കർമാരിൽ നിന്നും, "
+"സ്കാമർമാരിൽ നിന്നും, കമ്പനികളിൽ നിന്നും നിന്റെ ചാറ്റുകൾ സംരക്ഷിക്കുക. "
+"വിവരങ്ങൾ രഹസ്യമായി സൂക്ഷിക്കൂ. സൗജന്യം. അക്കൗണ്ട് ആവശ്യമില്ല."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23669,8 +23947,8 @@ msgstr "DuckDuckGo Private Search ഉപയോഗിക്കുക"
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
 msgstr ""
-"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private search "
-"ഉപയോഗിക്കുക!"
+"നിങ്ങളുടെ iPad, iPhone അല്ലെങ്കിൽ Android എന്നിവയിൽ DuckDuckGo private "
+"search ഉപയോഗിക്കുക!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23713,8 +23991,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്‌സസ് നഷ്‌ടപ്പെട്ടാൽ, നിങ്ങളുടെ ഡാറ്റ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക. ഇത് സുരക്ഷിതമായി സൂക്ഷിക്കുക."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23722,8 +24000,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ വീണ്ടെടുക്കാൻ ഈ കോഡ് "
-"ഉപയോഗിക്കുക."
+"നിങ്ങളുടെ ഉപകരണങ്ങളിലേക്കുള്ള ആക്സസ് നഷ്ടപ്പെട്ടാൽ, സംരക്ഷിച്ച ചാറ്റുകൾ "
+"വീണ്ടെടുക്കാൻ ഈ കോഡ് ഉപയോഗിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23847,8 +24125,9 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai-യിൽ നിന്ന് പങ്കിട്ട ഒരു സംഭാഷണം കാണൂ - DuckDuckGo-യുടെ സൗജന്യവും സ്വകാര്യവുമായ "
-"AI ചാറ്റ്. നിങ്ങളുടെ സ്വന്തം ചാറ്റുകളിലേക്ക് ഇത് സംരക്ഷിച്ച് സ്വകാര്യമായി തുടരൂ."
+"Duck.ai-യിൽ നിന്ന് പങ്കിട്ട ഒരു സംഭാഷണം കാണൂ - DuckDuckGo-യുടെ സൗജന്യവും "
+"സ്വകാര്യവുമായ AI ചാറ്റ്. നിങ്ങളുടെ സ്വന്തം ചാറ്റുകളിലേക്ക് ഇത് സംരക്ഷിച്ച് "
+"സ്വകാര്യമായി തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23883,8 +24162,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സ്വകാര്യതാ പരിരക്ഷ ചെയ്തിരിക്കുന്നു. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് Microsoft-ന്റെ പരസ്യ നെറ്റ്‌വർക്കാണ്"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23893,8 +24172,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ ക്ലിക്കുകൾ "
-"നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. പരസ്യ "
+"ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത് TripAdvisor ന്റെ പരസ്യ ശൃംഖലയാണ്."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23903,8 +24182,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. Yelp-ന്റെ പരസ്യ ശൃംഖലയാണ് "
-"പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത്."
+"പരസ്യങ്ങൾ കാണുന്നത് DuckDuckGo സംരക്ഷിച്ചിരിക്കുന്ന സ്വകാര്യതയാണ്. Yelp-ന്റെ "
+"പരസ്യ ശൃംഖലയാണ് പരസ്യ ക്ലിക്കുകൾ നിയന്ത്രിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23916,8 +24195,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23926,8 +24205,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ %1$sDuckAssist "
-"ക്രമീകരണം%2$s സന്ദർശിക്കുക."
+"ഈ ഫീച്ചർ എങ്ങനെ പ്രവർത്തിക്കണമെന്ന് ക്രമീകരിക്കാനോ അത് ഓഫ് ചെയ്യാനോ "
+"%1$sDuckAssist ക്രമീകരണം%2$s സന്ദർശിക്കുക."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23936,8 +24215,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ നിർദേശങ്ങൾ "
-"പാലിക്കുക."
+"നിങ്ങളുടെ ടാബ്‍ലെറ്റിലോ ഫോണിലോ %1$sDuckDuckGo.com%2$s സന്ദർശിച്ച് നൽകിയ "
+"നിർദേശങ്ങൾ പാലിക്കുക."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23952,9 +24231,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & "
-"Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് %1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > "
+"%3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നതിലേക്ക് പോയി %7$sമറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23964,9 +24243,10 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & "
-"Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" "
-"തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിൽ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
+"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു "
+"ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി "
+"PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23976,9 +24256,10 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, %1$sDuck.ai "
-"ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് ചെയ്യുക%6$s എന്നിടത്ത് "
-"%7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s തിരഞ്ഞെടുക്കുക."
+"നിങ്ങളുടെ മറ്റൊരു ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച്, "
+"%1$sDuck.ai ക്രമീകരണങ്ങൾ%2$s > %3$sSync & Backup%4$s > %5$sമാനേജ് "
+"ചെയ്യുക%6$s എന്നിടത്ത് %7$sമറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക%8$s "
+"തിരഞ്ഞെടുക്കുക."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23988,9 +24269,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai ക്രമീകരണങ്ങൾ "
-"തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി "
-"സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
+"നിങ്ങളുടെ മറ്റ് ബ്രൗസറിലോ DuckDuckGo ആപ്പിലോ Duck.ai സന്ദർശിച്ച് Duck.ai "
+"ക്രമീകരണങ്ങൾ തുറക്കുക. Sync & Backup എന്നതിന് കീഴിൽ \"ഓണാക്കുക\" "
+"തിരഞ്ഞെടുത്ത് \"മറ്റൊരു ഉപകരണവുമായി സമന്വയിപ്പിക്കുക\" തിരഞ്ഞെടുക്കുക. "
+"അല്ലെങ്കിൽ നിങ്ങളുടെ റിക്കവറി PDF-ലെ QR സ്കാൻ ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24043,8 +24325,8 @@ msgstr "വോയ്സ് ചാറ്റ് അവസാനിച്ചു"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"ഉപയോഗിച്ചിട്ടില്ല."
+"വോയ്സ് ചാറ്റ് ഞങ്ങൾ അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിച്ചിട്ടില്ല."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24194,8 +24476,9 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച പ്രവർത്തനത്തെ YouTube "
-"ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck Player-ൽ കാണുക."
+"YouTube-ൽ വ്യക്തിഗതമാക്കിയ പരസ്യങ്ങൾ തടയുന്നതിനും നിങ്ങളുടെ കാഴ്ച "
+"പ്രവർത്തനത്തെ YouTube ശുപാർശകൾ സ്വാധീനിക്കുന്നതിൽ നിന്ന് തടയുന്നതിനും Duck "
+"Player-ൽ കാണുക."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24215,10 +24498,11 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് "
-"ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. "
-"DuckDuckGo ഒരു സ്വതന്ത്ര കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി "
-"യാതൊരു ബന്ധവുമില്ല."
+"ഇവിടെ ഒരു വീഡിയോ കാണുക എന്നതിനർത്ഥം അത് ഹോസ്റ്റ് ചെയ്തിരിക്കുന്ന "
+"വെബ്‌സൈറ്റിന് നിങ്ങളെ ട്രാക്ക് ചെയ്യാൻ കഴിയും എന്നാണ്, കാരണം ഞങ്ങൾ അവിടെ "
+"നിന്ന് ഉള്ളടക്കം സ്ട്രീം ചെയ്യേണ്ടതുണ്ട്. DuckDuckGo ഒരു സ്വതന്ത്ര "
+"കമ്പനിയാണ് കൂടാതെ മിക്ക വീഡിയോകളും ഹോസ്റ്റ് ചെയ്യുന്ന YouTube-മായി യാതൊരു "
+"ബന്ധവുമില്ല."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24231,8 +24515,8 @@ msgstr "ഞങ്ങൾ അജ്ഞാതമാക്കുന്നു"
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
 msgstr ""
-"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ ലൊക്കേഷൻ%2$s "
-"അജ്ഞാതമാക്കാൻ കഴിയും."
+"നിങ്ങൾക്ക് കൂടുതൽ കൃത്യമായ ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക്%1$s നിങ്ങളുടെ "
+"ലൊക്കേഷൻ%2$s അജ്ഞാതമാക്കാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24244,9 +24528,10 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് പരിഹരിക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി ഈ സംഭാഷണം DuckDuckGo-യുമായി "
+"പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നത്തെക്കുറിച്ച് അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24258,17 +24543,18 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ ആയ ഒരു "
-"പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും പ്രതികരണവും പങ്കിടുക, അതുവഴി "
-"ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ കഴിയും."
+"കാണാൻ കഴിയുന്നത് മാത്രമേ ഞങ്ങൾക്ക് ശരിയാക്കാൻ കഴിയൂ. ദോഷകരമോ നിയമവിരുദ്ധമോ "
+"ആയ ഒരു പ്രതികരണം റിപ്പോർട്ട് ചെയ്യാൻ, ദയവായി നിങ്ങളുടെ പ്രോംപ്റ്റും "
+"പ്രതികരണവും പങ്കിടുക, അതുവഴി ഞങ്ങൾക്ക് പ്രശ്നം അന്വേഷിച്ച് പരിഹരിക്കാൻ "
+"കഴിയും."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
 msgstr ""
-"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s ലൊക്കേഷൻ%2$s "
-"ഉപയോഗിക്കാനാകും."
+"സമീപത്തുള്ള ഫലങ്ങൾ കാണിക്കുന്നതിന് ഞങ്ങൾക്ക് നിങ്ങളുടെ അജ്ഞാത%1$s "
+"ലൊക്കേഷൻ%2$s ഉപയോഗിക്കാനാകും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24276,8 +24562,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ ഞങ്ങൾക്ക് അവ "
-"വായിക്കാൻ കഴിയില്ല."
+"അറ്റാച്ച് ചെയ്ത ഫയലുകളിൽ ഒരെണ്ണമെങ്കിലും എൻക്രിപ്റ്റ് ചെയ്തിരിക്കുന്നതിനാൽ "
+"ഞങ്ങൾക്ക് അവ വായിക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24288,13 +24574,16 @@ msgstr "പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്�
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ സംഭരിക്കുന്നില്ല."
+msgstr ""
+"ഞങ്ങൾ ഉപയോക്തൃനാമങ്ങളോ വ്യക്തിപരമായി തിരിച്ചറിയിക്കുന്ന വിവരങ്ങളോ "
+"സംഭരിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ ഇല്ല. എപ്പോഴും."
+"ഞങ്ങൾ നിങ്ങളുടെ സ്വകാര്യ വിവരങ്ങൾ സംഭരിക്കുകയോ നിങ്ങളെ ട്രാക്ക് ചെയ്യുകയോ "
+"ഇല്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24306,8 +24595,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ നിങ്ങളെ "
-"പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ ഞങ്ങൾ സംഭരിക്കാറില്ല. പരസ്യങ്ങളുമായി ഞങ്ങൾ "
+"നിങ്ങളെ പിന്തുടരില്ല. ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യില്ല. എപ്പോഴും."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24321,8 +24610,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ കൊണ്ടുവന്നത് എന്താണെന്ന് "
-"ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് നിങ്ങളെ തിരികെ "
+"കൊണ്ടുവന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് "
+"ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24331,8 +24621,9 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ നിങ്ങൾക്ക് "
-"ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല, അതിനാൽ ഇന്ന് ഞങ്ങളെ പരീക്ഷിച്ചുനോക്കാൻ "
+"നിങ്ങൾക്ക് ബോധ്യംപകർന്നത് എന്താണെന്ന് ഞങ്ങളോട് പറയാൻ നിങ്ങളുടെ സഹായം "
+"ഞങ്ങൾക്ക് ഉപയോഗിക്കാം:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24343,7 +24634,9 @@ msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ നയം."
+msgstr ""
+"ഞങ്ങൾ നിങ്ങളെ ട്രാക്ക് ചെയ്യുന്നില്ല. ചുരുക്കത്തിൽ അതാണ് ഞങ്ങളുടെ സ്വകാര്യതാ "
+"നയം."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24372,8 +24665,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ ഉടനീളം "
-"പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
+"ഞങ്ങൾ നിങ്ങളുടെ തിരയൽ ചരിത്രം സൂക്ഷിക്കില്ല. അതുകൊണ്ട് നിങ്ങളെ ഇന്റർനെറ്റിൽ "
+"ഉടനീളം പിന്തുടരുന്ന പരസ്യദാതാക്കൾക്ക് വിൽക്കാൻ ഞങ്ങൾക്ക് ഒന്നുമില്ല"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24399,8 +24692,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ കണ്ടെത്തി നീക്കം "
-"ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
+"ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് ഞങ്ങൾ നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾ "
+"കണ്ടെത്തി നീക്കം ചെയ്യുന്നു. Plus, ഒരു VPN-ഉം അതിലധികവും നേടൂ."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24409,8 +24702,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് ഉറപ്പാക്കാൻ എല്ലാ AI "
-"ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
+"നിങ്ങളുടെ ചാറ്റുകൾ AI-കളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കപ്പെടുകയില്ലെന്ന് "
+"ഉറപ്പാക്കാൻ എല്ലാ AI ദാതാക്കളുമായും ഞങ്ങൾക്ക് കരാറുകളുണ്ട്."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24427,7 +24720,9 @@ msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെ�
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ ശ്രമിക്കൂ."
+msgstr ""
+"ഞങ്ങൾക്ക് കണക്ഷൻ നഷ്ടപ്പെട്ടു. ദയവായി നിങ്ങളുടെ സന്ദേശം വീണ്ടും അയയ്ക്കാൻ "
+"ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24435,8 +24730,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന തിരയൽ "
-"പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
+"ഞങ്ങൾ നിങ്ങളുടെ ഡാറ്റ ചൂഷണം ചെയ്യുന്നതിലൂടെയല്ല, %1$sസ്വകാര്യത മാനിക്കുന്ന "
+"തിരയൽ പരസ്യങ്ങളിൽ%2$s നിന്നാണ് പണം സമ്പാദിക്കുന്നത്."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24445,8 +24740,9 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ലൊക്കേഷൻ "
-"ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് മാറ്റാൻ കഴിയും."
+"നിങ്ങളുടെ സമീപത്തുള്ള മികച്ച ഫലങ്ങൾ നൽകാൻ മാത്രമേ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത "
+"ലൊക്കേഷൻ ഉപയോഗിക്കുകയുള്ളൂ. പിന്നീട് എപ്പോൾ വേണമെങ്കിലും നിങ്ങളുടെ മനസ്സ് "
+"മാറ്റാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24455,20 +24751,24 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി സ്കാൻ ചെയ്യുകയും, "
-"ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
+"നിങ്ങളുടെ വ്യക്തിഗത വിവരങ്ങൾക്കായി ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകൾ പതിവായി "
+"സ്കാൻ ചെയ്യുകയും, ഉപയോഗിക്കാൻ എളുപ്പമുള്ള ഡാഷ്‌ബോർഡിൽ ഞങ്ങളുടെ പുരോഗതി "
+"നിങ്ങളുമായി പങ്കിടുകയും ചെയ്യുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ ആശ്രയിക്കുന്നു."
+"എല്ലാവർക്കും DuckDuckGo മികച്ചതാക്കാൻ ഞങ്ങൾ നിങ്ങളുടെ അജ്ഞാത ഫീഡ്ബാക്കിനെ "
+"ആശ്രയിക്കുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ തടയുന്നു."
+msgstr ""
+"ഞങ്ങൾ ഉൾപ്പെടെ, നിങ്ങളുടെ തിരയൽ ചരിത്രം ആർക്കും ലഭിക്കുന്നതിൽ നിന്ന് ഞങ്ങൾ "
+"തടയുന്നു."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24484,15 +24784,16 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ "
-"വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം "
-"ദൃശ്യമാകണമെന്നില്ല."
+"DuckDuckGo മെച്ചപ്പെടുത്തുന്നതിന് ഞങ്ങൾ ഇതുപോലുള്ള ഫീഡ്ബാക്ക് "
+"ഉപയോഗിക്കാറുണ്ട്. %1$s-ന്റെ വിവേചനാധികാര പ്രകാരം നിർദേശങ്ങൾ "
+"സംയോജിപ്പിക്കുന്നതാണ്. തിരുത്തലുകൾ ഫലങ്ങളിൽ സത്വരം ദൃശ്യമാകണമെന്നില്ല."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
 msgstr ""
-"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
+"നിങ്ങൾ ബ്രൗസ് ചെയ്യുമ്പോൾ നിങ്ങളുടെ ഡാറ്റ ശേഖരിക്കാൻ ശ്രമിക്കുന്ന "
+"ട്രാക്കർമാരെ ഞങ്ങൾ തടയും."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24501,8 +24802,9 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ സൈറ്റുകളിൽ സ്കാൻ "
-"ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ പ്രവർത്തിക്കുകയും ചെയ്യും."
+"നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും മറ്റും ഞങ്ങൾ ഡാറ്റാ ബ്രോക്കർ "
+"സൈറ്റുകളിൽ സ്കാൻ ചെയ്യുകയും, നിങ്ങളെക്കുറിച്ച് കണ്ടെത്തുന്നത് നീക്കം ചെയ്യാൻ "
+"പ്രവർത്തിക്കുകയും ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24512,8 +24814,8 @@ msgid ""
 "continue to see this error, please reach out to %s."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, ദയവായി %1$s-നെ "
-"സമീപിക്കുക."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. നിങ്ങൾക്ക് ഈ പിശക് തുടർന്നും കാണുകയാണെങ്കിൽ, "
+"ദയവായി %1$s-നെ സമീപിക്കുക."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24523,7 +24825,8 @@ msgid ""
 "clearing your browser's cache can help."
 msgstr ""
 "ഈ പ്രശ്നത്തെക്കുറിച്ച് ഞങ്ങൾക്കറിയാം, അത് പരിഹരിക്കാൻ ഞങ്ങൾ ഇപ്പോൾ "
-"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ മായ്ക്കുന്നത് സഹായിക്കാം."
+"പ്രവർത്തിച്ചുകൊണ്ടിരിക്കുകയാണ്. ചിലപ്പോൾ നിങ്ങളുടെ ബ്രൗസറിന്റെ കാഷെ "
+"മായ്ക്കുന്നത് സഹായിക്കാം."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24538,8 +24841,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ ഞങ്ങൾ കഠിനമായി "
-"പരിശ്രമിക്കുന്നു."
+"ഈ അസൗകര്യത്തിന് ഞങ്ങൾ ക്ഷമ ചോദിക്കുന്നു. നിങ്ങളുടെ അനുഭവം മികച്ചതാക്കാൻ "
+"ഞങ്ങൾ കഠിനമായി പരിശ്രമിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24548,8 +24851,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് വീണ്ടും ലോഡ് "
-"ചെയ്യേണ്ടതുണ്ട്."
+"ഞങ്ങൾ Duck.ai സേവനം അപ്ഡേറ്റ് ചെയ്തു. മാറ്റം പ്രാബല്യത്തിൽ വരാൻ, നമ്മൾ പേജ് "
+"വീണ്ടും ലോഡ് ചെയ്യേണ്ടതുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24657,7 +24960,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് തുടരാം."
+msgstr ""
+"പ്രതിവാര ഉപയോഗ പരിധി എത്തി. നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉപയോഗിച്ച് ചാറ്റ് "
+"തുടരാം."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24671,8 +24976,9 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഞങ്ങൾ "
-"അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"Duck.ai-യിലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഞങ്ങൾ അജ്ഞാതമാക്കും, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24681,9 +24987,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ "
-"ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ "
-"ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും "
+"സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24693,16 +24999,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s ആണ്. "
-"ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും DuckDuckGo സംഭരിക്കുകയോ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
+"DuckDuckGo AI Chat-ലേക്ക് സ്വാഗതം! ഈ ചാറ്റ് സെഷൻ നൽകുന്നത് %1$s-ൻ്റെ %2$s "
+"ആണ്. ഇവിടെയുള്ള നിങ്ങളുടെ എല്ലാ ചാറ്റുകളും സ്വകാര്യമാണ്, അവ ഒരിക്കലും "
+"DuckDuckGo സംഭരിക്കുകയോ AI മോഡലുകളെ പരിശീലിപ്പിക്കുകയോ ചെയ്യുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
 msgstr ""
-"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്യാം."
+"പുതിയ Duck.ai-യിലേക്ക് സ്വാഗതം! ഇപ്പോൾ നിങ്ങൾ ഡൗൺലോഡ് ചെയ്ത ചാറ്റുകൾ "
+"ഇംപോർട്ട് ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24770,8 +25077,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. "
-"പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
+"ഞങ്ങൾക്കു വളരെ ക്ഷമിക്കണം, പക്ഷേ Duck.ai ലോഡ് ചെയ്യുന്നതിൽ ഒരു "
+"പ്രശ്നമുണ്ടായതായി തോന്നുന്നു. പേജ് വീണ്ടും ലോഡ് ചെയ്യാൻ ശ്രമിക്കൂ."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24786,8 +25093,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും പ്രതിവാദങ്ങളും "
-"എന്തൊക്കെയാണ്?"
+"ഒരു സസ്യാധിഷ്ഠിത ഭക്ഷണക്രമ ആശയത്തിനുള്ള ചില വാദങ്ങളും എതിർവാദങ്ങളും "
+"പ്രതിവാദങ്ങളും എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24808,8 +25115,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' എന്ന വാക്കിനുള്ള ചില "
-"ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
+"“ഞങ്ങൾ ശരിക്കും മികച്ചത് ചെയ്യേണ്ടതുണ്ട്” എന്ന പശ്ചാത്തലത്തിൽ 'മികച്ചത്' "
+"എന്ന വാക്കിനുള്ള ചില ഓപ്ഷനുകൾ എന്തൊക്കെയാണ്."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24834,11 +25141,12 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് ചെയ്യുന്നതിന്റെ "
-"പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ മാത്രം അവലംബിക്കുന്നു. Duck.ai "
-"സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് "
-"പ്രതികരണത്തെ വ്യക്തമായ വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം "
-"കൂടുതലുള്ളവർക്കും ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
+"Duck.ai ഉപയോഗിക്കാൻ താൽപ്പര്യമുള്ള ഒരാൾക്ക് DuckDuckGo ബ്രൗസർ ഡൗൺലോഡ് "
+"ചെയ്യുന്നതിന്റെ പ്രയോജനങ്ങൾ എന്തൊക്കെയാണ്? ഔദ്യോഗിക DuckDuckGo സ്രോതസ്സുകൾ "
+"മാത്രം അവലംബിക്കുന്നു. Duck.ai സംയോജനങ്ങളിലും സ്വകാര്യതാ സംരക്ഷണങ്ങളിലും "
+"ശ്രദ്ധ കേന്ദ്രീകരിച്ച്, തലക്കെട്ടുകൾ ഉപയോഗിച്ച് പ്രതികരണത്തെ വ്യക്തമായ "
+"വിഭാഗങ്ങളായി വിഭജിക്കുന്നു. AI അല്ലെങ്കിൽ സാങ്കേതിക പരിചയം കൂടുതലുള്ളവർക്കും "
+"ഇല്ലാത്തവർക്കും ഇത് വളരെ ചെറുതും ലളിതവും മനസ്സിലാക്കാൻ എളുപ്പവുമാക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24924,7 +25232,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
 msgstr ""
-"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ എന്തൊക്കെയാണ്?"
+"ഈ സ്ഥലത്തിന്റെ പ്രവർത്തന സമയം, ലൊക്കേഷൻ, ബന്ധപ്പെടാനുള്ള വിവരങ്ങൾ എന്നിവ "
+"എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25075,8 +25384,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ "
-"വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
+"Cloud Save ബുക്ക്മാര്‍ക്കലെറ്റ് എന്നാല്‍ എന്ത്? URL പാരാമീറ്റർ "
+"ബുക്ക്മാർക്ലറ്റിൽ നിന്ന് ഇത് എങ്ങനെ വ്യത്യാസപ്പെട്ടിരിക്കുന്നു?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25152,7 +25461,8 @@ msgstr "നിങ്ങൾ എന്തിനെക്കുറിച്ചാ�
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
 msgstr ""
-"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ സ്വാധീനിക്കില്ല."
+"DuckDuckGo-യിൽ നിങ്ങൾ എന്ത് കാണുന്നുവെന്നത് YouTube-ലെ നിങ്ങളുടെ ശുപാർശകളെ "
+"സ്വാധീനിക്കില്ല."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25178,8 +25488,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന "
-"ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
+"ഒരു തുടക്കക്കാരന് വേണ്ടി ഒരു ഇലക്ട്രിക് ഗിറ്റാർ വാങ്ങുമ്പോൾ, ഞാൻ "
+"പരിഗണിക്കേണ്ട മുൻനിര ഉൽപ്പന്ന ബ്രാൻഡുകൾ എന്തൊക്കെയാണ്?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25203,7 +25513,8 @@ msgstr "<strong>%1$s</strong> എവിടെ കാണാം"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
 msgstr ""
-"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s എന്നത് ക്ലിക്ക് ചെയ്യുക."
+"അത് ഹോംപേജ് എന്ന് പറയുന്നിടത്ത്, %1$sനിലവിലെ പേജിലേക്ക് സജ്ജമാക്കുക%2$s "
+"എന്നത് ക്ലിക്ക് ചെയ്യുക."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25244,7 +25555,8 @@ msgstr "ആരാണ് ഞങ്ങൾ"
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
 msgstr ""
-"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് അറിയപ്പെടുന്നത്?"
+"പ്രധാന അഭിനേതാക്കളും അണിയറപ്രവർത്തകരും ആരൊക്കെയാണ്, അവർ മറ്റെന്തിനൊക്കെയാണ് "
+"അറിയപ്പെടുന്നത്?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25382,9 +25694,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI പരിശീലിപ്പിക്കാൻ "
-"ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ "
-"ചെയ്യാം."
+"Duck.ai ഉപയോഗിച്ച്, നിങ്ങളുടെ ചാറ്റുകൾ അജ്ഞാതമാക്കപ്പെടുന്നു, കൂടാതെ AI "
+"പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല. '%1$s' മെനുവിൽ എപ്പോൾ വേണമെങ്കിലും "
+"ഇത് ഓണാക്കുകയോ ഓഫാക്കുകയോ ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25393,8 +25705,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ %1$s വരെ ഈ ഉപകരണത്തിൽ "
-"സംരക്ഷിക്കപ്പെടും."
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകളിൽ %1$s വരെ "
+"ഈ ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25402,8 +25714,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
-"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകൾ ഈ ഉപകരണത്തിൽ "
-"സംരക്ഷിക്കപ്പെടും."
+"ചാറ്റ് ചരിത്രം ഓണായിരിക്കുമ്പോൾ, നിങ്ങളുടെ ഏറ്റവും പുതിയ ചാറ്റുകൾ ഈ "
+"ഉപകരണത്തിൽ സംരക്ഷിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25418,8 +25730,9 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും അതിലേറെയും "
-"നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് പ്രവർത്തിക്കുന്നു."
+"ഡാറ്റ ബ്രോക്കർ സൈറ്റുകളിൽ നിന്ന് നിങ്ങളുടെ ഇമെയിൽ, പേര്, വിലാസം എന്നിവയും "
+"അതിലേറെയും നീക്കം ചെയ്യാൻ നിങ്ങളുടെ ഉപകരണത്തിൽ നിന്ന് നേരിട്ട് "
+"പ്രവർത്തിക്കുന്നു."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25668,7 +25981,8 @@ msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
 msgstr ""
-"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് വീണ്ടെടുക്കാൻ കഴിയില്ല."
+"അതെ, നിങ്ങൾ ഡാറ്റ പൂർത്തിയാക്കുമ്പോൾ ഞങ്ങൾ അത് വലിച്ചെറിയുന്നു, അത് "
+"വീണ്ടെടുക്കാൻ കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25688,8 +26002,8 @@ msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"നിങ്ങൾ %1$s എന്നയാളുമായി ചാറ്റ് ചെയ്യുന്നു. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25698,8 +26012,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ DuckDuckGo-യിൽ നിന്ന് മറ്റ് "
-"തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
+"%2$s തിരയൽ കുറുക്കുവഴികൾ ഉപയോഗിച്ച് നിങ്ങൾക്ക് %1$s അല്ലെങ്കിൽ "
+"DuckDuckGo-യിൽ നിന്ന് മറ്റ് തിരയൽ എഞ്ചിനുകളിൽ നേരിട്ട് തിരയാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25713,8 +26027,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ ക്രമീകരണങ്ങൾ%3$s-ൽ "
-"എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
+"നിങ്ങൾക്ക് %1$s എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %2$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%3$s-ൽ എപ്പോൾ വേണമെങ്കിലും അത് ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25723,21 +26037,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s-ൽ അത് "
-"എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
+"Assist എങ്ങനെ പ്രവർത്തിക്കുന്നുവെന്നത് ക്രമീകരിക്കാനോ %1$sതിരയൽ "
+"ക്രമീകരണങ്ങൾ%2$s-ൽ അത് എപ്പോൾ വേണമെങ്കിലും ഓഫാക്കാനോ നിങ്ങൾക്ക് കഴിയും."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s ഉപയോഗിക്കാം."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനും വാചകം സംഗ്രഹിക്കാനും നിങ്ങൾക്ക് %1$sDuck.ai%2$s "
+"ഉപയോഗിക്കാം."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI Chat%2$s "
-"ഉപയോഗിക്കാനും കഴിയും."
+"ചോദ്യങ്ങൾക്ക് ഉത്തരം നൽകാനോ വാചകം സംഗ്രഹിക്കാനോ നിങ്ങൾക്ക് %1$sDuckDuckGo AI "
+"Chat%2$s ഉപയോഗിക്കാനും കഴിയും."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25751,8 +26066,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist കാണണമെന്നത് "
-"മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
+"%1$sതിരയൽ ക്രമീകരണങ്ങൾ%2$s എന്നതിൽ നിങ്ങൾക്ക് എത്ര തവണ Search Assist "
+"കാണണമെന്നത് മാറ്റാനോ, പൂർണ്ണമായും ഓഫാക്കാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25773,8 +26088,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു പാസ്‌ഫ്രെയ്സിന് കീഴിൽ "
-"സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
+"ആദ്യ സെറ്റ് ഓപ്ഷണലായി ഇല്ലാതാക്കിക്കൊണ്ട്, നിങ്ങളുടെ ക്രമീകരണം മറ്റൊരു "
+"പാസ്‌ഫ്രെയ്സിന് കീഴിൽ സംരക്ഷിച്ചുകൊണ്ട് നിങ്ങൾക്ക് ഇത് ചെയ്യാൻ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25804,7 +26119,8 @@ msgstr "നിങ്ങളുടെ പ്രതിമാസ പരിധി ഉ
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് തുടർന്നോളൂ!"
+"നിങ്ങൾക്ക് ഇപ്പോൾ ഈ ഉപകരണത്തിൽ 100 ചാറ്റുകൾ വരെ സംരക്ഷിക്കാൻ കഴിയും. ചാറ്റ് "
+"തുടർന്നോളൂ!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25868,8 +26184,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം മറ്റൊരു സൈറ്റ് "
-"അൺബ്ലോക്ക് ചെയ്യണം."
+"നിങ്ങൾക്ക് %1$s സൈറ്റുകൾ വരെ മാത്രമേ ബ്ലോക്ക് ചെയ്യാനാകൂ. %2$s തടയാൻ, ആദ്യം "
+"മറ്റൊരു സൈറ്റ് അൺബ്ലോക്ക് ചെയ്യണം."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25905,7 +26221,9 @@ msgstr "നിങ്ങൾക്ക് ഈ പുതിയ ഡൊമെയ്ന
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can store several sets of settings for different purposes."
-msgstr "പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ സൂക്ഷിക്കാം."
+msgstr ""
+"പലതരം ആവശ്യങ്ങൾക്കായി ക്രമീകരണത്തിന്റെ വിവിധ സെറ്റുകൾ നിങ്ങൾക്ക് ഇവിടെ "
+"സൂക്ഷിക്കാം."
 
 # smartling.placeholder_format=C
 #. Instructions for user once they've failed the bot challenge
@@ -25933,8 +26251,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, Plus-നേക്കാൾ 2 മടങ്ങ് "
-"ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
+"നിങ്ങൾക്ക് ഇപ്പോൾ %1$s എന്നതിലേക്ക് ആക്സസ് ഉണ്ട്, ഉയർന്ന AI റീസണിംഗ്, "
+"Plus-നേക്കാൾ 2 മടങ്ങ് ഉയർന്ന ഉപയോഗ പരിധി എന്നിവയുണ്ട്."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25943,8 +26261,9 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് DuckDuckGo ബ്രൗസറിൽ VPN, "
-"മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് ചെയ്യാം."
+"നിങ്ങൾക്ക് ഇപ്പോൾ നൂതന AI മോഡലുകളിലേക്ക് ആക്‌സസ് ഉണ്ട്. നിങ്ങൾക്ക് "
+"DuckDuckGo ബ്രൗസറിൽ VPN, മറ്റ് DuckDuckGo സബ്സ്ക്രിപ്ഷൻ പരിരക്ഷകൾ ആക്സസ് "
+"ചെയ്യാം."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25966,9 +26285,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന "
-"30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് "
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെസംരക്ഷിച്ച ചാറ്റുകൾ ഇനി നിങ്ങൾക്ക് ആക്‌സസ് "
+"ചെയ്യാൻ കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. "
+"ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25978,9 +26297,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ കഴിയില്ല. അവസാന 30 "
-"ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"ഈ ബ്രൗസറിൽ നിന്ന് നിങ്ങളുടെ സംരക്ഷിച്ച ചാറ്റുകൾ ഇനി ആക്‌സസ് ചെയ്യാൻ "
+"കഴിയില്ല. അവസാന 30 ചാറ്റുകൾ ഇപ്പോഴും ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും. ഇത് "
+"എൻക്രിപ്റ്റ് ചെയ്ത സെർവറിൽ നിന്ന് നിങ്ങളുടെ ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25994,8 +26313,8 @@ msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
 msgstr ""
-"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo ആപ്പ് അപ്ഡേറ്റുകൾ "
-"ലഭിക്കും."
+"ഏറ്റവും പുതിയ പതിപ്പ് ലഭിച്ചുകഴിഞ്ഞാൽ നിങ്ങൾക്ക് സ്വയമേവയുള്ള DuckDuckGo "
+"ആപ്പ് അപ്ഡേറ്റുകൾ ലഭിക്കും."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -26010,8 +26329,9 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് ചെയ്യുന്നതിന് Chrome-ന് "
-"പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. സ്വകാര്യമായി ബ്രൗസ് "
+"ചെയ്യുന്നതിന് Chrome-ന് പകരം ഞങ്ങളുടെ ആപ്പും ഉപയോഗിക്കുക. ഇത് ഇതിനകം "
+"ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -26024,8 +26344,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും കുറയ്ക്കുന്നതിന് "
-"നുറുങ്ങുകൾ നേടുക."
+"നിങ്ങൾ ഇപ്പോൾ സ്വകാര്യത ഉപയോഗിച്ച് തിരയുന്നു. %1$sനിങ്ങളുടെ പാദമുദ്ര ഇനിയും "
+"കുറയ്ക്കുന്നതിന് നുറുങ്ങുകൾ നേടുക."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26075,8 +26395,8 @@ msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
 msgstr ""
-"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. ദയവായി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ തൽക്കാലത്തേക്ക് സന്ദേശങ്ങളുടെ പരമാവധി എണ്ണത്തിൽ എത്തിയിരിക്കുന്നു. "
+"ദയവായി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26103,8 +26423,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം തീർന്നു. സമന്വയം "
-"പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"അറ്റാച്ചുമെന്റുകളുള്ള Duck.ai ചാറ്റുകൾക്കുള്ള നിങ്ങളുടെ Sync & Backup സംഭരണം "
+"തീർന്നു. സമന്വയം പുനരാരംഭിക്കാൻ ഏറ്റവും പഴയ %1$s ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ "
+"ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26115,8 +26436,8 @@ msgid ""
 "deleted."
 msgstr ""
 "Duck.ai ചാറ്റുകൾക്കുള്ള Sync & Backup സ്റ്റോറേജ് തീർന്നിരിക്കുന്നു. സമന്വയം "
-"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ ഇല്ലാതാക്കുക. പിൻ ചെയ്ത "
-"ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
+"പുനരാരംഭിക്കുന്നതിന് അറ്റാച്ചുമെന്റുകളുള്ള %1$s ഏറ്റവും പഴയ ചാറ്റുകൾ "
+"ഇല്ലാതാക്കുക. പിൻ ചെയ്ത ചാറ്റുകൾ ഇല്ലാതാക്കില്ല."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26130,8 +26451,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ അനുവദിക്കുന്നില്ല. "
-"അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് YouTube/Google ട്രാക്ക് ചെയ്യും."
+"(Google ഉടമസ്ഥതയിലുള്ള) YouTube അജ്ഞാതനായി വീഡിയോകൾ കാണാൻ നിങ്ങളെ "
+"അനുവദിക്കുന്നില്ല. അതുപോലെ, ഇവിടെ YouTube വീഡിയോകൾ കാണുന്നത് "
+"YouTube/Google ട്രാക്ക് ചെയ്യും."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26152,14 +26474,18 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+msgstr ""
+"നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ "
+"ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ സമന്വയിപ്പിക്കപ്പെടുന്നു."
+msgstr ""
+"നിങ്ങളുടെ Duck.ai ചാറ്റുകൾ എൻഡ്-ടു-എൻഡ് എൻക്രിപ്ഷനോടെ "
+"സമന്വയിപ്പിക്കപ്പെടുന്നു."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26191,8 +26517,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26202,9 +26528,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ %1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"%1$s ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26214,9 +26540,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ ഉപകരണങ്ങളും "
-"സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ 100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ "
-"ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
+"DuckDuckGo-യുടെ സെർവറിൽ നിന്ന് നിങ്ങളുടെ ബാക്കപ്പ് ഇല്ലാതാക്കപ്പെടും. എല്ലാ "
+"ഉപകരണങ്ങളും സമന്വയത്തിൽ നിന്ന് വിച്ഛേദിക്കപ്പെടും. നിങ്ങളുടെ ഏറ്റവും പുതിയ "
+"100 ചാറ്റുകൾ ഈ ബ്രൗസറുകളിലെ ലോക്കൽ സ്റ്റോറേജിൽ ലഭ്യമാകും:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26232,7 +26558,9 @@ msgstr "നിങ്ങൾ ഈ ലിങ്ക് സന്ദർശിച്ച
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു."
+msgstr ""
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26241,8 +26569,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ നൽകുന്നു. DuckDuckGo-"
-"യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങൾ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ ഒരു ലിസ്റ്റ് നിങ്ങളുടെ ബ്രൗസർ "
+"നൽകുന്നു. DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26250,8 +26578,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. DuckDuckGo-യ്ക്ക് "
-"ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
+"നിങ്ങളുടെ ബ്രൗസർ ഏറ്റവും കൂടുതൽ സന്ദർശിച്ച സൈറ്റുകളുടെ പട്ടിക നൽകുന്നു. "
+"DuckDuckGo-യ്ക്ക് ഒരിക്കലും ഈ ഡാറ്റയിലേക്ക് ആക്സസ് ഇല്ല."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26260,8 +26588,8 @@ msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
 msgstr ""
-"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ കുറ്റകരമായതോ ആയ "
-"വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
+"%1$s -നോടുള്ള നിങ്ങളുടെ ചാറ്റ് സ്വകാര്യമാണ്. AI ചാറ്റുകൾ കൃത്യമല്ലാത്തതോ "
+"കുറ്റകരമായതോ ആയ വിവരങ്ങൾ പ്രദർശിപ്പിച്ചേക്കാം."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26274,15 +26602,16 @@ msgstr "നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോൾ 
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
-"സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, മാത്രമല്ല AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഒരിക്കലും സംരക്ഷിക്കുകയോ ഉപയോഗിക്കുകയോ ചെയ്യുന്നില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും ഉപയോഗിക്കില്ല"
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, അവ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഒരിക്കലും "
+"ഉപയോഗിക്കില്ല"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26308,8 +26637,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26317,8 +26646,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI മോഡലുകളെ "
-"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
+"നിങ്ങളുടെ ചാറ്റുകൾ സ്വകാര്യമാണ്, ഞങ്ങൾ ഒരിക്കലും സംരക്ഷിച്ചിട്ടില്ല, AI "
+"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കുന്നില്ല."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26333,9 +26662,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI "
-"മോഡലുകളെ പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ "
-"പാലിക്കൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇപ്പോഴും സ്വകാര്യമാണ്, ഞങ്ങൾ അത് "
+"അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ അവയെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
+"ഉപയോഗിക്കാറില്ല. നിങ്ങളുടെ ചാറ്റ് ചരിത്രം സൂക്ഷിക്കാൻ ഈ ഘട്ടങ്ങൾ പാലിക്കൂ."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26344,8 +26673,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി Duck.ai-ൽ നിർത്തിയിടത്ത് "
-"നിന്ന് തുടരൂ."
+"നിങ്ങളുടെ ചാറ്റുകൾ ഇംപോർട്ട് ചെയ്തിരിക്കുന്നു. നിങ്ങൾ മുന്നോട്ട് പോയി "
+"Duck.ai-ൽ നിർത്തിയിടത്ത് നിന്ന് തുടരൂ."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26393,8 +26722,8 @@ msgctxt ""
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
 msgstr ""
-"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ പരിശീലിപ്പിക്കാൻ "
-"ഉപയോഗിക്കാറില്ല."
+"നിങ്ങളുടെ ഫീഡ്‌ബാക്ക് അജ്ഞാതമാക്കിയിരിക്കുന്നു, കൂടാതെ AI മോഡലുകളെ "
+"പരിശീലിപ്പിക്കാൻ ഉപയോഗിക്കാറില്ല."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26423,10 +26752,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് "
-"ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ "
-"ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-"
-"യ്ക്ക് നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
+"%1$sSHA-2%2$s എന്നറിയപ്പെടുന്ന ഒരു സുരക്ഷിത ഹാഷ് അൽഗോരിതം ഉപയോഗിച്ച് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരു 512-ബിറ്റ് കീ സൃഷ്ടിക്കുന്നു. കീയും അനുബന്ധ "
+"ക്രമീകരണ ഫയലും മാത്രമേ നിങ്ങളുടെ ബ്രൗസർ ഉപേക്ഷിക്കുകയുള്ളൂ. പേരായി കീ "
+"ഉപയോഗിച്ചുകൊണ്ട് ക്രമീകരണ ഫയൽ ഞങ്ങൾ സംരക്ഷിക്കുന്നു. DuckDuckGo-യ്ക്ക് "
+"നിങ്ങളുടെ പാസ്‌ഫ്രെയ്സ് ഒരിക്കലും അറിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26441,9 +26771,10 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി തിരിച്ചറിയാൻ "
-"കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ ദാതാക്കൾക്ക് നിങ്ങളുടെ "
-"സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ കഴിയില്ല."
+"നിങ്ങളുടെ നിർദ്ദേശങ്ങൾ DuckDuckGo സെർവറുകളിലൂടെ കൈമാറുകയും വ്യക്തിപരമായി "
+"തിരിച്ചറിയാൻ കഴിയുന്ന മെറ്റാഡാറ്റ നീക്കം ചെയ്യുകയും ചെയ്യുന്നു, അതിനാൽ മോഡൽ "
+"ദാതാക്കൾക്ക് നിങ്ങളുടെ സംഭാഷണങ്ങൾ നിങ്ങളിലേക്ക് തിരികെ ബന്ധിപ്പിക്കാൻ "
+"കഴിയില്ല."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26457,8 +26788,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ പരിശോധിക്കാനോ "
-"എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
+"നിങ്ങളുടെ സമീപകാല ചാറ്റുകൾ ഇവിടെ കാണാം! നിങ്ങൾക്ക് നിങ്ങളുടെ ചാറ്റുകൾ "
+"പരിശോധിക്കാനോ എപ്പോൾ വേണമെങ്കിലും അവ മായ്ച്ചുകളയാനോ കഴിയും."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26490,8 +26821,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ പ്രവർത്തനക്ഷമമാക്കുക."
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"പ്രവർത്തനക്ഷമമാക്കുക."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26500,9 +26832,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് അവയെ പുനഃസജ്ജമാക്കും. ഇത് "
-"സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ "
-"അറിയുക%4$s"
+"നിങ്ങളുടെ ക്രമീകരണങ്ങൾ സംരക്ഷിച്ചിട്ടുണ്ട്, എന്നാൽ കുക്കികൾ മായ്ക്കുന്നത് "
+"അവയെ പുനഃസജ്ജമാക്കും. ഇത് സ്ഥിരമാക്കാൻ %1$sDuckDuckGo No AI%2$s എക്സ്റ്റൻഷൻ "
+"ഇൻസ്റ്റാൾ ചെയ്യുക. %3$sകൂടുതൽ അറിയുക%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26530,8 +26862,9 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി Chrome-ന് പകരം ഞങ്ങളുടെ "
-"ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
+"നിങ്ങൾ ഇപ്പോൾ Chrome-ൽ സ്വകാര്യമായി തിരയുന്നു. കൂടുതൽ സുരക്ഷയ്ക്കായി "
+"Chrome-ന് പകരം ഞങ്ങളുടെ ബ്രൗസർ ഉപയോഗിക്കുക. ഇത് ഇതിനകം ഇൻസ്റ്റാൾ "
+"ചെയ്തിട്ടുണ്ട്, ഇതിന് ഇവ ചെയ്യാനാകും:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26540,8 +26873,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം ചുരുക്കി വീണ്ടും "
-"ശ്രമിക്കുക."
+"നിങ്ങൾ സന്ദേശത്തിൻ്റെ പരമാവധി വലുപ്പം കവിഞ്ഞു. ദയവായി നിങ്ങളുടെ സന്ദേശം "
+"ചുരുക്കി വീണ്ടും ശ്രമിക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26550,8 +26883,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button ഉപയോഗിച്ച് ഈ "
-"സംഭാഷണം മായ്ക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ Fire Button "
+"ഉപയോഗിച്ച് ഈ സംഭാഷണം മായ്ക്കുക."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26560,7 +26893,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
 msgstr ""
-"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ ചാറ്റ് ആരംഭിക്കുക."
+"ഈ സംഭാഷണത്തിൽ നിങ്ങൾ പരമാവധി ചാറ്റ് ദൈർഘ്യത്തിൽ എത്തി. തുടരാൻ ഒരു പുതിയ "
+"ചാറ്റ് ആരംഭിക്കുക."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26575,8 +26909,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി നാളെ ഈ ചാറ്റ് "
-"തുടരുക."
+"ഒരു ദിവസത്തേക്കുള്ള പരമാവധി സന്ദേശങ്ങളുടെ എണ്ണത്തിൽ നിങ്ങൾ എത്തി. ദയവായി "
+"നാളെ ഈ ചാറ്റ് തുടരുക."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
@@ -26885,8 +27219,8 @@ msgstr "ഔദ്യോഗിക വെബ്സൈറ്റ്"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു എന്‍കോഡ് ചെയ്ത %3$s "
-"പ്രതീകം ആണ്)."
+"അല്ലെങ്കിൽ നിങ്ങൾക്ക് വേണ്ട നിറത്തിനുള്ള കോഡ് എഴുതുക, ഉദാ. %1$s (%2$s ഒരു "
+"എന്‍കോഡ് ചെയ്ത %3$s പ്രതീകം ആണ്)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/mn_MN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mn_MN/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/mr_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/mr_IN/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5214,6 +5225,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5303,6 +5319,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6768,6 +6789,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7021,6 +7047,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7768,6 +7799,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8687,6 +8723,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12621,6 +12662,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17664,6 +17710,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18022,6 +18073,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/ms_MY/LC_MESSAGES/duckduckgo.po
+++ b/locales/ms_MY/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5222,6 +5233,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Tutup"
@@ -5311,6 +5327,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6768,6 +6789,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7024,6 +7050,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7771,6 +7802,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8694,6 +8730,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12635,6 +12676,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17682,6 +17728,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18040,6 +18091,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -512,7 +512,8 @@ msgstr "%1$sFinn ut mer%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr ""
+"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -881,7 +882,8 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1897,7 +1899,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr ""
+"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1951,7 +1954,8 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr ""
+"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1973,7 +1977,8 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr ""
+"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2312,7 +2317,8 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr ""
+"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2544,12 +2550,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
-"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
-"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
-"språk-teknologi til å generere et kort svar basert på relevant informasjon "
-"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
-"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
+"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
+"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
+"teknologi til å generere et kort svar basert på relevant informasjon den har "
+"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
+"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2650,7 +2656,8 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr ""
+"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2697,7 +2704,8 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr ""
+"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2946,6 +2954,18 @@ msgstr ""
 "Før denne rapporten blir lagret, anonymiserer DuckDuckGo samtalen din ved å "
 "fjerne personlig identifiserbar informasjon (PII) som navn, e-postadresser "
 "og identifiserende metadata."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3337,8 +3357,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
-"%1$s%2$s-utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
+"utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3987,8 +4007,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
-"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
+"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -4045,7 +4065,8 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr ""
+"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4648,7 +4669,8 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr ""
+"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4681,7 +4703,8 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr ""
+"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5672,7 +5695,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr "Oppretter en kopi av chatten som kan ses og lagres av alle som åpner lenken."
+msgstr ""
+"Oppretter en kopi av chatten som kan ses og lagres av alle som åpner lenken."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6211,7 +6235,8 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr ""
+"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6253,7 +6278,8 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr ""
+"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6343,7 +6369,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6492,6 +6519,12 @@ msgid "Dislike source"
 msgstr "Misliker kilden"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Avslå"
@@ -6602,6 +6635,12 @@ msgid "Djibouti"
 msgstr "Djibouti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6697,8 +6736,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
-"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
+"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7100,8 +7139,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
-"%1$shttps://duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
+"duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7496,8 +7535,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
-"Duck.ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
+"ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7593,7 +7632,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr ""
+"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7877,7 +7917,8 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr ""
+"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8456,6 +8497,12 @@ msgid "Fast"
 msgstr "Rask"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8609,7 +8656,8 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr ""
+"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8695,7 +8743,8 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr ""
+"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8778,6 +8827,12 @@ msgstr "Oppfølgingsspørsmål"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Fortsettelsen er privat."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8913,7 +8968,8 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr ""
+"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9452,8 +9508,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte "
-"AI-modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
+"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte AI-"
+"modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9716,6 +9772,12 @@ msgstr "God design"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Gode personvernsregler"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10779,8 +10841,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
-"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
+"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10857,6 +10919,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Bildeprompter må være i samsvar med Duck.ai's %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12016,7 +12084,8 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr ""
+"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12127,7 +12196,8 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr ""
+"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12909,7 +12979,8 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14389,8 +14460,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden "
-"%1$sURL-parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
+"parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -15715,6 +15786,12 @@ msgid "Poor formatting"
 msgstr "Dårlig formatering"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16229,7 +16306,8 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr ""
+"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16508,7 +16586,8 @@ msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
+msgstr ""
+"Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16564,8 +16643,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16574,8 +16653,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på "
-"DuckDuckGo-servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
+"servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17635,7 +17714,8 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr ""
+"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17830,7 +17910,8 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr ""
+"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18068,8 +18149,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
-"POST-forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
+"forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18188,8 +18269,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18198,8 +18279,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
-"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
+"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18353,7 +18434,8 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr ""
+"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18507,7 +18589,8 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr ""
+"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18535,7 +18618,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr ""
+"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18887,8 +18971,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
-"AI-modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19445,12 +19529,14 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr ""
+"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19762,7 +19848,8 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr ""
+"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19836,7 +19923,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr ""
+"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19890,7 +19978,8 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr ""
+"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20095,7 +20184,8 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr ""
+"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20703,7 +20793,8 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr ""
+"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20762,9 +20853,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
-"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
-"data hvis du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
+"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
+"du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -21215,7 +21306,8 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr ""
+"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21237,7 +21329,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr ""
+"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21406,7 +21499,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr ""
+"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21439,9 +21533,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
-"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
-"for mer informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
+"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
+"informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21565,14 +21659,16 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr ""
+"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr ""
+"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21740,7 +21836,8 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr ""
+"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21931,8 +22028,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater "
-"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
+"nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22030,6 +22127,12 @@ msgstr "For mange resultater fra denne kilden"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "For tregt"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22472,6 +22575,12 @@ msgstr "Prøv å eksperimentere med hver modell – de gir forskjellige svar."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prøv færre ord."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23051,8 +23160,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
-"https://duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23074,7 +23183,8 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr ""
+"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23181,8 +23291,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et "
-"DuckDuckGo-abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23846,9 +23956,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til "
-"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
-"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
+"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
+"deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23884,8 +23994,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på "
-"gjenopprettings-PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
+"PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23937,7 +24047,8 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr ""
+"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24179,7 +24290,8 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr ""
+"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24359,7 +24471,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr ""
+"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24382,7 +24495,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr ""
+"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24426,7 +24540,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr ""
+"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24536,7 +24651,8 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr ""
+"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24589,13 +24705,15 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr ""
+"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr ""
+"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25551,7 +25669,8 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr ""
+"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25570,7 +25689,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr ""
+"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25756,7 +25876,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr ""
+"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25906,7 +26027,8 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr ""
+"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25955,7 +26077,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr ""
+"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26157,8 +26280,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp "
-"AI-modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26190,8 +26313,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26199,8 +26322,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
-"AI-modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26301,11 +26424,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
-"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
-"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
-"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
-"passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
+"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
+"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
+"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26765,7 +26887,8 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr ""
+"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/nb_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nb_NO/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -512,8 +512,7 @@ msgstr "%1$sFinn ut mer%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
+msgstr "%1$sFinn ut mer%2$s om hvordan chatter lagres privat på DuckDuckGos server."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -882,8 +881,7 @@ msgstr "6 timers bruksgrense er nådd."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "6 timers bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1899,8 +1897,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "All model providers are prevented from training their AI on your "
 "conversations."
-msgstr ""
-"Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
+msgstr "Alle modelleverandører er forhindret i å trene AI-ene sine på samtalene dine."
 
 # smartling.placeholder_format=C
 #. Text displayed in the subheader of the modal that allows the user to pick an AI chat model.
@@ -1954,8 +1951,7 @@ msgstr "Tillat"
 msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
-msgstr ""
-"Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
+msgstr "Gi DuckDuckGo mikrofontilgang i systeminnstillingene for å bruke talechat."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1977,8 +1973,7 @@ msgstr "Vil du tillate anonym gjennomgang av filer i denne chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
+msgstr "Tillat annonser som respekterer personvernet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2317,8 +2312,7 @@ msgstr "Er du der fortsatt?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
+msgstr "Er du sikker på at du vil fjerne alle chattene dine? Dette kan ikke angres."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2550,12 +2544,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere KI-"
-"assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner den "
-"nettet etter relevant innhold, og bruker deretter KI-drevet naturlig språk-"
-"teknologi til å generere et kort svar basert på relevant informasjon den har "
-"funnet. Det er viktig å huske at svarene genereres automatisk fra siterte "
-"kilder og er basert på %1$sgjennomsøking av nettet%2$s."
+"Assist er en valgfri funksjon i søkeresultatene våre, som kan generere "
+"KI-assisterte svar anonymt på søkeforespørsler. For å gjøre dette skanner "
+"den nettet etter relevant innhold, og bruker deretter KI-drevet naturlig "
+"språk-teknologi til å generere et kort svar basert på relevant informasjon "
+"den har funnet. Det er viktig å huske at svarene genereres automatisk fra "
+"siterte kilder og er basert på %1$sgjennomsøking av nettet%2$s."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2656,8 +2650,7 @@ msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er avsluttet."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
+msgstr "Lyd lagres ikke av oss eller av OpenAI etter at chatten er transkribert."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2704,8 +2697,7 @@ msgstr "Autogenerert basert på oppførte kilder. Kan inneholde unøyaktigheter.
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
+msgstr "Autogenerert basert på oppførte kilder. Svarene kan inneholde unøyaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2966,6 +2958,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Før denne rapporten blir lagret, fjerner DuckDuckGo opplastede filer og "
+"genererte bilder, og anonymiserer samtalen din ved å fjerne personlig "
+"identifiserbar informasjon (PII) som navn, e-postadresser og identifiserende "
+"metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3357,8 +3353,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Bruk nettleseren som vanlig, så legger vi til personvernbeskyttelse. Vi har "
-"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én %1$s%2$s-"
-"utvidelse%3$s."
+"samlet søkemotoren, sporingsblokkeren og krypteringsvakten i én "
+"%1$s%2$s-utvidelse%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -4007,8 +4003,8 @@ msgid ""
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
 "Med chatten (via Duck.ai-tjenesten vår) kan du ha anonyme samtaler med "
-"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic m."
-"m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
+"tredjeparts AI-chatmodeller. Disse støtter modeller fra OpenAI, Anthropic "
+"m.m. Hvis du slår av denne innstillingen, skjules chat-knapper og -lenker på "
 "DuckDuckGo Search. Men du kan likevel få tilgang til chatten når denne "
 "innstillingen er av, ved å gå til %1$shttps.://duck.ai%2$s direkte."
 
@@ -4065,8 +4061,7 @@ msgstr "Chat privat"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
+msgstr "Chat privat på ethvert nettsted med Duck.ai innebygd i vår gratis nettleser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4669,8 +4664,7 @@ msgstr "Klikk %1$sher%2$s for å laste ned DuckDuckGo-utvidelsen"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
+msgstr "Klikk på %1$sÅpne%2$s for å laste ned og åpne DuckDuckGo sin Safari-utvidelse"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4703,8 +4697,7 @@ msgstr "Klikk på %1$sInnstillinger%2$s i nedtrekksmenyen."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
+msgstr "Klikk på %1$sVelg nåværende sider%2$s, og %3$sklikk deretter på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5695,8 +5688,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr ""
-"Oppretter en kopi av chatten som kan ses og lagres av alle som åpner lenken."
+msgstr "Oppretter en kopi av chatten som kan ses og lagres av alle som åpner lenken."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6235,8 +6227,7 @@ msgstr "Vil du slette de eldste chattene for å frigjøre lagringsplass?"
 #. Title shown when user has reached the file storage sync quota (5GB).
 msgctxt "Sync file storage limit modal title"
 msgid "Delete oldest chats with attachments to free up storage?"
-msgstr ""
-"Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
+msgstr "Vil du slette de eldste chattene med vedlegg for å frigjøre lagringsplass?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to delete all recent chats.
@@ -6278,8 +6269,7 @@ msgstr ""
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
 msgctxt "settings"
 msgid "Deleting cookies will reset these settings."
-msgstr ""
-"Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
+msgstr "Hvis du sletter informasjonskapslene, blir disse innstillingene tilbakestilt."
 
 # smartling.placeholder_format=C
 msgid "Democratic People's Republic of Korea"
@@ -6369,8 +6359,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
+msgstr "Diktering anonymiseres av oss, og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6522,7 +6511,7 @@ msgstr "Misliker kilden"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Misliker den visuelle stilen"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6638,7 +6627,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Instruksjonene blir ikke fulgt"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6736,8 +6725,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten AI-"
-"funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
+"Vil du ikke ha AI? Besøk %1$snoai.duckduckgo.com%2$s for å søke uten "
+"AI-funksjoner og med AI-bilder filtrert ut. %3$sFinn ut mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7139,8 +7128,8 @@ msgstr ""
 "Med Duck.ai kan du ha anonyme samtaler med tredjeparts AI-chatmodeller, som "
 "OpenAI, Anthropic og andre. Hvis du slår av denne innstillingen, skjules "
 "Duck.ai-knapper og -lenker på DuckDuckGo Search. Men du kan likevel få "
-"tilgang til Duck.ai når denne innstillingen er av, ved å gå til %1$shttps://"
-"duck.ai%2$s direkte."
+"tilgang til Duck.ai når denne innstillingen er av, ved å gå til "
+"%1$shttps://duck.ai%2$s direkte."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7535,8 +7524,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du Duck."
-"ai's %2$s."
+"DuckDuckGo anonymiserer chattene dine. Ved å klikke på «%1$s» godtar du "
+"Duck.ai's %2$s."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7632,8 +7621,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
+msgstr "DuckDuckGo-abonnementer er ikke tilgjengelige for kjøp i denne regionen."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -7917,8 +7905,7 @@ msgstr "Aktiver diktering i Duck.ai"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
+msgstr "Aktiver posisjonsinnstillinger på enheten din for å bruke anonym posisjon"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8500,7 +8487,7 @@ msgstr "Rask"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Rask bildegenerering"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8656,8 +8643,7 @@ msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater"
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
+msgstr "Filtrerer ut AI-genererte bilder fra bildesøkresultater. %1$sFinn ut mer%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8743,8 +8729,7 @@ msgstr "Søk nærmere der du er."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
+msgstr "Finn resultater nær deg. %1$sPosisjonen din forblir privat, sikker og anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8832,7 +8817,7 @@ msgstr "Fortsettelsen er privat."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Instruksjonene ble fulgt"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8968,8 +8953,7 @@ msgstr "Kan deles og brukes kommersielt"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
+msgstr "Frigjør plass ved å slette chattene dine. Festede chatter blir ikke slettet."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9508,8 +9492,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte AI-"
-"modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
+"Få vår raske VPN uten aktivitetslogger, valgfri tilgang til avanserte "
+"AI-modeller med høyere chattegrenser og flere førsteklasses beskyttelser."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9777,7 +9761,7 @@ msgstr "Gode personvernsregler"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "God visuell stil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10841,8 +10825,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt chat-"
-"svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
+"Hvis du har bekymringer om chat-leverandørene våre eller et bestemt "
+"chat-svar, kan du også kontakte støttesiden til %1$s og %2$s direkte."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10924,7 +10908,7 @@ msgstr "Bildeprompter må være i samsvar med Duck.ai's %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Bildekvalitet"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12084,8 +12068,7 @@ msgstr "Lenker:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
+msgstr "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12196,8 +12179,7 @@ msgstr "Laster flere bilderesultater når du ruller"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
+msgstr "Laster inn flere resultater i Bilder, Videoer og Shopping når du ruller"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12979,8 +12961,7 @@ msgstr "Månedlig grense er nådd"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Månedlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -14460,8 +14441,8 @@ msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
 msgstr ""
-"Bare innstillingene du har endret. De er spesifisert på siden %1$sURL-"
-"parameter%2$s."
+"Bare innstillingene du har endret. De er spesifisert på siden "
+"%1$sURL-parameter%2$s."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -15789,7 +15770,7 @@ msgstr "Dårlig formatering"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Dårlig bildekvalitet"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16306,8 +16287,7 @@ msgstr "Spør meg"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
+msgstr "Spør meg om å bruke omtrentlig lokasjon for å få resultater i nærheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16586,8 +16566,7 @@ msgstr "Resonnering kan gi bedre svar på komplekse spørsmål."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
+msgstr "Resonnering er grundigere, men når bruksgrensen 2–5 ganger raskere. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16643,8 +16622,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter som lagres lokalt på enheten din, i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter som lagres lokalt på enheten din, i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16653,8 +16632,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"Nylige chatter lagres lokalt på enheten din i stedet for på DuckDuckGo-"
-"servere eller andre eksterne servere."
+"Nylige chatter lagres lokalt på enheten din i stedet for på "
+"DuckDuckGo-servere eller andre eksterne servere."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17714,8 +17693,7 @@ msgstr "Lagre opptil 30 av de siste chattene lokalt på enheten din."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
+msgstr "Lagre Duck.ai-chattene mellom enhetene dine med ende-til-ende-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17910,8 +17888,7 @@ msgstr "Rull ned til %1$sDuckDuckGo%2$s og la den bruke posisjonen din."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
+msgstr "Rull ned til %1$sTjenester%2$s-delen, og klikk på %3$sAdresselinje%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18149,8 +18126,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke POST-"
-"forespørsler)"
+"Søkeforespørsler er inkludert i URL-en (hvis avslått, vil søkene bruke "
+"POST-forespørsler)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18269,8 +18246,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18279,8 +18256,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagre nesten ubegrenset med chatter sikkert på serveren vår med ende-til-"
-"ende-kryptering, og få tilgang til dem fra alle enhetene dine."
+"Lagre nesten ubegrenset med chatter sikkert på serveren vår med "
+"ende-til-ende-kryptering, og få tilgang til dem fra alle enhetene dine."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18434,8 +18411,7 @@ msgstr "Se noen av våre nyeste oppdateringer"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
+msgstr "Se %1$sreferansesiden for nettadresseparametere%2$s for mer informasjon."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18589,8 +18565,7 @@ msgstr "Velg %1$sInnstillinger%2$s fra nedtrekksmenyen."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
+msgstr "Velg %1$sInnstillinger%2$s, og deretter %3$sAvanserte innstillinger%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18618,8 +18593,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
+msgstr "Velg %1$snettleseren din%2$s i listen og %3$stillat%4$s posisjonstilgang"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18971,8 +18945,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Del plassering så nær som nærmeste by med AI-modeller for å forbedre "
-"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller AI-"
-"modeller."
+"relevansen. Duck.ai avslører aldri din nøyaktige plassering til oss eller "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19529,14 +19503,12 @@ msgstr "Viser de mest besøkte lenkene på ny fane"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo i nettleseren din"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
+msgstr "Viser sporadiske påminnelser om å legge til DuckDuckGo på enhetene dine"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19848,8 +19820,7 @@ msgstr "Noen ganger"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
+msgstr "Beklager at jeg ikke kan hjelpe deg. Prøv å beskrive bildet på en annen måte."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19923,8 +19894,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
+msgstr "Beklager, vi kunne ikke sende inn tilbakemeldingen din. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19978,8 +19948,7 @@ msgstr "Kildetekst fjernet"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
+msgstr "Kildeteksten er for lang til å oppsummere. Prøv igjen med en kortere tekst."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20184,8 +20153,7 @@ msgstr "Bli på DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
+msgstr "Beskytt deg selv og hold deg informert med personvern-nyhetsbrevet vårt."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
@@ -20793,8 +20761,7 @@ msgstr "Sync & Backup er aktivert!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
+msgstr "Sync & Backup-data kan ikke gjenopprettes etter 18 måneder med inaktivitet."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20853,9 +20820,9 @@ msgid ""
 msgstr ""
 "Synkroniseringsgjenopprettingskode\n"
 "\n"
-"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og Duck.ai-"
-"chatter på tvers av flere enheter, og gjenopprette synkroniserte data hvis "
-"du mister tilgangen til en enhet.\n"
+"Gjenopprettingskoden lar deg synkronisere passord, autofylle data og "
+"Duck.ai-chatter på tvers av flere enheter, og gjenopprette synkroniserte "
+"data hvis du mister tilgangen til en enhet.\n"
 "\n"
 "Ta godt vare på denne informasjonen.\n"
 "Alle som har tilgang til denne koden kan få tilgang til de synkroniserte "
@@ -21306,8 +21273,7 @@ msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
+msgstr "De vedlagte filene overskrider den totale størrelsesgrensen på %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21329,8 +21295,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
+msgstr "Modelleverandøren sletter alle data knyttet til denne chatten innen 30 dager."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21499,8 +21464,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
+msgstr "Dette øyeblikkelige svaret ble laget av %1$sDuckDuckHack%2$s-samfunnet."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21533,9 +21497,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss %3$s-"
-"modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s for mer "
-"informasjon)."
+"Denne samtalen ble generert med Duck.ai (%1$s) ved hjelp av %2$ss "
+"%3$s-modell. KI-chatter kan vise feil eller støtende informasjon (se %4$s "
+"for mer informasjon)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21659,16 +21623,14 @@ msgstr "Dette bildet kunne ikke opprettes."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
+msgstr "Denne bildetypen støttes ikke. Legg ved en JPG-, PNG-, WebP- eller GIF-fil"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
+msgstr "Denne bildetypen støttes ikke. Legg heller ved en JPG, PNG, WebP eller GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21836,8 +21798,7 @@ msgstr "Denne oversettelsen er feil"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
+msgstr "Videoen er ikke ennå i stand til å spilles av her. Du kan se den på %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22028,8 +21989,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"For å overføre chat-historikken din til Duck.ai, oppdater DuckDuckGo-"
-"nettleseren din til den nyeste versjonen og prøv igjen."
+"For å overføre chat-historikken din til Duck.ai, oppdater "
+"DuckDuckGo-nettleseren din til den nyeste versjonen og prøv igjen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22132,7 +22093,7 @@ msgstr "For tregt"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Genererer for sakte"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22580,7 +22541,7 @@ msgstr "Prøv færre ord."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Prøv gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23160,8 +23121,8 @@ msgstr "Under %1$sÅpne med%2$s velger du %3$sEn spesifikk side eller sider%4$s"
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: https://"
-"duckduckgo.com"
+"Under %1$sOPPSTART > Startside%2$s startside skriver du inn: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23183,8 +23144,7 @@ msgstr "Under %1$sSøke%2$sseksjon trykker du på %3$sBehandle søkemotorer …%
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
+msgstr "Under Ved oppstart velger du %1$sÅpne en spesifikk side eller flere sider%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23291,8 +23251,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Få tilgang til avanserte AI-modeller og høyere grenser med et DuckDuckGo-"
-"abonnement"
+"Få tilgang til avanserte AI-modeller og høyere grenser med et "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23956,9 +23916,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"Gå til Duck.ai i den andre nettleseren din og så til %1$sDuck.ai-"
-"innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. Velg "
-"deretter %7$sSynkroniser med en annen enhet%8$s."
+"Gå til Duck.ai i den andre nettleseren din og så til "
+"%1$sDuck.ai-innstillinger%2$s > %3$sSync & Backup%4$s > %5$sAdministrer%6$s. "
+"Velg deretter %7$sSynkroniser med en annen enhet%8$s."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23994,8 +23954,8 @@ msgid ""
 msgstr ""
 "Gå til Duck.ai i nettleseren din eller i DuckDuckGo-appen, og åpne "
 "innstillingene for Duck.ai. Velg «Slå på» under Sync & Backup og velg "
-"«Synkroniser med en annen enhet». Eller skann QR-koden på gjenopprettings-"
-"PDF-en din."
+"«Synkroniser med en annen enhet». Eller skann QR-koden på "
+"gjenopprettings-PDF-en din."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24047,8 +24007,7 @@ msgstr "Talechatten er avsluttet"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-"Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
+msgstr "Talechatten anonymiseres av oss og brukes aldri til å trene AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24290,8 +24249,7 @@ msgstr "Vi følger ikke etter deg med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
+msgstr "Vi lager hverken brukernavn eller informasjon som kan identifisere personer."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24471,8 +24429,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
+msgstr "Vi stopper alle fra å få tak i søkehistorikken din, inkludert oss selv."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24495,8 +24452,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
+msgstr "Vi blokkerer sporere som prøver å samle inn dataene dine mens du surfer."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24540,8 +24496,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
+msgstr "Vi beklager ulempen. Vi jobber hardt for å gjøre opplevelsen din bedre."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24651,8 +24606,7 @@ msgstr "Ukentlig bruksgrense er nådd"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
+msgstr "Ukentlig bruksgrense er nådd. Du kan fortsette denne chatten etter %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24705,15 +24659,13 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
+msgstr "Velkommen til nye Duck.ai! Du kan nå importere de nedlastede chattene dine."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai, it's time to import your chats"
-msgstr ""
-"Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
+msgstr "Velkommen til den nye Duck.ai, det er på tide å importere chattene dine"
 
 # smartling.placeholder_format=C
 #. Welcome message for new DuckDuckGo users.
@@ -25669,8 +25621,7 @@ msgstr "Ja, ny bruker!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
+msgstr "Ja, vi kaster data du er ferdig med, og dataene kan ikke gjenopprettes."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25689,8 +25640,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
+msgstr "Du chatter med %1$s. AI-chatter kan vise feil eller støtende informasjon."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25876,8 +25826,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
+msgstr "Du kan gjenopprette innstillingene etter at informasjonskapslene er slettet."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -26027,8 +25976,7 @@ msgstr "Du søker nå med personvern!"
 msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
-msgstr ""
-"Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
+msgstr "Du søker nå med personvern. %1$sFå flere tips til å redusere ditt fotavtrykk."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26077,8 +26025,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
+msgstr "Du har nådd maksimalt antall meldinger for øyeblikket. Prøv igjen senere."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26280,8 +26227,8 @@ msgstr "Chattene dine blir nå lagret."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Chattene dine er private og verken lagres eller brukes til å trene opp AI-"
-"modeller"
+"Chattene dine er private og verken lagres eller brukes til å trene opp "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26313,8 +26260,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26322,8 +26269,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene AI-"
-"modeller."
+"Chattene dine er private, lagres aldri av oss og brukes ikke til å trene "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26424,10 +26371,11 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure Hash-"
-"algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den tilhørende "
-"innstillingsfilen som forlater nettleseren din. Vi lagrer innstillingsfilen "
-"ved å bruke nøkkelen som navn. DuckDuckGo vet aldri passordet ditt."
+"Passordet ditt genererer en 512-biters nøkkel ved hjelp av Secure "
+"Hash-algoritmen kjent som %1$sSHA-2%2$s. Det er kun nøkkelen og den "
+"tilhørende innstillingsfilen som forlater nettleseren din. Vi lagrer "
+"innstillingsfilen ved å bruke nøkkelen som navn. DuckDuckGo vet aldri "
+"passordet ditt."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26887,8 +26835,7 @@ msgstr "det offisielle nettstedet"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
+msgstr "eller skriv fargekoden du ønsker, f.eks. %1$s (%2$s er et kodet %3$s-tegn)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ne_NP/LC_MESSAGES/duckduckgo.po
+++ b/locales/ne_NP/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6771,6 +6792,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7024,6 +7050,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7771,6 +7802,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8693,6 +8729,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12627,6 +12668,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17670,6 +17716,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18028,6 +18079,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/nl_BE/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_BE/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5224,6 +5235,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Afwijzen"
@@ -5313,6 +5329,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6771,6 +6792,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7026,6 +7052,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7773,6 +7804,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8695,6 +8731,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12637,6 +12678,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17693,6 +17739,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18052,6 +18103,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,7 +95,8 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr ""
+"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -448,7 +449,8 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr ""
+"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -518,7 +520,8 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr ""
+"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -885,7 +888,8 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1978,7 +1982,8 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr ""
+"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2138,8 +2143,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2148,8 +2153,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
-"open-source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
+"source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2541,8 +2546,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
-"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
+"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2556,8 +2561,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem "
-"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
+"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -2971,6 +2976,18 @@ msgstr ""
 "Voordat dit rapport wordt opgeslagen, maakt DuckDuckGo je gesprek anoniem "
 "door persoonlijk identificeerbare gegevens zoals namen, e-mailadressen en "
 "identificerende metadata te verwijderen."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3864,7 +3881,8 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr ""
+"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4075,14 +4093,16 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr ""
+"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4163,9 +4183,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"Chats worden veilig opgeslagen op de server van DuckDuckGo met "
-"end-to-end-versleuteling. Niemand anders dan jij kan je gegevens zien, zelfs "
-"wij niet."
+"Chats worden veilig opgeslagen op de server van DuckDuckGo met end-to-end-"
+"versleuteling. Niemand anders dan jij kan je gegevens zien, zelfs wij niet."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5600,7 +5619,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr ""
+"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5661,7 +5681,8 @@ msgstr "Deellink aanmaken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr ""
+"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5956,7 +5977,8 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6481,7 +6503,8 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr ""
+"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6529,6 +6552,12 @@ msgstr "Vind het ontwerp niet leuk"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Ik vind bron niet leuk"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6641,6 +6670,12 @@ msgid "Djibouti"
 msgstr "Djibouti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6736,8 +6771,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
-"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
+"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6966,7 +7001,8 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr ""
+"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7102,8 +7138,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
-"e-mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
+"mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7165,7 +7201,8 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr ""
+"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7209,8 +7246,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
-"source  AI-modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
+"modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7282,9 +7319,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
-"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
-"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
+"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
+"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7382,7 +7419,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr ""
+"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7641,7 +7679,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr ""
+"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -8052,7 +8091,8 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr ""
+"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8266,7 +8306,8 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr ""
+"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8506,6 +8547,12 @@ msgid "Fast"
 msgstr "Snel"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8653,7 +8700,8 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr ""
+"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8834,6 +8882,12 @@ msgstr "Vervolgvraag"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Vervolgvragen blijven privé."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9052,9 +9106,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie "
-"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
-"en selecteer vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
+"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
+"vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9347,7 +9401,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+msgstr ""
+"Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9467,9 +9522,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
-"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
-"privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
+"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9513,8 +9567,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde "
-"AI-modellen met hogere chatlimieten en meer premium beschermingen."
+"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde AI-"
+"modellen met hogere chatlimieten en meer premium beschermingen."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9648,9 +9702,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9660,9 +9714,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
-"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
+"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
+"een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9674,8 +9728,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
-"herstel-PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9778,6 +9832,12 @@ msgstr "Goed ontwerp"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Goed privacybeleid"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10922,6 +10982,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Beeldprompts moeten voldoen aan de %1$s van Duck.ai."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Tegels met afbeeldingen"
@@ -11011,8 +11077,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
-"URL-indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
+"indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11908,7 +11974,8 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr ""
+"Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12387,7 +12454,8 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr ""
+"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13866,7 +13934,8 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr ""
+"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14538,7 +14607,8 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr ""
+"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14715,7 +14785,8 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr ""
+"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15798,6 +15869,12 @@ msgid "Poor formatting"
 msgstr "Slechte opmaak"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16029,7 +16106,8 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr ""
+"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16312,7 +16390,8 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr ""
+"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16966,7 +17045,8 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr ""
+"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17723,7 +17803,8 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr ""
+"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17869,13 +17950,15 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr ""
+"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18132,8 +18215,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
-"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
+"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18318,7 +18401,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr ""
+"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18445,7 +18529,8 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr ""
+"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18472,7 +18557,8 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr ""
+"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18485,18 +18571,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18508,7 +18597,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18520,7 +18610,8 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18607,7 +18698,8 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr ""
+"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18629,7 +18721,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr ""
+"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18982,8 +19075,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
-"AI-modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
+"modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19542,7 +19635,8 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr ""
+"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19556,8 +19650,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de "
-"DuckDuckGo-nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
+"nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19567,7 +19661,8 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr ""
+"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19596,8 +19691,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het "
-"EU-Android-voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
+"voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19829,7 +19924,8 @@ msgstr "Er is iets misgegaan bij het laden van deze gedeelde chat."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr ""
+"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19867,7 +19963,8 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr ""
+"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -19941,7 +20038,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr ""
+"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20257,7 +20355,8 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr ""
+"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21323,13 +21422,15 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr ""
+"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21385,7 +21486,8 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr ""
+"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21525,7 +21627,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr ""
+"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21783,7 +21886,8 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr ""
+"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21835,7 +21939,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
+msgstr ""
+"Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21864,13 +21969,15 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr ""
+"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr ""
+"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21989,8 +22096,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
-"helpen.%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22022,7 +22129,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr ""
+"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22063,8 +22171,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
-"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
+"browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22166,6 +22274,12 @@ msgstr "Te veel resultaten van deze bron"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Te langzaam"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22453,7 +22567,8 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr ""
+"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22594,20 +22709,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr ""
+"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr ""
+"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Probeer minder zoekwoorden."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22653,7 +22776,8 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr ""
+"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22692,7 +22816,8 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr ""
+"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23143,7 +23268,8 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr ""
+"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -23184,7 +23310,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr ""
+"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23199,13 +23326,15 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr ""
+"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr ""
+"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23219,7 +23348,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr ""
+"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23320,8 +23450,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
-"DuckDuckGo-abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
+"abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23593,7 +23723,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr ""
+"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23703,7 +23834,8 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr ""
+"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24022,10 +24154,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
-"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
-"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
-"herstel-PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
+"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
+"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
+"PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24230,8 +24362,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
-"YouTube-aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
+"aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24324,12 +24456,14 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr ""
+"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr ""
+"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24355,7 +24489,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24363,7 +24498,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr ""
+"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24460,7 +24596,8 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr ""
+"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24502,7 +24639,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr ""
+"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24525,7 +24663,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr ""
+"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24569,7 +24708,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr ""
+"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24679,7 +24819,8 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr ""
+"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24732,7 +24873,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr ""
+"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25798,7 +25940,8 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr ""
+"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25981,8 +26124,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de "
-"DuckDuckGo-browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
+"browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -26134,7 +26277,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr ""
+"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26332,8 +26476,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26341,8 +26485,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26375,8 +26519,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
-"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
+"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26622,7 +26766,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr ""
+"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26705,7 +26850,8 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr ""
+"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nl_NL/LC_MESSAGES/duckduckgo.po
+++ b/locales/nl_NL/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,8 +95,7 @@ msgstr "%1$s en %2$s AI-modellen"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
+msgstr "%1$s komt voor in een aantal van de beste resultaten voor deze zoekopdracht."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -449,8 +448,7 @@ msgstr "%1$s woorden"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
+msgstr "%1$sKlik op %2$sToevoegen%3$sSelecteer %4$sToestaan%5$s en klik op %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -520,8 +518,7 @@ msgstr ""
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
+msgstr "%1$sLees meer%2$s over hoe chats privé worden opgeslagen op je apparaat."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -888,8 +885,7 @@ msgstr "De 6-uurs gebruikslimiet is bereikt."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "De 6-uurs gebruikslimiet is bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1982,8 +1978,7 @@ msgstr "Anonieme bestandscontrole toestaan voor deze chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
+msgstr "Advertenties die de privacy respecteren toestaan in DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2143,8 +2138,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2153,8 +2148,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en open-"
-"source %3$s en %4$s."
+"Anonieme toegang tot populaire AI-modellen, waaronder %1$s, %2$s, en "
+"open-source %3$s en %4$s."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2546,8 +2541,8 @@ msgstr ""
 "relevante webinhoud samen te vatten. Je kunt kiezen hoe vaak je wilt dat "
 "Assist wordt weergegeven: 'Nooit' (de Assist-gebruikersinterface wordt "
 "helemaal uit de zoekresultaten verwijderd), 'Op verzoek' (AI-antwoorden "
-"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' (AI-"
-"antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
+"worden alleen weergegeven als je op de Assist-knop klikt), 'Soms' "
+"(AI-antwoorden worden alleen weergegeven als ze zeer relevant zijn), of "
 "'Vaak' (wordt vaker weergegeven bij een breder scala aan zoekopdrachten). "
 "Voorlopig zijn AI-antwoorden alleen beschikbaar in de Amerikaanse regio."
 
@@ -2561,8 +2556,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist is een optionele functie in onze zoekresultaten die anoniem AI-"
-"ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
+"Assist is een optionele functie in onze zoekresultaten die anoniem "
+"AI-ondersteunde antwoorden op zoekopdrachten kan genereren. De functie scant "
 "het web op relevante inhoud en gebruikt vervolgens AI-technologie op basis "
 "van natuurlijke taal om een kort antwoord te genereren aan de hand van de "
 "gevonden relevante informatie. Het is belangrijk om te onthouden dat "
@@ -2988,6 +2983,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Voordat dit rapport wordt opgeslagen, verwijdert DuckDuckGo geüploade "
+"bestanden en gegenereerde afbeeldingen, en maakt DuckDuckGo je gesprek "
+"anoniem door persoonlijk identificeerbare gegevens zoals namen, "
+"e-mailadressen en identificerende metadata te verwijderen."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3881,8 +3880,7 @@ msgstr "Wijzigt hoe URL's van resultaten worden weergegeven"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
+msgstr "Wijzigt de weergave van de header en bepaalt wat ermee gebeurt als je scrolt"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -4093,16 +4091,14 @@ msgstr "Privé chatten"
 #. Mobile variant of DUCKCHAT_BROWSER_UPSELL_PROMO_TEXT. Shorter version for the promotional card encouraging third-party browser users to download the DuckDuckGo browser.
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
-msgstr ""
-"Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
+msgstr "Chat privé op elke website met Duck.ai, ingebouwd in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
-msgstr ""
-"Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
+msgstr "Chat privé op elke website met de Duck.ai-zijbalk in onze gratis browser."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4183,8 +4179,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"Chats worden veilig opgeslagen op de server van DuckDuckGo met end-to-end-"
-"versleuteling. Niemand anders dan jij kan je gegevens zien, zelfs wij niet."
+"Chats worden veilig opgeslagen op de server van DuckDuckGo met "
+"end-to-end-versleuteling. Niemand anders dan jij kan je gegevens zien, zelfs "
+"wij niet."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -5619,8 +5616,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
+msgstr "Uw herstelcode kon niet worden geladen. Sluit dit en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5681,8 +5677,7 @@ msgstr "Deellink aanmaken"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
+msgstr "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -5977,8 +5972,7 @@ msgstr "Dagelijkse limiet bereikt"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Dagelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6503,8 +6497,7 @@ msgstr "Uitschakelen en loskoppelen"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
+msgstr "Chatgeschiedenis uitschakelen en de verbinding met Sync & Backup verbreken?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6557,7 +6550,7 @@ msgstr "Ik vind bron niet leuk"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Ik vind de visuele stijl niet leuk"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6673,7 +6666,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Volgt instructies niet"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6771,8 +6764,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder AI-"
-"functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
+"Liever geen AI? Ga naar %1$snoai.duckduckgo.com%2$s om te zoeken zonder "
+"AI-functies en met AI-afbeeldingen weggefilterd. %3$sMeer informatie%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7001,8 +6994,7 @@ msgstr "Sleep je foto's of PDF-bestanden"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
+msgstr "Met Duck Player kun je YouTube-video's bekijken zonder gerichte advertenties"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7138,8 +7130,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een e-"
-"mail met deze anonieme code %1$s naar %2$s"
+"Duck.ai is tijdelijk niet beschikbaar. Als dit aanhoudt, stuur dan een "
+"e-mail met deze anonieme code %1$s naar %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7201,8 +7193,7 @@ msgstr ""
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
 msgctxt "Promotional text for PDF upload feature"
 msgid "Duck.ai now can read and analyze PDFs. Give it a try!"
-msgstr ""
-"Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
+msgstr "Duck.ai kan nu pdf-bestanden lezen en analyseren. Probeer het maar eens!"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown above the chat input only when coming from a DuckAssist grounded response into ungrounded models.
@@ -7246,8 +7237,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, privé AI-chatbot, gratis AI-chat, anonieme AI-chat, "
-"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open source  AI-"
-"modellen, privacy  AI, AI-chat zonder account"
+"AI-chat zonder aanmelden, OpenAI, Anthropic, Llama, Mistral, open "
+"source  AI-modellen, privacy  AI, AI-chat zonder account"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7319,9 +7310,9 @@ msgid ""
 msgstr ""
 "DuckAssist is een nieuwe functie in onze zoekresultaten die anoniem "
 "antwoorden voor zoekopdrachten kan genereren. Hij scant daarvoor Wikipedia "
-"en gerelateerde sites op relevante inhoud en gebruikt vervolgens AI-"
-"technologie voor natuurlijke taal om die informatie samen te vatten. Let op: "
-"de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
+"en gerelateerde sites op relevante inhoud en gebruikt vervolgens "
+"AI-technologie voor natuurlijke taal om die informatie samen te vatten. Let "
+"op: de antwoorden zijn op dit moment gebaseerd op Wikipedia en gerelateerde "
 "inhoud en worden niet gecontroleerd op juistheid."
 
 # smartling.placeholder_format=C
@@ -7419,8 +7410,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
+msgstr "DuckDuckGo AI Chat is tijdelijk niet beschikbaar. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7679,8 +7669,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
+msgstr "DuckDuckGo-abonnementen zijn niet beschikbaar voor aankoop in deze regio."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -8091,8 +8080,7 @@ msgstr "Ben je tevreden met Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
+msgstr "Zorg dat %1$s'Toestaan'%2$s is geselecteerd voor de instelling 'Locatie'."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8306,8 +8294,7 @@ msgstr "Kaart uitvouwen"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
+msgstr "Vakkundig vervaardigde producten voor mensen die echt om privacy geven."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8550,7 +8537,7 @@ msgstr "Snel"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Snelle afbeeldingsgeneratie"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8700,8 +8687,7 @@ msgstr "Filters niet effectief"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Filters out AI-generated images from image search results"
-msgstr ""
-"Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
+msgstr "Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8887,7 +8873,7 @@ msgstr "Vervolgvragen blijven privé."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Instructies opgevolgd"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9106,9 +9092,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Selecteer in de menubalk van de app voor Mac de optie <strong>DuckDuckGo</"
-"strong> &gt; <strong>Controleren op updates...</strong> en selecteer "
-"vervolgens <strong>Update installeren</strong>."
+"Selecteer in de menubalk van de app voor Mac de optie "
+"<strong>DuckDuckGo</strong> &gt; <strong>Controleren op updates...</strong> "
+"en selecteer vervolgens <strong>Update installeren</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9401,8 +9387,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
+msgstr "Krijg DuckDuckGo VPN, geavanceerde Duck.ai en Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9522,8 +9507,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een DuckDuckGo-"
-"abonnement, dat ook onze VPN en andere premium privacybeschermingen omvat."
+"Krijg toegang tot geavanceerde AI-modellen in Duck.ai met een "
+"DuckDuckGo-abonnement, dat ook onze VPN en andere premium "
+"privacybeschermingen omvat."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9567,8 +9553,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde AI-"
-"modellen met hogere chatlimieten en meer premium beschermingen."
+"Krijg onze snelle, no-log VPN, optionele toegang tot geavanceerde "
+"AI-modellen met hogere chatlimieten en meer premium beschermingen."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9702,9 +9688,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9714,9 +9700,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de DuckDuckGo-"
-"app en ga naar %3$sChats › Synchroniseren en back-ups › Synchroniseren met "
-"een ander apparaat%4$s en scan deze code:"
+"Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of de "
+"DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
+"Synchroniseren met een ander apparaat%4$s en scan deze code:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9728,8 +9714,8 @@ msgid ""
 msgstr ""
 "Ga naar %1$sDuck.ai-instellingen%2$s in je andere browser, of naar de "
 "DuckDuckGo-app en ga naar %3$sChats › Synchroniseren en back-ups › "
-"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je herstel-"
-"PDF."
+"Synchroniseren met een ander apparaat%4$s. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9837,7 +9823,7 @@ msgstr "Goed privacybeleid"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Goede visuele stijl"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10985,7 +10971,7 @@ msgstr "Beeldprompts moeten voldoen aan de %1$s van Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Afbeeldingskwaliteit"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11077,8 +11063,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"Verbetert de leesbaarheid van het resultaat met een bijgewerkte URL-"
-"indeling, -plaatsing en -kleur"
+"Verbetert de leesbaarheid van het resultaat met een bijgewerkte "
+"URL-indeling, -plaatsing en -kleur"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -11974,8 +11960,7 @@ msgstr "Lees meer over hoe het werkt"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Informatie over waarom het terugdringen van online tracking belangrijk is."
+msgstr "Informatie over waarom het terugdringen van online tracking belangrijk is."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12454,8 +12439,7 @@ msgstr "Zorg ervoor dat alle woorden correct gespeld zijn."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
+msgstr "Controleer of %1$s'Dit wordt mijn standaard zoekmachine'%2$s is aangevinkt"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13934,8 +13918,7 @@ msgstr "Geen resultaten gevonden."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the recording contains no audible speech.
 msgid "No speech detected. Please try again and speak into your microphone."
-msgstr ""
-"Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
+msgstr "Geen spraak gedetecteerd. Probeer het nog eens en spreek in de microfoon."
 
 # smartling.placeholder_format=C
 #. Button that dismisses a feedback form.
@@ -14607,8 +14590,7 @@ msgstr "%1$s-website openen"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
+msgstr "Open %1$sLocatie%2$s en zorg ervoor dat locatie %3$sis ingeschakeld%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14785,8 +14767,7 @@ msgstr "Open het paneel 'Hoe Duck.ai werkt'"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
+msgstr "Open het Safari-menu en selecteer %1$sInstellingen voor DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15872,7 +15853,7 @@ msgstr "Slechte opmaak"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Slechte afbeeldingskwaliteit"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16106,8 +16087,7 @@ msgstr "Prijs"
 #. Category of feedback a user can select on a feedback form.
 msgctxt "feedback form"
 msgid "Price shown doesn't reflect merchant site"
-msgstr ""
-"De weergegeven prijs komt niet overeen met die op de site van de verkoper"
+msgstr "De weergegeven prijs komt niet overeen met die op de site van de verkoper"
 
 # smartling.placeholder_format=C
 #. A button that prints the contents of a page.
@@ -16390,8 +16370,7 @@ msgstr "Vraag het mij"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
+msgstr "Vraag me om mijn geschatte locatie te gebruiken voor resultaten in de buurt."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -17045,8 +17024,7 @@ msgstr "Mijn keuze onthouden"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
+msgstr "Onthoud mijn keuze (dit kun je wijzigen in de %1$s%2$s%3$sInstellingen%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17803,8 +17781,7 @@ msgstr "Bewaar maximaal 30 van je meest recente chats op je apparaat."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
+msgstr "Bewaar je Duck.ai-chats tussen je apparaten met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17950,15 +17927,13 @@ msgstr "Schotland"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Scroll down and click %sView advanced settings%s"
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
+msgstr "Scroll naar beneden en klik op %1$sGeavanceerde instellingen weergeven%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18215,8 +18190,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar \"!"
-"w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
+"Zoek op andere sites met snelkoppelingen naar %1$s: een zoekopdracht naar "
+"\"!w ducks\" zal onmiddellijk op Wikipedia naar \"eenden\" zoeken."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18401,8 +18376,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
+msgstr "Veilig opgeslagen op de server van DuckDuckGo met end-to-end-versleuteling."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18529,8 +18503,7 @@ msgstr "Bekijk enkele van onze nieuwste updates"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
+msgstr "Kijk op de %1$sreferentiepagina voor URL-parameters%2$s voor meer informatie."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18557,8 +18530,7 @@ msgstr "Selecteer %1$s%2$s%3$s en vervolgens %4$sZoekmachine%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
+msgstr "Selecteer %1$s'Instellingen voor deze website...'%2$s vanuit het Safari-menu."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18571,21 +18543,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sToevoegen als standaard%4$s."
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
+msgstr "Selecteer %1$sDuckDuckGo%2$s en klik op %3$sInstellen als standaard%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18597,8 +18566,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in het uitklapmenu Standaard zoekmachine"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst en geef %3$stoegang tot%4$s locatie"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18610,8 +18578,7 @@ msgstr "Selecteer %1$sDuckDuckGo%2$s in de lijst met zoekmachines"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sDuckDuckGo%2$s in het gedeelte %3$sStandaard zoekmachine%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18698,8 +18665,7 @@ msgstr ""
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
+msgstr "Selecteer %1$sInstellingen%2$s en vervolgens %3$sStandaard zoekmachine%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18721,8 +18687,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
+msgstr "Selecteer %1$sje browser%2$s in de lijst en %3$slaat%4$s locatietoegang toe"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19075,8 +19040,8 @@ msgid ""
 "never reveals your precise location to us or AI models."
 msgstr ""
 "Deel een locatie op stadsniveau met AI-modellen om de relevantie te "
-"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan AI-"
-"modellen."
+"verbeteren. Duck.ai onthult nooit je precieze locatie aan ons of aan "
+"AI-modellen."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19635,8 +19600,7 @@ msgstr "Meest bezochte links weergeven op een nieuw tabblad"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
+msgstr "Geeft af en toe herinneringen weer om DuckDuckGo aan je browser toe te voegen"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19650,8 +19614,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"Geeft af en toe herinneringen weer om je aan te melden voor de DuckDuckGo-"
-"nieuwsbrieven over privacy"
+"Geeft af en toe herinneringen weer om je aan te melden voor de "
+"DuckDuckGo-nieuwsbrieven over privacy"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19661,8 +19625,7 @@ msgstr "Geeft paginanummers weer naast resultaatpagina-einden"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
+msgstr "Geeft een inschrijfformulier weer voor de DuckDuckGo-privacynieuwsbrieven"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19691,8 +19654,8 @@ msgstr "Geeft een welkomstbericht weer bovenaan de pagina met zoekresultaten"
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
 msgstr ""
-"Geeft een welkomstbericht weer aan gebruikers van het EU-Android-"
-"voorkeursmenu"
+"Geeft een welkomstbericht weer aan gebruikers van het "
+"EU-Android-voorkeursmenu"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19924,8 +19887,7 @@ msgstr "Er is iets misgegaan bij het laden van deze gedeelde chat."
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
+msgstr "Er is iets misgegaan tijdens het opslaan naar de server. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19963,8 +19925,7 @@ msgstr "Soms"
 #. Generic error message shown when the image generation model cannot process the user's request.
 msgctxt "Error message from the image generation model"
 msgid "Sorry I can't help, please describe your image in a different way."
-msgstr ""
-"Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
+msgstr "Sorry, ik kan het niet helpen. Omschrijf je afbeelding op een andere manier."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20038,8 +19999,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
+msgstr "Sorry, we konden je feedback niet verzenden. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20355,8 +20315,7 @@ msgstr "Stop verborgen trackers die op de loer liggen op andere websites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Stop de meeste verborgen trackers die op de loer liggen op andere websites."
+msgstr "Stop de meeste verborgen trackers die op de loer liggen op andere websites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21422,15 +21381,13 @@ msgstr "Gambia"
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB"
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$sMB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the total size of all attached files in a conversation exceeds the allowed limit. Placeholder is the combined size limit in megabytes. E.g. The attached files exceed the total size limit of 5 MB
 msgctxt "Error message when combined file size exceeds the limit"
 msgid "The attached files exceed the total size limit of %s MB."
-msgstr ""
-"De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
+msgstr "De bijgevoegde bestanden overschrijden de totale groottelimiet van %1$s MB."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
@@ -21486,8 +21443,7 @@ msgstr "Het verzoek is verlopen. Probeer het opnieuw."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
+msgstr "De server heeft een fout aangetroffen en kon je verzoek niet voltooien."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21627,8 +21583,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
+msgstr "Dit directe antwoord is gemaakt door de %1$sDuckDuckHack%2$s-community."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21886,8 +21841,7 @@ msgstr "Voor deze pagina moet JavaScript zijn ingeschakeld."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
+msgstr "De inhoud van deze pagina wordt samen met je bericht naar Duck.ai gestuurd"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21939,8 +21893,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
+msgstr "Deze gedeelde chat kon niet worden geopend. De link is mogelijk onvolledig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21969,15 +21922,13 @@ msgstr "Deze vertaling is onjuist"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
+msgstr "Deze video kan hier nog niet worden bekeken. Je kunt 'm bekijken op %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
+msgstr "Deze webpagina gebruikt geen beveiligde, versleutelde verbinding (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22096,8 +22047,8 @@ msgstr "Tips"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij helpen."
-"%2$s"
+"Ben je het zat om online te worden gevolgd? %1$sWij kunnen je hierbij "
+"helpen.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22129,8 +22080,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
+msgstr "Om door te gaan, moet je akkoord gaan met het %1$s en het %2$s van Duck.ai"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22171,8 +22121,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je DuckDuckGo-"
-"browser naar de nieuwste versie en probeer het opnieuw."
+"Opdate om je chatgeschiedenis over te zetten naar Duck.ai je "
+"DuckDuckGo-browser naar de nieuwste versie en probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22279,7 +22229,7 @@ msgstr "Te langzaam"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Duurt te lang om te genereren"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22567,8 +22517,7 @@ msgstr "Probeer %1$s om dit soort berichten niet meer te zien."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
+msgstr "Probeer %1$s, ons eerste model zonder enige zichtbaarheid bij zorgverleners."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22709,16 +22658,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
+msgstr "Probeer anonieme locatie in te schakelen voor nauwkeurigere resultaten."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
+msgstr "Probeer met alle modellen te experimenteren. Ze reageren allemaal anders."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22730,7 +22677,7 @@ msgstr "Probeer minder zoekwoorden."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Probeer gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22776,8 +22723,7 @@ msgstr "Probeer het gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
+msgstr "Probeer het gratis! Een veilige VPN, geavanceerde en privé-AI, en meer."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22816,8 +22762,7 @@ msgstr "Probeer onze browser"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
+msgstr "Probeer onze homepage, waar je deze berichten nooit te zien zult krijgen:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23268,8 +23213,7 @@ msgstr ""
 #. Message shown to the user when there was an issue connecting to their microphone.
 msgctxt "voice chat"
 msgid "Unable to connect to your mic. Please try again."
-msgstr ""
-"Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
+msgstr "Er kan geen verbinding worden gemaakt met je microfoon. Probeer het opnieuw."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when answer fails to load
@@ -23310,8 +23254,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
+msgstr "Bij %1$sOpenen met%2$s selecteer je %3$sEen specifieke pagina of pagina's%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23326,15 +23269,13 @@ msgstr "Bij %1$sZoekinstellingen%2$s selecteer je %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
+msgstr "Bij %1$sZoek in de adresbalk met%2$s selecteer je %3$sNieuwe toevoegen%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
+msgstr "Bij het gedeelte %1$sZoeken%2$s klik je op %3$sZoekmachines beheren...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23348,8 +23289,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
+msgstr "Bij Zoeken klik je op het uitklapmenu en selecteer je %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23450,8 +23390,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Ontgrendel geavanceerde AI-modellen en hogere limieten met een DuckDuckGo-"
-"abonnement"
+"Ontgrendel geavanceerde AI-modellen en hogere limieten met een "
+"DuckDuckGo-abonnement"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23723,8 +23663,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
+msgstr "Upgrade naar Pro om 2x hogere gebruikslimieten dan Plus te ontgrendelen"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23834,8 +23773,7 @@ msgstr "Gebruik DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
+msgstr "Gebruik DuckDuckGo Private Search op je iPad, iPhone of Android-apparaat."
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24154,10 +24092,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open 'Duck.ai-"
-"instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en selecteer "
-"'Synchroniseren met een ander apparaat'. Of scan de QR-code op je herstel-"
-"PDF."
+"Bezoek Duck.ai in je andere browser of de DuckDuckGo-app en open "
+"'Duck.ai-instellingen'. Selecteer 'Inschakelen' onder Sync & Backup en "
+"selecteer 'Synchroniseren met een ander apparaat'. Of scan de QR-code op je "
+"herstel-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24362,8 +24300,8 @@ msgid ""
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
 "Kijk in Duck Player om gepersonaliseerde advertenties op YouTube te "
-"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op YouTube-"
-"aanbevelingen."
+"blokkeren en te voorkomen dat je kijkactiviteit invloed heeft op "
+"YouTube-aanbevelingen."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24456,14 +24394,12 @@ msgstr "We achtervolgen je niet met advertenties."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
+msgstr "We slaan geen gebruikersnamen of persoonlijk identificeerbare informatie op."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
+msgstr "We slaan je persoonlijke gegevens niet op en volgen je ook niet. Nooit."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24489,8 +24425,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je bij ons terugkeert:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24498,8 +24433,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
+msgstr "We volgen je niet, dus we horen graag van je waarom je ons wilt uitproberen:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24596,8 +24530,7 @@ msgstr "De verbinding is verbroken. Probeer het later opnieuw."
 #. We store chats for 15 minutes in the BE. If the user tries to fetch it after the 15 minutes elapsed or if we had an issue saving it we show them this error message so they can re-submit their prompt.
 msgctxt "AI Chat: Error message for unsaved or expired chats saved in sync"
 msgid "We lost the connection. Please try sending your message again."
-msgstr ""
-"We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
+msgstr "We hebben de verbinding verloren. Probeer je bericht opnieuw te verzenden."
 
 # smartling.placeholder_format=C
 #. Message asking the user to disable their ad blocker, with a link to how our ads don't track you. The placeholders are for the start and end tags of that link (e.g. <a href="%">, </a>)
@@ -24639,8 +24572,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
+msgstr "We zorgen ervoor dat niemand je zoekgeschiedenis kan inzien, ook wij niet."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24663,8 +24595,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
+msgstr "We blokkeren trackers die je gegevens willen verzamelen terwijl je surft."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24708,8 +24639,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
+msgstr "Onze excuses voor dit ongemak. We doen ons best om je ervaring te verbeteren."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24819,8 +24749,7 @@ msgstr "Wekelijkse gebruikslimiet bereikt"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
+msgstr "Wekelijkse gebruikslimiet bereikt. Je kunt dit gesprek voortzetten na %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24873,8 +24802,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
+msgstr "Welkom bij de nieuwe Duck.ai! Je kunt nu je gedownloade chats importeren."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -25940,8 +25868,7 @@ msgstr "Je kunt dit op elk moment wijzigen in %1$sZoekinstellingen%2$s"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
+msgstr "Je kunt dit gesprek voortzetten wanneer je limiet op %1$s wordt gereset."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -26124,8 +26051,8 @@ msgid ""
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
 "Je hebt nu toegang tot geavanceerde AI-modellen. Je hebt toegang tot de VPN "
-"en andere beveiligingen van het DuckDuckGo-abonnement in de DuckDuckGo-"
-"browser."
+"en andere beveiligingen van het DuckDuckGo-abonnement in de "
+"DuckDuckGo-browser."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -26277,8 +26204,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
+msgstr "Je hebt je limiet voor dicteergebruik bereikt. probeer het later opnieuw"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26476,8 +26402,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26485,8 +26411,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26519,8 +26445,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om AI-"
-"modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
+"Je chats zijn privé, geanonimiseerd door ons en worden niet gebruikt om "
+"AI-modellen te trainen. Volg deze stappen om je chatgeschiedenis te bewaren."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26766,8 +26692,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
+msgstr "Je hebt de limiet voor spraakchat voor nu bereikt. Probeer het later opnieuw."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26850,8 +26775,7 @@ msgstr "door %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
+msgstr "Door DuckDuckGo — online bescherming vertrouwd door miljoenen elke dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/nn_NO/LC_MESSAGES/duckduckgo.po
+++ b/locales/nn_NO/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5222,6 +5233,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Avvis"
@@ -5311,6 +5327,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6770,6 +6791,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7025,6 +7051,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7772,6 +7803,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8692,6 +8728,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12634,6 +12675,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17688,6 +17734,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18047,6 +18098,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Prøv færre søkjeord"
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/od_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/od_IN/LC_MESSAGES/duckduckgo.po
@@ -2375,6 +2375,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5218,6 +5229,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "ଖାରଜ"
@@ -5307,6 +5323,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6765,6 +6786,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7020,6 +7046,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7767,6 +7798,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8691,6 +8727,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12629,6 +12670,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17687,6 +17733,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18046,6 +18097,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "ସ୍ୱଳ୍ପ ଶବ୍ଦ ଚେଷ୍ଟା କରନ୍ତୁ ।"
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -314,7 +315,8 @@ msgstr "Rankingi %1$s nie są jeszcze dostępne"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
+msgstr ""
+"%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -528,7 +530,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr ""
+"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -885,7 +888,8 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1012,8 +1016,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie "
-"%1$sduckduckgo.com/aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
+"aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -2034,7 +2038,8 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr ""
+"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2730,7 +2735,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr ""
+"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2978,6 +2984,18 @@ msgstr ""
 "metadane."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3127,7 +3145,8 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr ""
+"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3467,7 +3486,8 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr ""
+"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3872,7 +3892,8 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr ""
+"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3891,7 +3912,8 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr ""
+"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4024,8 +4046,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres "
-"%1$shttps://duck.ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
+"ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5371,7 +5393,8 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
+msgstr ""
+"Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5721,7 +5744,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr "Tworzy kopię czatu, którą może wyświetlić i zapisać każdy, kto otworzy link."
+msgstr ""
+"Tworzy kopię czatu, którą może wyświetlić i zapisać każdy, kto otworzy link."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5969,7 +5993,8 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6543,6 +6568,12 @@ msgid "Dislike source"
 msgstr "Nie lubię źródła"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Odrzuć"
@@ -6651,6 +6682,12 @@ msgstr "Rekord dywizji"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Dżibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7126,7 +7163,8 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr ""
+"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7399,7 +7437,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr ""
+"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8088,7 +8127,8 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr ""
+"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8228,7 +8268,8 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr ""
+"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8288,7 +8329,8 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr ""
+"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8528,6 +8570,12 @@ msgstr "Koniec meczu"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Szybko"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8860,6 +8908,12 @@ msgid "Follow-ups remain private."
 msgstr "Pytania uzupełniające pozostają prywatne."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8963,7 +9017,8 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr ""
+"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9207,19 +9262,22 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr ""
+"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9601,8 +9659,8 @@ msgstr "Pobierz aplikację"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
-"YouTube.%2$s"
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9715,7 +9773,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr ""
+"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9802,6 +9861,12 @@ msgstr "Dobry wygląd"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Dobra polityka prywatności"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10243,7 +10308,8 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr ""
+"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10896,7 +10962,8 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr ""
+"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10943,6 +11010,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Prompty obrazowe muszą być zgodne z %1$s Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11088,7 +11161,8 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr ""
+"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11466,7 +11540,8 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr ""
+"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11531,7 +11606,8 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr ""
+"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -12106,7 +12182,8 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr ""
+"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12217,7 +12294,8 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr ""
+"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13001,7 +13079,8 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -15819,6 +15898,12 @@ msgid "Poor formatting"
 msgstr "Słabe formatowanie"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16353,7 +16438,8 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr ""
+"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16590,19 +16676,22 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr ""
+"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16622,7 +16711,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
+msgstr ""
+"Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17752,8 +17842,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
-"end-to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
+"to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18351,7 +18441,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr ""
+"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18539,13 +18630,15 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr ""
+"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18636,7 +18729,8 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr ""
+"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18990,7 +19084,8 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr ""
+"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19561,7 +19656,8 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr ""
+"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19577,7 +19673,8 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr ""
+"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20291,7 +20388,8 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr ""
+"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20853,7 +20951,8 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr ""
+"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21387,7 +21486,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr ""
+"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21718,14 +21818,16 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr ""
+"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21812,7 +21914,8 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr ""
+"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21865,7 +21968,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
+msgstr ""
+"Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21932,7 +22036,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr ""
+"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22057,7 +22162,8 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr ""
+"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22121,13 +22227,15 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Przełącz na prywatny czat AI lub %1$swyłącz tę funkcję w ustawieniach%2$s."
+msgstr ""
+"Przełącz na prywatny czat AI lub %1$swyłącz tę funkcję w ustawieniach%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
+msgstr ""
+"Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22188,6 +22296,12 @@ msgstr "Za dużo wyników z tego źródła"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Za wolno"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22608,26 +22722,35 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr ""
+"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr ""
+"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Spróbuj z mniejszą liczbą słów kluczowych."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22984,7 +23107,8 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr ""
+"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23208,14 +23332,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr ""
+"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
-"https://duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23225,13 +23350,15 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr ""
+"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr ""
+"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23345,7 +23472,8 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr ""
+"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23384,7 +23512,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr ""
+"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23788,7 +23917,8 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr ""
+"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24192,7 +24322,8 @@ msgstr "Tapeta"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Chcesz mieć łatwy dostęp do prywatnego czatu AI na stronie nowej karty?"
+msgstr ""
+"Chcesz mieć łatwy dostęp do prywatnego czatu AI na stronie nowej karty?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24356,7 +24487,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr ""
+"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24440,7 +24572,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr ""
+"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24452,7 +24585,8 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr ""
+"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24715,7 +24849,8 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr ""
+"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25143,7 +25278,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr ""
+"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25218,7 +25354,8 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr ""
+"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25484,8 +25621,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres "
-"e-mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
+"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres e-"
+"mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25770,7 +25907,8 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr ""
+"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25824,7 +25962,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr ""
+"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25869,7 +26008,8 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr ""
+"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25946,7 +26086,8 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr ""
+"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26151,7 +26292,8 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr ""
+"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26231,7 +26373,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
+msgstr ""
+"Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26313,8 +26456,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
-"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
+"DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26353,7 +26496,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr ""
+"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/pl_PL/LC_MESSAGES/duckduckgo.po
+++ b/locales/pl_PL/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -315,8 +314,7 @@ msgstr "Rankingi %1$s nie są jeszcze dostępne"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
+msgstr "%1$s osiąga limity użycia 2-5 razy szybciej niż podstawowe modele. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -530,8 +528,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
+msgstr "%1$sNaciśnij i przytrzymaj%2$s ikonę aplikacji DuckDuckGo na ekranie głównym"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -888,8 +885,7 @@ msgstr "Osiągnięto limit 6 godzin użytkowania."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto limit 6 godzin użytkowania. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -1016,8 +1012,8 @@ msgstr ""
 "Funkcja AI Chat umożliwia prowadzenie anonimowych rozmów z modelami czatu AI "
 "oferowanymi przez inne firmy. Wyłączenie tej opcji spowoduje ukrycie funkcji "
 "AI Chat w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do funkcji AI Chat na stronie %1$sduckduckgo.com/"
-"aichat%2$s."
+"możesz uzyskać dostęp do funkcji AI Chat na stronie "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -2038,8 +2034,7 @@ msgstr "To urządzenie jest już zsynchronizowane."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
+msgstr "Możesz też wyszukiwać prywatnie na swoim iPadzie, iPhonie oraz Androidzie!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2735,8 +2730,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
 msgid "Auto-generated from sources. May be inaccurate."
-msgstr ""
-"Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
+msgstr "Generowane automatycznie na podstawie źródeł. Może zawierać nieścisłości."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2994,6 +2988,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Przed zapisaniem tego zgłoszenia DuckDuckGo usunie przesłane pliki i "
+"wygenerowane obrazy oraz zanonimizuje Twoją konwersację, usuwając dane "
+"osobowe, takie jak nazwiska, adresy e-mail i identyfikujące metadane."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3145,8 +3142,7 @@ msgstr "Zablokuj tę witrynę we wszystkich wynikach"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
+msgstr "Zablokuj skrypty śledzące i przejmij kontrolę nad swoimi danymi osobowymi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3486,8 +3482,7 @@ msgstr "Burundi"
 #. The first %s is the action button label ('Continue'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab.
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid "By clicking '%s' you agree to our %s."
-msgstr ""
-"Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
+msgstr "Klikając przycisk „%1$s”, akceptujesz postanowienia naszego dokumentu %2$s."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to Duck.ai Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'By clicking “Agree and Continue,” you accept Duck.ai’s Privacy Policy and Terms of Service.'
@@ -3892,8 +3887,7 @@ msgstr "Zmienia sposób wyświetlania adresów URL wyników"
 #. This is the description of a user setting
 msgctxt "settings"
 msgid "Changes how the header is displayed and its behavior as you scroll"
-msgstr ""
-"Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
+msgstr "Zmienia sposób wyświetlania nagłówka i jego zachowanie podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/mcZdcaF.png
@@ -3912,8 +3906,7 @@ msgstr "Zmienia kolor tła na całej stronie"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
+msgstr "Zmienia kolor tła wyników po najechaniu kursorem, modułów i rozwijanych menu"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4046,8 +4039,8 @@ msgstr ""
 "rozmów z zewnętrznymi modelami czatu AI, obsługującymi modele OpenAI, "
 "Anthropic i inne. Wyłączenie tej opcji spowoduje ukrycie przycisków czatu i "
 "linków w DuckDuckGo Search. Nawet w przypadku wyłączenia tego ustawienia "
-"możesz uzyskać dostęp do czatu, przechodząc pod adres %1$shttps://duck."
-"ai%2$s bezpośrednio."
+"możesz uzyskać dostęp do czatu, przechodząc pod adres "
+"%1$shttps://duck.ai%2$s bezpośrednio."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -5393,8 +5386,7 @@ msgstr "Kontynuuj blokowanie reklam"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
+msgstr "Kontynuuj ostatnie czaty tutaj. Możesz też usunąć je przyciskiem Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5744,8 +5736,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr ""
-"Tworzy kopię czatu, którą może wyświetlić i zapisać każdy, kto otworzy link."
+msgstr "Tworzy kopię czatu, którą może wyświetlić i zapisać każdy, kto otworzy link."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -5993,8 +5984,7 @@ msgstr "Osiągnięto dzienny limit"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto dzienny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6571,7 +6561,7 @@ msgstr "Nie lubię źródła"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nie lubię tego stylu wizualnego"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6687,7 +6677,7 @@ msgstr "Dżibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nie wykonuje poleceń"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7163,8 +7153,7 @@ msgstr ""
 msgctxt "Error message for VQD error"
 msgid ""
 "Duck.ai is temporarily unavailable. Please refresh the page and try again."
-msgstr ""
-"Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
+msgstr "Funkcja Duck.ai jest chwilowo niedostępna. Odśwież stronę i spróbuj ponownie."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7437,8 +7426,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
+msgstr "DuckDuckGo AI Chat jest chwilowo niedostępny. Spróbuj ponownie później."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8127,8 +8115,7 @@ msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
+msgstr "Upewnij się, że opcja „Lokalizacja” jest ustawiona na %1$szezwalaj%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8268,8 +8255,7 @@ msgstr "Gwinea Równikowa"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
+msgstr "Błyskawicznie usuń dane przeglądania za pomocą przycisku %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8329,8 +8315,7 @@ msgstr "Rozwiń mapę"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
+msgstr "Profesjonalnie wykonane produkty dla osób, które naprawdę dbają o prywatność."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8575,7 +8560,7 @@ msgstr "Szybko"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Szybkie generowanie obrazów"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8911,7 +8896,7 @@ msgstr "Pytania uzupełniające pozostają prywatne."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Stosowanie się do instrukcji"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9017,8 +9002,7 @@ msgstr "Bezpłatne i prywatne czaty anonimizowane przez nas"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
+msgstr "Darmowe i prywatne czaty, anonimizowane przez nas. Nie trzeba zakładać konta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9262,22 +9246,19 @@ msgstr "Ogólnego przeznaczenia"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z wysoką wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia z niską wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
+msgstr "Sztuczna inteligencja ogólnego przeznaczenia ze średnią wbudowaną moderacją"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9659,8 +9640,8 @@ msgstr "Pobierz aplikację"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na YouTube."
-"%2$s"
+"Pobierz darmową przeglądarkę DuckDuckGo, aby %1$sblokować reklamy na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9773,8 +9754,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
+msgstr "Wybierz kolejno %1$sPrywatność i bezpieczeństwo > Usługi lokalizacji%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9866,7 +9846,7 @@ msgstr "Dobra polityka prywatności"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Dobry styl wizualny"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10308,8 +10288,7 @@ msgstr "Podaj powód negatywnej oceny"
 #. A subtitle of a page that encourages users to share DuckDuckGo with their friends.
 msgctxt "showcase_spread"
 msgid "Help your friends and family join the Duck Side!"
-msgstr ""
-"Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
+msgstr "Pomóż swoim przyjaciołom oraz rodzinie dołączyć do społeczności DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Text description for the Spread card in the SERP footer
@@ -10962,8 +10941,7 @@ msgstr "Jeśli chcesz nas wesprzeć, %1$spomóż nam rozpowszechnić DuckDuckGo%
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
+msgstr "Jeśli chcesz używać DuckDuckGo bez JavaScript, użyj wersji %1$s lub %2$s."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -11015,7 +10993,7 @@ msgstr "Prompty obrazowe muszą być zgodne z %1$s Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Jakość obrazu"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11161,8 +11139,7 @@ msgstr "W menu na górze ekranu wybierz %1$sNarzędzia%2$s > %3$sUstawienia%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
+msgstr "W wyskakującym okienku zaznacz %1$sUstaw jako domyślną wyszukiwarkę%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11540,8 +11517,7 @@ msgstr "Jest szybki, bezpłatny i zapewnia Ci jeszcze większą ochronę online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
+msgstr "Zgadzam się na (bardzo rzadkie) pytania o moje doświadczenia z DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11606,8 +11582,7 @@ msgstr "Dołącz do nas!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
+msgstr "Dołącz do naszego konkursu na ochronę prywatności w wysokości 500 000 USD"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -12182,8 +12157,7 @@ msgstr "Linki:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
+msgstr "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12294,8 +12268,7 @@ msgstr "Ładuj więcej obrazów podczas przewijania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
+msgstr "Automatycznie wczytuje więcej obrazów, filmów i zakupów podczas przewijania"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13079,8 +13052,7 @@ msgstr "Osiągnięty limit miesięczny"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto miesięczny limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -15901,7 +15873,7 @@ msgstr "Słabe formatowanie"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Słaba jakość obrazu"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16438,8 +16410,7 @@ msgstr "Chroń swoje dane podczas wyszukiwania i przeglądania."
 #. Shown on the Mac and Windows browser promo cards. DuckDuckGo's desktop browser protects your data across search, browsing, and AI chat.
 msgctxt "SERP footer content"
 msgid "Protect your data as you search, browse, and use AI."
-msgstr ""
-"Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
+msgstr "Chroń swoje dane podczas wyszukiwania, przeglądania i korzystania z AI."
 
 # smartling.placeholder_format=C
 #. A title above links to download the DuckDuckGo apps.
@@ -16676,22 +16647,19 @@ msgstr "Wnioskowanie AI"
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a high moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with high built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z wysokim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a low moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with low built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja z niskim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Text with short description for a reasoning AI (Artificial Intelligence) Model that has a medium moderation level. Reasoning refers to the AI ability to think logically to draw conclusions before providing an answer. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "Reasoning AI with medium built-in moderation"
-msgstr ""
-"Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
+msgstr "Rozumująca sztuczna inteligencja ze średnim poziomem wbudowanej moderacji"
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
@@ -16711,8 +16679,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
+msgstr "Rozumowanie jest dokładniejsze, ale zużywa limity 2-5 razy szybciej. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -17842,8 +17809,8 @@ msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
 msgstr ""
-"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu end-"
-"to-end."
+"Zapisuj swoje czaty Duck.ai między urządzeniami dzięki szyfrowaniu typu "
+"end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18441,8 +18408,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
+msgstr "Bezpieczne przechowywanie na serwerze DuckDuckGo z kompleksowym szyfrowaniem."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18630,15 +18596,13 @@ msgstr "Wybierz %1$sDuckDuckGo%2$s i kliknij %3$sUstaw jako domyślną%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
+msgstr "Wybierz %1$sDuckDuckGo%2$s w rozwijanym menu jako domyślną wyszukiwarkę"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
+msgstr "Wybierz %1$sDuckDuckGo%2$s z listy i %3$szezwól%4$s na dostęp do lokalizacji"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18729,8 +18693,7 @@ msgstr "Wybierz %1$sUstawienia%2$s z rozwijanego menu."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
+msgstr "Wybierz %1$sUstawienia%2$s, a następnie %3$sUstawienia zaawansowane%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -19084,8 +19047,7 @@ msgstr "Udostępnij"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
+msgstr "Udostępniaj informacje o DuckDuckGo i pomóż znajomym odzyskać prywatność!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19656,8 +19618,7 @@ msgstr "Wyświetla poziome linie pomiędzy stronami z wynikami wyszukiwania"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
+msgstr "Wyświetla łącza do instrukcji dodawania DuckDuckGo do Twojej przeglądarki"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19673,8 +19634,7 @@ msgstr "Wyświetla najczęściej odwiedzane łącza na stronie nowej karty"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
+msgstr "Wyświetla sporadyczne przypomnienia o dodaniu DuckDuckGo do przeglądarki"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20388,8 +20348,7 @@ msgstr "Zatrzymaj generowanie"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
+msgstr "Blokowanie mechanizmów śledzących ukrytych na innych stronach internetowych."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20951,8 +20910,7 @@ msgstr "Sync & Backup włączone!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
+msgstr "Danych Sync & Backup nie można odzyskać po 18 miesiącach braku aktywności."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21486,8 +21444,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
+msgstr "Dostawca modelu usuwa wszelkie dane związane z tym czatem w ciągu 30 dni."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21818,16 +21775,14 @@ msgstr "Tego obrazu nie dało się stworzyć."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
+msgstr "Ten typ obrazu nie jest obsługiwany, dołącz plik JPG, PNG, WebP lub GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21914,8 +21869,7 @@ msgstr "Ta strona do działania wymaga włączonego Javascriptu."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
+msgstr "Zawartość tej strony zostanie wysłana wraz z Twoją wiadomością do Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21968,8 +21922,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
+msgstr "Nie udało się otworzyć tego udostępnionego czatu. Link może być niekompletny."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -22036,8 +21989,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
+msgstr "Spowoduje to usunięcie wybranego obrazu. Tej czynności nie można cofnąć."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22162,8 +22114,7 @@ msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
+msgstr "Aby kontynuować, musisz wyrazić zgodę na %1$s i %2$s DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22227,15 +22178,13 @@ msgstr "Dziś"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Przełącz na prywatny czat AI lub %1$swyłącz tę funkcję w ustawieniach%2$s."
+msgstr "Przełącz na prywatny czat AI lub %1$swyłącz tę funkcję w ustawieniach%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
+msgstr "Przełącz, aby wypróbować prywatny czat AI, lub %1$swyłącz go w menu %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22301,7 +22250,7 @@ msgstr "Za wolno"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Zbyt wolne generowanie"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22722,23 +22671,20 @@ msgstr "Spróbuj innych słów kluczowych."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
+msgstr "Spróbuj wyłączyć blokadę reklam w DuckDuckGo, aby zobaczyć więcej wyników."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
+msgstr "Spróbuj włączyć anonimową lokalizację, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
+msgstr "Spróbuj poeksperymentować z każdym modelem — otrzymasz różne odpowiedzi."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22750,7 +22696,7 @@ msgstr "Spróbuj z mniejszą liczbą słów kluczowych."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Wypróbuj bezpłatnie"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23107,8 +23053,7 @@ msgstr "Wyłącz:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
+msgstr "Włącz opcję %1$sDokładna lokalizacja%2$s, aby uzyskać dokładniejsze wyniki."
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23332,15 +23277,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
+msgstr "Pod %1$sOtwórz za pomocą%2$s wybierz %3$sKonkretna strona lub strony%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: https://"
-"duckduckgo.com"
+"Pod %1$sPrzy uruchomieniu > Strona główna \\%2$s wprowadź: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23350,15 +23294,13 @@ msgstr "Pod %1$sUstawienia wyszukiwania%2$s wybierz %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
+msgstr "Pod %1$sWyszukaj w pasku adresu za pomocą%2$s wybierz %3$sDodaj nową%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
+msgstr "W dziale %1$sWyszukiwanie%2$s kliknij %3$sZarządzaj wyszukiwarkami…%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23472,8 +23414,7 @@ msgstr "Odblokuj za pomocą subskrypcji DuckDuckGo"
 msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
-msgstr ""
-"Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
+msgstr "Odblokuj zaawansowane modele AI i wyższe limity dzięki subskrypcji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23512,8 +23453,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
+msgstr "Odblokuj bardziej wydajne modele AI dzięki subskrypcji DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23917,8 +23857,7 @@ msgstr ""
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
 msgctxt "DuckChat location prompt"
 msgid "Use your approximate location for more accurate results?"
-msgstr ""
-"Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
+msgstr "Czy użyć Twojej przybliżonej lokalizacji, aby uzyskać dokładniejsze wyniki?"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes before every user message in the downloaded file, indicating which message it is out of the total number of messages. Example: 'User prompt 3 of 5'
@@ -24322,8 +24261,7 @@ msgstr "Tapeta"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Chcesz mieć łatwy dostęp do prywatnego czatu AI na stronie nowej karty?"
+msgstr "Chcesz mieć łatwy dostęp do prywatnego czatu AI na stronie nowej karty?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24487,8 +24425,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
+msgstr "Nie przechowujemy informacji na Twój temat ani Cię nie śledzimy. Nigdy."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24572,8 +24509,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
+msgstr "Nie śledzimy Cię, niezależnie od tego czy używasz trybu incognito, czy nie."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24585,8 +24521,7 @@ msgstr "Nie śledzimy Cię. To jest nasza polityka prywatności w skrócie…"
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
+msgstr "Zakończyliśmy czat z powodu braku aktywności. Chcesz spróbować ponownie?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24849,8 +24784,7 @@ msgstr "Osiągnięto tygodniowy limit użycia"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
+msgstr "Osiągnięto tygodniowy limit użycia. Możesz kontynuować tę rozmowę po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -25278,8 +25212,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
+msgstr "Czym jest skryptozakładka Cloud Save i czym różni się od skryptozakładki URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25354,8 +25287,7 @@ msgstr "Na jaki temat chcesz przekazać opinię?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
+msgstr "To, co oglądasz w DuckDuckGo, nie wpłynie na rekomendacje w serwisie YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25621,8 +25553,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres e-"
-"mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
+"Działa bezpośrednio z Twojego urządzenia, pozwalając usunąć Twój adres "
+"e-mail, imię i nazwisko, adres i inne dane z witryn brokerów danych."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25907,8 +25839,7 @@ msgstr ""
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
 msgctxt "Information about direct access to DuckDuckGo AI Chat"
 msgid "You can access DuckDuckGo AI Chat directly at %s."
-msgstr ""
-"Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
+msgstr "Możesz uzyskać dostęp do DuckDuckGo AI Chat bezpośrednio pod adresem %1$s."
 
 # smartling.placeholder_format=C
 #. Search Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Search Assist.
@@ -25962,8 +25893,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
+msgstr "Możesz to zmienić w dowolnym momencie w %1$sustawieniach wyszukiwania%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26008,8 +25938,7 @@ msgstr "Możesz kontynuować rozmowę, korzystając z limitu miesięcznego."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
+msgstr "Teraz możesz zapisać do 100 czatów na tym urządzeniu. Rozmawiajcie śmiało!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26086,8 +26015,7 @@ msgstr "Można przywrócić swoje ustawienia po usunięciu plików cookie."
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can share your settings among computers and browsers."
-msgstr ""
-"Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
+msgstr "Możesz używać tych samych ustawień na różnych komputerach i przeglądarkach."
 
 # smartling.placeholder_format=C
 #. Alternative option description on export screen.
@@ -26292,8 +26220,7 @@ msgstr ""
 #. Description shown when the user has reached the maximum voice chat duration.
 msgctxt "voice chat duration limit modal"
 msgid "You've reached the maximum voice chat duration for a single session."
-msgstr ""
-"Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
+msgstr "Osiągnięto maksymalny czas trwania czatu głosowego w ramach jednej sesji."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the daily voice chat limit.
@@ -26373,8 +26300,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
+msgstr "Twoje czaty Duck.ai są synchronizowane z użyciem szyfrowania end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26456,8 +26382,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych witryn."
-"DuckDuckGo nigdy nie ma dostępu do tych danych."
+"Twoja przeglądarka udostępnia listę najczęściej odwiedzanych "
+"witryn.DuckDuckGo nigdy nie ma dostępu do tych danych."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26496,8 +26422,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
+msgstr "Twoje czaty są prywatne i nigdy nie są wykorzystywane do trenowania modeli AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.

--- a/locales/ps_AF/LC_MESSAGES/duckduckgo.po
+++ b/locales/ps_AF/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/pt_BR/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_BR/LC_MESSAGES/duckduckgo.po
@@ -2387,6 +2387,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5258,6 +5269,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Dispensar"
@@ -5348,6 +5364,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6831,6 +6852,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7086,6 +7112,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7835,6 +7866,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8770,6 +8806,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12732,6 +12773,11 @@ msgstr "Polonês"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17823,6 +17869,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18183,6 +18234,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Tente menos palavras-chave."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -532,7 +532,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr ""
+"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1334,7 +1335,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr ""
+"Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1989,7 +1991,8 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr ""
+"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2717,7 +2720,8 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr ""
+"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2972,8 +2976,20 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de "
-"e-mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de e-"
+"mail e metadados identificativos."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3888,7 +3904,8 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr ""
+"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4294,7 +4311,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr ""
+"Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4777,7 +4795,8 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr ""
+"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5547,9 +5566,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do "
-"Duck.ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e "
-"tenta novamente."
+"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do Duck."
+"ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e tenta "
+"novamente."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5965,7 +5984,8 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6539,6 +6559,12 @@ msgid "Dislike source"
 msgstr "Não gosto da fonte"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Recusar"
@@ -6647,6 +6673,12 @@ msgstr "Registo da divisão"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Jibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7128,7 +7160,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr ""
+"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7208,7 +7241,8 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr ""
+"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7653,7 +7687,8 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr ""
+"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -8072,19 +8107,22 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr ""
+"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr ""
+"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8124,13 +8162,15 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr ""
+"Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8532,6 +8572,12 @@ msgid "Fast"
 msgstr "Rápido"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8860,6 +8906,12 @@ msgid "Follow-ups remain private."
 msgstr "As mensagens de acompanhamento permanecem privadas."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8963,7 +9015,8 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr ""
+"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9371,7 +9424,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+msgstr ""
+"Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9521,7 +9575,8 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
+msgstr ""
+"Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9600,8 +9655,8 @@ msgstr "Descarrega a aplicação"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
-"YouTube.%2$s"
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9801,6 +9856,12 @@ msgstr "Bom design"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Boa política de privacidade"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10942,6 +11003,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Os prompts de imagem devem cumprir os termos do Duck.ai %1$s."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Azulejos de imagem"
@@ -11463,7 +11530,8 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr ""
+"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11865,7 +11933,8 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr ""
+"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11987,7 +12056,8 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
+msgstr ""
+"Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12099,7 +12169,8 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr ""
+"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12397,8 +12468,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
-"pré-definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
+"definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12937,7 +13008,8 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr ""
+"Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -12996,7 +13068,8 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -15552,7 +15625,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr ""
+"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15813,6 +15887,12 @@ msgstr "Polaco"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Má formatação"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16978,8 +17058,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
-"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
+"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16989,7 +17069,8 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr ""
+"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17382,7 +17463,8 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr ""
+"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17740,7 +17822,8 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr ""
+"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -17938,7 +18021,8 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr ""
+"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18519,7 +18603,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18536,7 +18621,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18556,7 +18642,8 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18641,7 +18728,8 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr ""
+"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18991,7 +19079,8 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr ""
+"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19418,7 +19507,8 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr ""
+"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19560,7 +19650,8 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19576,12 +19667,14 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr ""
+"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19612,7 +19705,8 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr ""
+"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19622,7 +19716,8 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr ""
+"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19949,7 +20044,8 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr ""
+"Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20236,19 +20332,22 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr ""
+"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20291,7 +20390,8 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr ""
+"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20464,7 +20564,8 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr ""
+"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21554,7 +21655,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr ""
+"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21649,13 +21751,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr ""
+"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21894,7 +21998,8 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr ""
+"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21928,7 +22033,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr ""
+"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22055,7 +22161,8 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr ""
+"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22126,8 +22233,8 @@ msgstr "Muda para o chat com IA privado ou %1$sdesativa-o nas definições%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
-"%2$s.%3$s"
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22188,6 +22295,12 @@ msgstr "Demasiados resultados desta fonte"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Demasiado lento"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22475,7 +22588,8 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr ""
+"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22616,7 +22730,8 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr ""
+"Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22630,6 +22745,12 @@ msgstr "Experimenta os vários modelos — vão dar respostas diferentes."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Experimenta com menos palavras-chave."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22797,7 +22918,8 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr ""
+"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -23208,12 +23330,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr ""
+"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr ""
+"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23378,7 +23502,8 @@ msgstr "Desbloqueia modelos avançados"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr ""
+"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -23996,7 +24121,8 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr ""
+"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24192,7 +24318,8 @@ msgstr "Wallpaper"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Queres acesso fácil ao chat privado com IA na página do novo separador?"
+msgstr ""
+"Queres acesso fácil ao chat privado com IA na página do novo separador?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24714,7 +24841,8 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr ""
+"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24859,13 +24987,15 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr ""
+"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr ""
+"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24990,7 +25120,8 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr ""
+"Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25140,7 +25271,8 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr ""
+"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25215,7 +25347,8 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr ""
+"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25822,7 +25955,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr ""
+"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25867,7 +26001,8 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr ""
+"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26159,7 +26294,8 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr ""
+"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26415,7 +26551,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr ""
+"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26643,13 +26780,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr ""
+"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr ""
+"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26732,7 +26871,8 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr ""
+"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: pt_PT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -532,8 +532,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
+msgstr "%1$sPrime sem soltar%2$s o ícone da aplicação DuckDuckGo no ecrã inicial"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -1335,8 +1334,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
 msgid "Ad clicks aren’t used to profile you"
-msgstr ""
-"Os cliques em anúncios não são usados para criar perfis de utilizadores"
+msgstr "Os cliques em anúncios não são usados para criar perfis de utilizadores"
 
 # smartling.placeholder_format=C
 #. Category of problem a user can select on a feedback form.
@@ -1991,8 +1989,7 @@ msgstr "Permitir a revisão anónima de ficheiros neste chat?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
+msgstr "Permitir anúncios que respeitam a privacidade na Private Search do DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2720,8 +2717,7 @@ msgstr "Resposta automática"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
+msgstr "Gerada automaticamente com base nas fontes listadas. Pode conter imprecisões."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2976,8 +2972,8 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 "Antes de guardar este relatório, o DuckDuckGo irá anonimizar a tua conversa "
-"removendo informações de identificação pessoal, como nomes, endereços de e-"
-"mail e metadados identificativos."
+"removendo informações de identificação pessoal, como nomes, endereços de "
+"e-mail e metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2990,6 +2986,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Antes de guardar este relatório, o DuckDuckGo irá remover os ficheiros "
+"carregados e as imagens geradas, e irá anonimizar a tua conversa removendo "
+"informações de identificação pessoal, como nomes, endereços de e-mail e "
+"metadados identificativos."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3904,8 +3904,7 @@ msgstr "Modifica a cor de fundo em todo o site"
 msgctxt "settings"
 msgid ""
 "Changes the background color of results on hover, modules, and dropdown menus"
-msgstr ""
-"Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
+msgstr "Altera a cor de fundo dos resultados em menus suspensos, hovers e módulos"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/NdpkbY0.png
@@ -4311,8 +4310,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Consulta a página de estado para atualizações sobre esta indisponibilidade."
+msgstr "Consulta a página de estado para atualizações sobre esta indisponibilidade."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4795,8 +4793,7 @@ msgstr "Clica em %1$sFornecedores de Pesquisa%2$s em tipos de Add-on"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
+msgstr "No canto superior direito do navegador, clica no %1$sícone de Ferramentas%2$s"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -5566,9 +5563,9 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do Duck."
-"ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e tenta "
-"novamente."
+"Copia o código a partir de outro dispositivo. Vai a %1$sDefinições do "
+"Duck.ai › Chats › Sync & Backup › Sincronizar com outro dispositivo%2$s e "
+"tenta novamente."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5984,8 +5981,7 @@ msgstr "Limite diário atingido"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização diária atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização diária atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6562,7 +6558,7 @@ msgstr "Não gosto da fonte"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Não gosto do estilo visual"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6678,7 +6674,7 @@ msgstr "Jibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Não segue as instruções"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7160,8 +7156,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
+msgstr "O Duck.ai está temporariamente indisponível. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7241,8 +7236,7 @@ msgstr "Duck.ai atualizado!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
+msgstr "O Duck.ai funciona melhor na nossa aplicação privada e gratuita DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7687,8 +7681,7 @@ msgctxt ""
 "Description of the DuckDuckGo subscription setting when it is not available "
 "in the user region"
 msgid "DuckDuckGo subscriptions are not available to purchase in this region."
-msgstr ""
-"As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
+msgstr "As subscrições da DuckDuckGo não estão disponíveis para compra nesta região."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to use 'ducky' tone in its responses. When this option is selected, the AI assistant speaks like a duck.
@@ -8107,22 +8100,19 @@ msgstr ""
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location Services' is %senabled%s."
-msgstr ""
-"Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
+msgstr "Certifica-te de que os \"Serviços de Localização\" estão %1$sativos%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
+msgstr "Certifica-te de que a \"Localização\" está definida como %1$spermitir%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s."
-msgstr ""
-"Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
+msgstr "Certifica-te de que a \"Localização\" está definida para %1$spermitir%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -8162,15 +8152,13 @@ msgstr ""
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access"
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização"
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização"
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed location access."
-msgstr ""
-"Certifica-te de que o teu navegador tem permissão para aceder à localização."
+msgstr "Certifica-te de que o teu navegador tem permissão para aceder à localização."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -8575,7 +8563,7 @@ msgstr "Rápido"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Geração rápida de imagens"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8909,7 +8897,7 @@ msgstr "As mensagens de acompanhamento permanecem privadas."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Seguiu as instruções"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9015,8 +9003,7 @@ msgstr "Chats gratuitos e privados, anonimizados por nós"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
+msgstr "Chats gratuitos e privados, anonimizados por nós. Não é necessária conta."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9424,8 +9411,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
+msgstr "Obtém a VPN da DuckDuckGo, Duck.ai avançado e Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9575,8 +9561,7 @@ msgstr "Obter ajuda informática"
 #. Description shown beneath the reached-limit title when a subscription-eligible free user has reached a Duck.ai usage limit.
 msgctxt "Subscription upsell in the usage limit banner in Duck.ai."
 msgid "Get higher usage limits with a DuckDuckGo subscription."
-msgstr ""
-"Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
+msgstr "Obtém limites de utilização mais elevados com uma subscrição da DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Promotional text that appears in popup promo to encourage user's to download DuckDuckGo Browser from the settings page.
@@ -9655,8 +9640,8 @@ msgstr "Descarrega a aplicação"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no YouTube."
-"%2$s"
+"Obtém o navegador DuckDuckGo gratuito %1$spara bloquear anúncios no "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9861,7 +9846,7 @@ msgstr "Boa política de privacidade"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Bom estilo visual"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -11006,7 +10991,7 @@ msgstr "Os prompts de imagem devem cumprir os termos do Duck.ai %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Qualidade da imagem"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11530,8 +11515,7 @@ msgstr "É rápido, gratuito e oferece ainda mais proteção online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
+msgstr "Inquéritos (pouco frequentes) acerca da minha experiência com o DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11933,8 +11917,7 @@ msgstr "Saber mais sobre a Proteção de privacidade ativa"
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
+msgstr "Sabe mais sobre privacidade online diretamente na tua caixa de entrada."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -12056,8 +12039,7 @@ msgstr "Deixa-te pesquisar anonimamente com o DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
+msgstr "Permite alternar entre o envio de consultas de pesquisa e pedidos ao Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12169,8 +12151,7 @@ msgstr "Ligações:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
+msgstr "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12468,8 +12449,8 @@ msgstr "Certifica-te de que todas as palavras estão escritas corretamente."
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
 msgstr ""
-"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar pré-"
-"definido\"%2$s"
+"Certifica-te de marcar %1$s\"Tornar este no meu motor de buscar "
+"pré-definido\"%2$s"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -13008,8 +12989,7 @@ msgstr "Capitalização do mercado"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Mobile Instructions (not displayed on settings page)"
-msgstr ""
-"Instruções para dispositivos móveis (não disponível na página de definições)"
+msgstr "Instruções para dispositivos móveis (não disponível na página de definições)"
 
 # smartling.placeholder_format=C
 #. A short label indicating that a user is a moderator of a discussion.
@@ -13068,8 +13048,7 @@ msgstr "Limite mensal atingido"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização mensal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -15625,8 +15604,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
+msgstr "Indica por que motivo a resposta do chat é prejudicial ou ilegal. (opcional)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15892,7 +15870,7 @@ msgstr "Má formatação"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Má qualidade de imagem"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17058,8 +17036,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão &quot;"
-"Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
+"Recarrega o DuckDuckGo seguindo as instruções ou clicando no botão "
+"&quot;Atualizar&quot; ou &quot;Recarregar&quot; do teu navegador."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17069,8 +17047,7 @@ msgstr "Memorizar a minha opção"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
+msgstr "Lembrar escolha (isto pode ser alterado nas %1$s%2$s%3$sDefinições%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17463,8 +17440,7 @@ msgstr "Os resultados excluem informações de sites bloqueados."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
+msgstr "Os resultados excluem os teus sites bloqueados, que podes gerir no teu %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17822,8 +17798,7 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
+msgstr "Guarda até 30 das tuas conversas mais recentes localmente no teu dispositivo."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
@@ -18021,8 +17996,7 @@ msgstr "Desce na página e localiza %1$so teu navegador%2$s na lista."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
+msgstr "Desce até %1$sDuckDuckGo%2$s e autoriza a utilização da tua localização."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -18603,8 +18577,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
+msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sAdicionar como predefinido%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -18621,8 +18594,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s e clica em %3$sPredefinir%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
+msgstr "Seleciona %1$sDuckDuckGo%2$s no menu suspenso de motor de busca predefinido"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18642,8 +18614,7 @@ msgstr "Seleciona %1$sDuckDuckGo%2$s na lista de fornecedores de pesquisa"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDuckDuckGo%2$s na secção%3$sMotor de busca predefinido%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18728,8 +18699,7 @@ msgstr "Seleciona %1$sDefinições%2$s e depois %3$sDefinições Avançadas%4$s"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
+msgstr "Seleciona %1$sDefinições%2$s e depois %3$sMotor de busca predefinido%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -19079,8 +19049,7 @@ msgstr "Partilhar"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
+msgstr "Partilha o DuckDuckGo e ajuda os teus amigos a recuperar a sua privacidade!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19507,8 +19476,7 @@ msgstr "Mostrar todos os resultados"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
+msgstr "Mostra as respostas com mais frequência. (Também podes %1$sdesativá-las%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19650,8 +19618,7 @@ msgstr "Mostrar linhas horizontais nas quebras de página de resultados"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra links para instruções de como adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19667,14 +19634,12 @@ msgstr "Mostra os links mais visitados na página de um novo separador"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo ao teu navegador"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
+msgstr "Mostra lembretes ocasionais para adicionar o DuckDuckGo aos teus dispositivos"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19705,8 +19670,7 @@ msgstr "Mostra sugestões na caixa de pesquisa enquanto digitas"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
+msgstr "Mostra os benefícios de privacidade do uso do DuckDuckGo na página inicial"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19716,8 +19680,7 @@ msgstr "Mostra o fundo do botão de pesquisa"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
+msgstr "Mostra a mensagem de boas-vindas no topo da página dos resultados de pesquisa"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20044,8 +20007,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
-msgstr ""
-"Este código é inválido. Confirma que introduziste ou leste o código correto."
+msgstr "Este código é inválido. Confirma que introduziste ou leste o código correto."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
@@ -20332,22 +20294,19 @@ msgstr "Fica no DuckDuckGo"
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletter."
-msgstr ""
-"Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
+msgstr "Mantém-te protegido e informado com a nossa newsletter sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
+msgstr "Mantém-te protegido e informado com as nossas newsletters sobre privacidade."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20390,8 +20349,7 @@ msgstr "Bloqueia os rastreadores ocultos que se escondem noutros sites."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
+msgstr "Bloqueia a maioria dos rastreadores ocultos que se escondem noutros sites."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20564,8 +20522,7 @@ msgstr "Sugere um título para uma publicação num blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
+msgstr "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21655,8 +21612,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
+msgstr "Esta resposta instantânea foi dada pela Comunidade %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21751,15 +21707,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
+msgstr "Este ficheiro é demasiado grande. O tamanho máximo do ficheiro é %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21998,8 +21952,7 @@ msgstr "Esta tradução está errada"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
+msgstr "Ainda não é possível visualizar este vídeo aqui. Podes visualizá-lo em %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22033,8 +21986,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
+msgstr "Isto irá eliminar a imagem selecionada. Esta ação não pode ser anulada."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22161,8 +22113,7 @@ msgstr "Para continuar, tens de concordar com a %1$s e os %2$sdo Duck.ai"
 msgctxt ""
 "Copy stating agreement to AI Chat Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to DuckDuckGo AI Chat’s %s and %s"
-msgstr ""
-"Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
+msgstr "Para continuar, tens de concordar com a %1$s e os %2$s do DuckDuckGo AI Chat"
 
 # smartling.placeholder_format=C
 #. Instructions for how to print driving directions.
@@ -22233,8 +22184,8 @@ msgstr "Muda para o chat com IA privado ou %1$sdesativa-o nas definições%2$s."
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu %2$s."
-"%3$s"
+"Muda para experimentares o chat privado de IA ou %1$sdesativa-o no menu "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22300,7 +22251,7 @@ msgstr "Demasiado lento"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Demasiado lento a gerar"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22588,8 +22539,7 @@ msgstr "Experimenta %1$s para deixar de ver mensagens como esta."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
+msgstr "Experimenta %1$s, o nosso primeiro modelo sem visibilidade para o fornecedor."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22730,8 +22680,7 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Tenta permitir a localização anónima para obter resultados mais específicos."
+msgstr "Tenta permitir a localização anónima para obter resultados mais específicos."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22750,7 +22699,7 @@ msgstr "Experimenta com menos palavras-chave."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Experimentar gratuitamente"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22918,8 +22867,7 @@ msgstr "Experimenta o novo chat privado de voz em tempo real!"
 #. Text for a promotional card that encourages users to try the recently added open-source AI models. The placeholders are the names of AI models like 'Try the recently added open-source Llama 3.1 and Mistral.'
 msgctxt "Promotional text for new AI models"
 msgid "Try the recently added open-source %s and %s"
-msgstr ""
-"Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
+msgstr "Experimenta o %1$s e o %2$s, de código aberto, adicionados recentemente"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that encourages users to try the recently added open-source AI models Llama 3.1 and Mixtral.
@@ -23330,14 +23278,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
+msgstr "Em %1$s\"Abrir com\"%2$s, seleciona %3$sUma página específica ou várias%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
+msgstr "Em %1$sNo arranque > Página inicial%2$s, introduz: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23502,8 +23448,7 @@ msgstr "Desbloqueia modelos avançados"
 #. Upsell message shown in the voice chat duration limit modal for free users.
 msgctxt "voice chat duration limit modal"
 msgid "Unlock longer voice chats with a DuckDuckGo Subscription"
-msgstr ""
-"Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
+msgstr "Desbloqueia conversas de voz mais longas com uma subscrição da DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text informing the user that more capable AI models can be unlocked with a subscription, with a trailing call-to-action link. %s is replaced with either the 'Try for free' link (for unauthenticated users) or the 'Learn more' link (for authenticated users). The link opens the subscription modal. Example: Unlock more capable AI models with a DuckDuckGo subscription. Try for free
@@ -24121,8 +24066,7 @@ msgctxt "mobile promotion on desktop"
 msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
-msgstr ""
-"Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
+msgstr "Vai a %1$sDuckDuckGo.com%2$s no tablet ou smartphone e segue as instruções."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -24318,8 +24262,7 @@ msgstr "Wallpaper"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Queres acesso fácil ao chat privado com IA na página do novo separador?"
+msgstr "Queres acesso fácil ao chat privado com IA na página do novo separador?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24841,8 +24784,7 @@ msgstr "Limite de utilização semanal atingido"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
+msgstr "Limite de utilização semanal atingido. Podes continuar este chat após %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24987,15 +24929,13 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Quais são alguns fatores a considerar ao comprar um monitor de computador?"
+msgstr "Quais são alguns fatores a considerar ao comprar um monitor de computador?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
+msgstr "Quais são algumas das atrações imperdíveis em Paris para a primeira visita?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -25120,8 +25060,7 @@ msgstr "Quais são os pratos que tens de experimentar aqui?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Quais são os horários de funcionamento, localização e contactos deste local?"
+msgstr "Quais são os horários de funcionamento, localização e contactos deste local?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25271,8 +25210,7 @@ msgctxt "cloudsave"
 msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
-msgstr ""
-"O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
+msgstr "O que é o marcador Cloud Save e como é que difere do de parâmetros de URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25347,8 +25285,7 @@ msgstr "Sobre o que gostarias de dar feedback?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
+msgstr "O que vês no DuckDuckGo não influencia as tuas recomendações no YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25955,8 +25892,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
+msgstr "Podes alterar isto em qualquer altura nas %1$sDefinições de pesquisa%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -26001,8 +25937,7 @@ msgstr "Podes continuar a conversar usando o teu limite mensal."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
+msgstr "Agora podes guardar até 100 chats neste dispositivo. Conversa à vontade!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26294,8 +26229,7 @@ msgstr "Atingiste o limite de chat de voz para hoje. Tente novamente amanhã."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
+msgstr "Atingiste o limite de utilização de ditado. tentar novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26551,8 +26485,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
+msgstr "Os teus chats foram importados. Continua a partir de onde ficaste no Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26780,15 +26713,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
+msgstr "Atingiste o número máximo de mensagens para um dia. Continua o chat amanhã."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
+msgstr "Atingiste o limite do chat de voz por agora. Tenta novamente mais tarde."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26871,8 +26802,7 @@ msgstr "por %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
+msgstr "DuckDuckGo — proteção online em que milhões de pessoas confiam todos os dias."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/pt_PT/LC_MESSAGES/duckduckgo.po
+++ b/locales/pt_PT/LC_MESSAGES/duckduckgo.po
@@ -27157,7 +27157,7 @@ msgstr "bloqueador de rastreio"
 #. Inform the users that "something" went wrong and discourage the user from immediately reloading the page.
 msgctxt "noresults"
 msgid "try again later"
-msgstr "tentar novamente mais tarde"
+msgstr "tenta novamente mais tarde"
 
 # smartling.placeholder_format=C
 #. A link that will allow users to reload the page, show when no search results loaded due to an error

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -532,7 +533,8 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr ""
+"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -2155,8 +2157,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2165,8 +2167,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
-"open-source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
+"source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2335,7 +2337,8 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr ""
+"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2677,7 +2680,8 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr ""
+"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2718,7 +2722,8 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr ""
+"Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2977,6 +2982,18 @@ msgstr ""
 "adresele de e-mail și metadatele de identificare."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3095,7 +3112,8 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr ""
+"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3191,7 +3209,8 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr ""
+"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -4299,7 +4318,8 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr ""
+"Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4701,7 +4721,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr ""
+"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4728,7 +4749,8 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr ""
+"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4784,7 +4806,8 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr ""
+"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4859,7 +4882,8 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr ""
+"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4911,7 +4935,8 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr ""
+"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5614,7 +5639,8 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr ""
+"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6498,7 +6524,8 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr ""
+"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6546,6 +6573,12 @@ msgstr "Nu-mi place designul"
 msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr "Nu-mi place sursa"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6656,6 +6689,12 @@ msgstr "Rezultate divizie"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Djibouti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7006,8 +7045,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului "
-"Duck.ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -7031,7 +7070,8 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr ""
+"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7403,7 +7443,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr ""
+"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7797,7 +7838,8 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr ""
+"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8116,7 +8158,8 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr ""
+"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8336,7 +8379,8 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr ""
+"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8530,6 +8574,12 @@ msgstr "Final"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Rapid"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8863,6 +8913,12 @@ msgid "Follow-ups remain private."
 msgstr "Mesajele ulterioare rămân private."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8966,7 +9022,8 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr ""
+"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8996,7 +9053,8 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr ""
+"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9077,9 +9135,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează "
-"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
-"selectează <strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
+"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
+"<strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9603,8 +9661,8 @@ msgstr "Descarcă aplicația"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
-"YouTube.%2$s"
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9716,7 +9774,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr ""
+"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9804,6 +9863,12 @@ msgstr "Design bun"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Politică de confidențialitate bună"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -9993,7 +10058,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr ""
+"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10642,7 +10708,8 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr ""
+"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10884,7 +10951,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr ""
+"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10942,6 +11010,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Prompturile pentru imagini trebuie să respecte %1$s Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11413,7 +11487,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr ""
+"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -12214,7 +12289,8 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr ""
+"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12998,7 +13074,8 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr ""
+"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13406,7 +13483,8 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr ""
+"National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -14548,7 +14626,8 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr ""
+"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15488,7 +15567,8 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
+msgstr ""
+"Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15806,6 +15886,12 @@ msgstr "Poloneză"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Formatare inadecvată"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16982,7 +17068,8 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr ""
+"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17375,7 +17462,8 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr ""
+"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17731,14 +17819,16 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr ""
+"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr ""
+"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18287,7 +18377,8 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr ""
+"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18445,7 +18536,8 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr ""
+"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18463,7 +18555,8 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr ""
+"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18490,7 +18583,8 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr ""
+"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18503,30 +18597,35 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18538,7 +18637,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr ""
+"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18549,7 +18649,8 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr ""
+"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18645,7 +18746,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr ""
+"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18717,7 +18819,8 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr ""
+"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19279,7 +19382,8 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr ""
+"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19539,7 +19643,8 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr ""
+"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19693,7 +19798,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr ""
+"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19852,7 +19958,8 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr ""
+"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19907,7 +20014,8 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr ""
+"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -19956,7 +20064,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr ""
+"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20225,13 +20334,15 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr ""
+"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20274,7 +20385,8 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr ""
+"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20448,7 +20560,8 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr ""
+"Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20828,7 +20941,8 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr ""
+"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21079,8 +21193,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
-"Duck.ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21345,7 +21459,8 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr ""
+"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21533,7 +21648,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr ""
+"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21628,13 +21744,15 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr ""
+"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21792,7 +21910,8 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr ""
+"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21907,7 +22026,8 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr ""
+"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22043,8 +22163,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
-"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
+"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -22170,6 +22290,12 @@ msgid "Too slow"
 msgstr "Prea încet"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22272,7 +22398,8 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr ""
+"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22616,6 +22743,12 @@ msgid "Try fewer keywords."
 msgstr "Încearcă mai puține cuvinte cheie."
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22659,7 +22792,8 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr ""
+"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22698,7 +22832,8 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr ""
+"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22969,7 +23104,8 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr ""
+"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23186,12 +23322,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr ""
+"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr ""
+"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23201,7 +23339,8 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr ""
+"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23215,13 +23354,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr ""
+"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr ""
+"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23695,9 +23836,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
-"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
-"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
+"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
+"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -24277,7 +24418,8 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr ""
+"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24424,7 +24566,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr ""
+"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24438,7 +24581,8 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr ""
+"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24519,7 +24663,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr ""
+"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24825,8 +24970,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
-"Duck.ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
+"ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24895,10 +25040,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
-"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
-"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
-"în domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
+"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
+"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
+"domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24964,7 +25109,8 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr ""
+"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25136,8 +25282,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
-"bookmarklet-ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
+"ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25246,7 +25392,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr ""
+"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25264,7 +25411,8 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr ""
+"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25480,8 +25628,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de "
-"e-mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
+"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de e-"
+"mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -26137,7 +26285,8 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr ""
+"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26164,8 +26313,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
-"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
+"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -26224,7 +26373,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
+msgstr ""
+"Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26409,7 +26559,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr ""
+"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26456,7 +26607,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr ""
+"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26638,13 +26790,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr ""
+"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr ""
+"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ro_RO/LC_MESSAGES/duckduckgo.po
+++ b/locales/ro_RO/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
-"20)) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -533,8 +532,7 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
+msgstr "%1$sApasă lung%2$s pe pictograma aplicației DuckDuckGo din pagina de pornire"
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
@@ -2157,8 +2155,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2167,8 +2165,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s open-"
-"source."
+"Acces anonim la modele AI populare, inclusiv %1$s, %2$s și %3$s și %4$s "
+"open-source."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2337,8 +2335,7 @@ msgstr "Ești încă acolo?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
+msgstr "Sigur dorești să ștergi toate chaturile tale? Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2680,8 +2677,7 @@ msgstr "Sunetul nu este stocat de noi sau de OpenAI după încheierea chatului."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
+msgstr "Sunetul nu este stocat de noi sau de OpenAI după ce chatul este transcris."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2722,8 +2718,7 @@ msgstr "Răspuns automat"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Generat automat pe baza surselor menționate. Poate conține inexactități."
+msgstr "Generat automat pe baza surselor menționate. Poate conține inexactități."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2992,6 +2987,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Înainte de a stoca acest raport, DuckDuckGo va elimina fișierele încărcate "
+"și imaginile generate și îți va anonimiza conversația prin eliminarea "
+"informațiilor de identificare personală, cum ar fi numele, adresele de "
+"e-mail și metadatele de identificare."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3112,8 +3111,7 @@ msgstr "Blochează ferestrele pop-up enervante privind modulele cookie"
 #. DuckDuckGo Email Protection offers the ability to generate random email addresses to protect your personal email address
 msgctxt "SERP footer content"
 msgid "Block email trackers and hide your address."
-msgstr ""
-"Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
+msgstr "Blochează modulele cookie de urmărire pentru e-mail și ascunde-ți adresa."
 
 # smartling.placeholder_format=C
 #. Body text of the VPN instant answer shown on the search results page. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -3209,8 +3207,7 @@ msgstr "Blocat:"
 #. shown after the DuckDuckGo extension is installed
 msgctxt "welcome message"
 msgid "Blocks trackers on websites you visit"
-msgstr ""
-"Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
+msgstr "Blochează instrumentele de urmărire pe site-urile web pe care le vizitezi"
 
 # smartling.placeholder_format=C
 msgid "Blog"
@@ -4318,8 +4315,7 @@ msgstr ""
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Verifică pagina de stare pentru actualizări despre această întrerupere."
+msgstr "Verifică pagina de stare pentru actualizări despre această întrerupere."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4721,8 +4717,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click %sPrivacy and Services%s in the left sidebar."
-msgstr ""
-"Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
+msgstr "Fă click pe %1$sConfidențialitate și Servicii%2$s în bara laterală stângă."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -4749,8 +4744,7 @@ msgstr "Fă click pe %1$sSetări%2$s în meniul vertical."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
+msgstr "Fă click pe %1$sUtilizează paginile curente%2$s apoi %3$sfă click pe OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4806,8 +4800,7 @@ msgstr "Fă click pe %1$sFurnizori căutare%2$s sub Tipuri Add-on-uri"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sTools icon%s in the top-right of the browser"
-msgstr ""
-"Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
+msgstr "Fă click pe %1$spictograma Instrumente%2$s din dreapta sus a browserului"
 
 #  Firefox default search engine instruction
 # smartling.placeholder_format=C
@@ -4882,8 +4875,7 @@ msgstr "Apasă pe pictograma %1$spermisiuni%2$s din bara de adrese"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
+msgstr "Fă click pe pictograma Duck din partea de sus a browserului pentru a căuta!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4935,8 +4927,7 @@ msgstr "Fă click pe lupa din bara de căutare"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
+msgstr "Fă click pe lupa din căsuța de căutare (în partea de sus a browserului)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5639,8 +5630,7 @@ msgstr "Costa Rica"
 #. Inline error shown on the recovery code screen when exportSyncSettings rejects.
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
-msgstr ""
-"Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
+msgstr "Codul tău de recuperare nu s-a putut încărca. Închide și încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -6524,8 +6514,7 @@ msgstr "Dezactivare și deconectare"
 #. Title of a modal that asks the user if they want to turn off chat history and disconnect from Sync & Backup.
 msgctxt "Modal header for disabling chat history and disconnecting sync"
 msgid "Disable chat history and disconnect from Sync & Backup?"
-msgstr ""
-"Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
+msgstr "Dezactivezi istoricul chaturilor și te deconectezi de la Sync & Backup?"
 
 # smartling.placeholder_format=C
 #. Title of a modal that asks the user if they want to turn off the chat history feature.
@@ -6578,7 +6567,7 @@ msgstr "Nu-mi place sursa"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nu-mi place stilul vizual"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6694,7 +6683,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nu respectă instrucțiunile"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7045,8 +7034,8 @@ msgstr "Duck.ai"
 msgctxt "Text on link to the Duck.ai Privacy Policy & Terms of Service page."
 msgid "Duck.ai Privacy Policy and Terms of Service"
 msgstr ""
-"Politica de confidențialitate și Condițiile de utilizare a serviciului Duck."
-"ai"
+"Politica de confidențialitate și Condițiile de utilizare a serviciului "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Title of the modal that contains settings for Duck.ai.
@@ -7070,8 +7059,7 @@ msgstr "Condiții de utilizare Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
+msgstr "Duck.ai de la DuckDuckGo. Chat privat cu inteligență artificială. Gratuit."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7443,8 +7431,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
+msgstr "DuckDuckGo AI Chat este temporar indisponibil. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7838,8 +7825,7 @@ msgstr "Se editează imaginea..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
+msgstr "Editarea mesajului tău va elimina răspunsul de mai jos și va genera unul nou."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8158,8 +8144,7 @@ msgstr "Asigură-te că accesul la locație este %1$spermis%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
+msgstr "Asigură-te că browserul tău are permisiunea de a %1$saccesa locația%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8379,8 +8364,7 @@ msgstr "Explică răspunsul acceptat în termeni simpli."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
+msgstr "Explică-mi conceptele fundamentale ale găurilor negre la nivel de liceu."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8579,7 +8563,7 @@ msgstr "Rapid"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Generare rapidă de imagini"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8916,7 +8900,7 @@ msgstr "Mesajele ulterioare rămân private."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "A respectat instrucțiunile"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9022,8 +9006,7 @@ msgstr "Chaturi gratuite și private, anonimizate de noi"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
+msgstr "Chaturi gratuite și private, anonimizate de noi. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9053,8 +9036,7 @@ msgstr "Fără restricții de distrubuire și utilizare comercială"
 #. Description text explaining how to free up sync storage. Pinned chats are chats the user has explicitly marked to keep.
 msgctxt "Sync limit modal description"
 msgid "Free up space by deleting your chats. Pinned chats will not be deleted."
-msgstr ""
-"Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
+msgstr "Eliberează spațiu ștergând chaturile. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
 #. Indicates that this streaming service is free to watch but shows ads
@@ -9135,9 +9117,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"Din bara de meniu a aplicației pe Mac, selectează <strong>DuckDuckGo</"
-"strong> &gt; <strong>Caută actualizări...</strong>, apoi selectează "
-"<strong>Instalează actualizările</strong>."
+"Din bara de meniu a aplicației pe Mac, selectează "
+"<strong>DuckDuckGo</strong> &gt; <strong>Caută actualizări...</strong>, apoi "
+"selectează <strong>Instalează actualizările</strong>."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9661,8 +9643,8 @@ msgstr "Descarcă aplicația"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe YouTube."
-"%2$s"
+"Obține browserul gratuit DuckDuckGo %1$spentru a bloca reclamele pe "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9774,8 +9756,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
+msgstr "Accesează %1$sConfidențialitate și securitate > Servicii de localizare%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9868,7 +9849,7 @@ msgstr "Politică de confidențialitate bună"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Stil vizual bun"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10058,8 +10039,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
+msgstr "Ghidează-mă prin pașii de bază ai înlocuirii unui ștergător de ferestre."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10708,8 +10688,7 @@ msgstr "Cât de mult vrei să apară răspunsurile asistate de AI?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
+msgstr "Ce proporție din limitele tale zilnice și săptămânale ai utilizat până acum."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10951,8 +10930,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
+msgstr "Dacă încă dorești să ne susții, %1$sajută-ne să promovăm DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -11015,7 +10993,7 @@ msgstr "Prompturile pentru imagini trebuie să respecte %1$s Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Calitatea imaginii"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11487,8 +11465,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
+msgstr "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -12289,8 +12266,7 @@ msgstr "Încarcă mai multe imagini rezultate când derulezi"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
+msgstr "Încarcă mai multe rezultate în imagini, clipuri și cumpărături la derulare"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13074,8 +13050,7 @@ msgstr "Limita lunară a fost atinsă"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
+msgstr "Limita lunară de utilizare a fost atinsă. Poți continua acest chat după %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13483,8 +13458,7 @@ msgstr "Namibia"
 #. Title of the divisional championship series for the National League division of Major League Baseball
 msgctxt "Sports module"
 msgid "National League Championship Series"
-msgstr ""
-"National League Championship Series (Seria Campionatului Ligii Naționale)"
+msgstr "National League Championship Series (Seria Campionatului Ligii Naționale)"
 
 # smartling.placeholder_format=C
 #. Title of the divisional semi-final series for the National League division of Major League Baseball
@@ -14626,8 +14600,7 @@ msgstr "Deschide website-ul %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
+msgstr "Deschide %1$sLocație%2$s și asigură-te că locația este %3$sactivată%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15567,8 +15540,7 @@ msgstr "Fixat"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
+msgstr "Chaturile fixate vor apărea în partea de sus a chaturilor tale recente."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15891,7 +15863,7 @@ msgstr "Formatare inadecvată"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Calitate scăzută a imaginii"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17068,8 +17040,7 @@ msgstr "Reține alegerea mea"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
+msgstr "Ține minte alegerea mea (poate fi modificată în %1$s%2$s%3$sSetări%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17462,8 +17433,7 @@ msgstr "Rezultatele exclud informațiile de pe site-urile blocate."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
+msgstr "Rezultatele exclud site-urile blocate, pe care le poți gestiona în %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17819,16 +17789,14 @@ msgstr ""
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
 msgctxt "Short description for Chat History feature on native DDG browsers"
 msgid "Save up to 30 of your most recent chats locally on your device."
-msgstr ""
-"Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
+msgstr "Salvează local pe dispozitiv până la 30 dintre cele mai recente chaturi."
 
 # smartling.placeholder_format=C
 #. Desktop/mobile intro modal body under the title per Sync Chats Figma (choose step).
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
+msgstr "Salvează-ți chaturile Duck.ai între dispozitive cu criptare end-to-end."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -18377,8 +18345,7 @@ msgstr "A doua opinie"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
+msgstr "Salvează și sincronizează-ți în siguranță chaturile pe toate dispozitivele."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18536,8 +18503,7 @@ msgstr "Vezi mai multe pe %1$s"
 # smartling.placeholder_format=C
 #. Title of a notice that DuckDuckGo has noticed the user is blocking its non-tracking ads
 msgid "See more shopping results from popular retailers"
-msgstr ""
-"Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
+msgstr "Vezi mai multe rezultate privind cumpărăturile, de la comercianți populari"
 
 # smartling.placeholder_format=C
 #. Text for tooltip shown on hover when displaying the number of reviews the product has on an ad, indicating that users can see more ratings on bing.com
@@ -18555,8 +18521,7 @@ msgstr "Vezi câteva dintre cele mai recente actualizări ale noastre"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
+msgstr "Vezi %1$spagina de referință a parametrilor URL%2$s pentru mai multe detalii."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18583,8 +18548,7 @@ msgstr "Selectează %1$s%2$s%3$s, apoi %4$sMotor de căutare%5$s"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %s'Setting for this Website...'%s from the Safari menu."
-msgstr ""
-"Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
+msgstr "Selectează %1$s„Setare pentru acest site web...”%2$s din meniul Safari."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -18597,35 +18561,30 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sAdaugă ca implicit%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
+msgstr "Selectează %1$sDuckDuckGo%2$s și fă click pe %3$sSetează ca implicit%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
+msgstr "Selectează %1$sDuckDuckGo%2$s în meniul vertical Motor de căutare implicit"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sDuckDuckGo%2$s din listă și %3$spermite%4$s accesul la locație"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18637,8 +18596,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s din lista de furnizori de căutare"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
+msgstr "Selectează %1$sDuckDuckGo%2$s sub%3$ssecțiunea Motor de căutare implicit%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18649,8 +18607,7 @@ msgstr "Selectează %1$sDuckDuckGo%2$s!"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Select %sEdit Search Engines...%sin the dropdown"
-msgstr ""
-"Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
+msgstr "Selectează %1$sEditează motoarele de căutare...%2$s din meniul vertical"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18746,8 +18703,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
+msgstr "Selectează %1$sbrowserul%2$s din listă și %3$spermite%4$s accesul la locație"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -18819,8 +18775,7 @@ msgstr "Text selectat din %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
+msgstr "Textul selectat este prea lung. Încearcă din nou cu o selecție mai scurtă."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19382,8 +19337,7 @@ msgstr "Afișează DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
+msgstr "Arată DuckAssist mai des. (De asemenea, îl poți %1$sdezactiva%2$s complet.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19643,8 +19597,7 @@ msgstr "Afișează linii orizontale la sfârșitul paginilor de rezultate"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
+msgstr "Afișează linkuri spre instrucțiuni pentru a adăuga DuckDuckGo în browser"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19798,8 +19751,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
+msgstr "Site-urile pe care le blochezi vor fi ascunse din toate rezultatele căutării."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19958,8 +19910,7 @@ msgstr "Ceva nu a funcționat, te rugăm să încerci din nou."
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
+msgstr "A apărut o eroare la activarea funcției Sync & Backup. Încearcă din nou."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20014,8 +19965,7 @@ msgstr "Ne pare rău, a survenit o eroare neașteptată."
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid "Sorry, no relevant information was found in our search."
-msgstr ""
-"Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
+msgstr "Ne pare rău, nu au fost găsite informații relevante în căutarea noastră."
 
 # smartling.placeholder_format=C
 #. Indicates that there were no search results for a user's search.
@@ -20064,8 +20014,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
+msgstr "Ne pare rău, nu am putut trimite feedbackul tău. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20334,15 +20283,13 @@ msgstr ""
 #. Prompt to subscribe to a newsletter.
 msgctxt "SERP footer content"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Text on the page where users can subscribe to DuckDuckGo's privacy newsletter
 msgctxt "showcase_newsletter"
 msgid "Stay protected and informed with our privacy newsletters."
-msgstr ""
-"Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
+msgstr "Rămâi protejat și informat cu newsletterele noastre despre confidențialitate."
 
 # smartling.placeholder_format=C
 #. Loading message shown when image generation is taking longer than usual.
@@ -20385,8 +20332,7 @@ msgstr "Oprește instrumentele de urmărire ascunse de pe alte site-uri."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
+msgstr "Oprește majoritatea instrumentelor de urmărire ascunse de pe alte site-uri."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20560,8 +20506,7 @@ msgstr "Sugerează un titlu pentru o postare pe blog"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Sugerează articole sau subiecte similare care merită explorate în continuare."
+msgstr "Sugerează articole sau subiecte similare care merită explorate în continuare."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -20941,8 +20886,7 @@ msgstr "Sync & Backup activat!"
 #. Notice shown under the recovery code explaining that backup data has an inactivity expiration.
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
-msgstr ""
-"Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
+msgstr "Datele Sync & Backup nu pot fi recuperate după 18 luni de inactivitate."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -21193,8 +21137,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți Duck."
-"ai."
+"Completează acest sondaj anonim pentru a ne spune cum putem îmbunătăți "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21459,8 +21403,7 @@ msgstr "Fișierele atașate depășesc limita totală de %1$s MB."
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the server rejects corrupt or unrecognized audio.
 msgid "The audio could not be processed. Please try recording again."
-msgstr ""
-"Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
+msgstr "Materialul audio nu a putut fi prelucrat. Încearcă să înregistrezi din nou."
 
 # smartling.placeholder_format=C
 #. Second paragraph explaining where the encryption key is stored on the entry screen.
@@ -21648,8 +21591,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
+msgstr "Acest răspuns instant a fost creat de Comunitatea %1$sDuckDuckHack%2$s."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21744,15 +21686,13 @@ msgstr ""
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB"
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
 msgctxt "Error message when a single file exceeds the size limit"
 msgid "This file is too large. The maximum file size is %s MB."
-msgstr ""
-"Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
+msgstr "Fișierul acesta e prea mare. Dimensiunea maximă a fișierului este de %1$s MB."
 
 # smartling.placeholder_format=C
 #. Generic error message displayed when the user tries to upload an unsupported file type and we cannot determine the accepted types
@@ -21910,8 +21850,7 @@ msgstr "Această pagină necesită JavaScript pentru a funcționa."
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
+msgstr "Conținutul acestei pagini va fi trimis împreună cu mesajul tău către Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -22026,8 +21965,7 @@ msgstr ""
 #. Message explaining what will happen when the user deletes an image.
 msgctxt "Confirmation message in delete image modal"
 msgid "This will delete your selected image. This cannot be undone."
-msgstr ""
-"Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
+msgstr "Aceasta va șterge imaginea selectată de tine. Acest lucru nu poate fi anulat."
 
 # smartling.placeholder_format=C
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
@@ -22163,8 +22101,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Pentru a tipări indicații de orientare:%1$sîntoarce-te la hartă."
-"%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
+"Pentru a tipări indicații de orientare:%1$sîntoarce-te la "
+"hartă.%2$sSelectează ruta pe care dorești să o tipărești.%3$sFă click pe "
 "pictograma de tipărire.%4$s"
 
 # smartling.placeholder_format=C
@@ -22293,7 +22231,7 @@ msgstr "Prea încet"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Prea încet pentru a se genera"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22398,8 +22336,7 @@ msgstr "Instrumente de urmărire blocate în ultima oră"
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Trackers that DuckDuckGo blocks will appear here"
-msgstr ""
-"Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
+msgstr "Instrumentele de urmărire pe care DuckDuckGo le blochează vor apărea aici"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22746,7 +22683,7 @@ msgstr "Încearcă mai puține cuvinte cheie."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Încearcă gratuit"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22792,8 +22729,7 @@ msgstr "Încearcă gratis"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
 msgctxt "SERP footer content"
 msgid "Try for free! A secure VPN, advanced & private AI, and more."
-msgstr ""
-"Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
+msgstr "Încearcă gratuit! Un VPN securizat, AI avansată și privată și multe altele."
 
 # smartling.placeholder_format=C
 #. Secondary text under the subscription row, pointing at the 7-day free trial.
@@ -22832,8 +22768,7 @@ msgstr "Încearcă browserul nostru"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
+msgstr "Încearcă pagina noastră de pornire care nu afișează niciodată aceste mesaje:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -23104,8 +23039,7 @@ msgstr "Activează %1$sLocație precisă%2$s pentru rezultate mai precise"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
+msgstr "Activează Duck Player pentru a viziona pe YouTube fără reclame direcționate"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23322,14 +23256,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
+msgstr "Sub %1$sDeschide cu%2$s selectează %3$sUna sau mai multe pagini specifice%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
+msgstr "Sub %1$sPORNIRE > Pagina de pornire%2$s introdu: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23339,8 +23271,7 @@ msgstr "Sub %1$sSetări de căutare%2$s selectează %3$sDuckDuckGo%4$s"
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
+msgstr "Sub %1$sCaută în bara de adrese cu%2$s selectează %3$sAdăugare nouă%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23354,15 +23285,13 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
+msgstr "Sub Pornire, selectează %1$sDeschide una sau mai multe pagini specifice%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
+msgstr "Sub Căutare, fă click pe meniul vertical și selectează %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23836,9 +23765,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. Protejează-"
-"ți chaturile împotriva hackerilor, a escrocilor și a companiilor. Păstrează "
-"informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
+"Folosește ChatGPT, Claude și alte platforme de IA, în mod privat. "
+"Protejează-ți chaturile împotriva hackerilor, a escrocilor și a companiilor. "
+"Păstrează informațiile confidențiale. Gratuit. Nu este nevoie de un cont."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -24418,8 +24347,7 @@ msgstr "Anonimizăm"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
+msgstr "Putem anonimiza%1$s locația ta%2$s pentru a-ți afișa rezultate mai precise."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24566,8 +24494,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
+msgstr "Noi nu te monitorizăm în interiorul sau în afara modului de navigare privată."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24581,8 +24508,7 @@ msgstr ""
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
 msgctxt "voice chat error"
 msgid "We ended the chat due to inactivity. Want to try again?"
-msgstr ""
-"Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
+msgstr "Am încheiat chatul din cauza inactivității. Dorești să încerci din nou?"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the subscription also includes a VPN and other premium protections.
@@ -24663,8 +24589,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We stop anyone from getting your search history, including us."
-msgstr ""
-"Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
+msgstr "Împiedicăm pe oricine, inclusiv pe noi, să obțină istoricul căutărilor tale."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -24970,8 +24895,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea Duck."
-"ai. Încearcă să reîncarci pagina."
+"Ne pare foarte rău, dar se pare că a apărut o problemă la încărcarea "
+"Duck.ai. Încearcă să reîncarci pagina."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -25040,10 +24965,10 @@ msgid ""
 msgstr ""
 "Care sunt beneficiile descărcării browserului DuckDuckGo pentru tine, dacă "
 "vrei să folosești Duck.ai? Citește doar surse oficiale DuckDuckGo. Împarte "
-"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările Duck."
-"ai și pe protecția confidențialității. Păstrează-l destul de scurt, simplu "
-"și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau în "
-"domeniul tehnic."
+"răspunsul în secțiuni clare cu titluri, concentrându-te pe integrările "
+"Duck.ai și pe protecția confidențialității. Păstrează-l destul de scurt, "
+"simplu și ușor de înțeles pentru cei care au (sau nu) experiență în IA sau "
+"în domeniul tehnic."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25109,8 +25034,7 @@ msgstr "Care sunt principalele lucruri pe care le voi învăța din acest curs?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
+msgstr "Care sunt principalele contraargumente sau critici la adresa acestui lucru?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25282,8 +25206,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de bookmarklet-"
-"ul cu parametri URL?"
+"Ce este bookmarklet-ul Cloud Save și cum se diferențiază el de "
+"bookmarklet-ul cu parametri URL?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25392,8 +25316,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
+msgstr "Când este activat, Duck.ai va afișa răspunsuri instantanee în conversație."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25411,8 +25334,7 @@ msgstr "Unde să urmărești <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
+msgstr "Fă click pe %1$sSetează ca pagină curentă%2$s unde scrie Pagină de pornire."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25628,8 +25550,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de e-"
-"mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
+"Funcționează direct de pe dispozitivul tău pentru a-ți elimina adresa de "
+"e-mail, numele, adresa și multe altele de pe site-urile brokerilor de date."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -26285,8 +26207,7 @@ msgctxt "Error message for user limit"
 msgid ""
 "You've reached the maximum number of messages for the moment. Please try "
 "again later."
-msgstr ""
-"Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
+msgstr "Pentru moment, ai atins numărul maxim de mesaje. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26313,8 +26234,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile Duck."
-"ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
+"Ai rămas fără spațiu de stocare pentru Sync & Backup pentru chaturile "
+"Duck.ai cu atașări. Șterge cele mai vechi %1$s chaturi pentru a relua "
 "sincronizarea. Chaturile fixate nu vor fi șterse."
 
 # smartling.placeholder_format=C
@@ -26373,8 +26294,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
+msgstr "Chaturile tale Duck.ai sunt sincronizate cu criptare de la un capăt la altul."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26559,8 +26479,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
+msgstr "Chaturile tale au fost importate. Continuă de unde ai rămas în Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26607,8 +26526,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
+msgstr "Feedbackul tău este anonimizat și nu este folosit pentru antrenarea IA."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26790,15 +26708,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
+msgstr "Ai atins numărul maxim de mesaje pentru o zi. Continuă acest chat mâine."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
+msgstr "Ai atins limita de chat vocal pentru moment. Încearcă din nou mai târziu."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -255,7 +256,8 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr ""
+"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -512,13 +514,15 @@ msgstr "%1$sПодробнее%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr ""
+"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr ""
+"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -1009,8 +1013,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке "
-"%1$sduckduckgo.com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
+"com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1126,7 +1130,8 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr ""
+"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1990,8 +1995,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
-"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
+"прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2538,9 +2543,10 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
-"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
-"базе ИИ предоставляются только на территории США (на английском языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
+"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
+"ответы на базе ИИ предоставляются только на территории США (на английском "
+"языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2963,6 +2969,18 @@ msgstr ""
 "идентифицирующие метаданные."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3096,7 +3114,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr ""
+"Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -4008,11 +4027,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
-"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
-"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
-"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
-"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
+"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
+"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
+"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
+"его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4273,7 +4292,8 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr ""
+"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4711,7 +4731,8 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr ""
+"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5486,7 +5507,8 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr ""
+"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5539,8 +5561,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки "
-"Duck.ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
+"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки Duck."
+"ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
 "повторите попытку."
 
 # smartling.placeholder_format=C
@@ -5662,7 +5684,8 @@ msgstr "Создать ссылку для доступа"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr ""
+"Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -6382,7 +6405,8 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr ""
+"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6531,6 +6555,12 @@ msgid "Dislike source"
 msgstr "Не нравится источник"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Отклонить"
@@ -6639,6 +6669,12 @@ msgstr "Статистика по дивизиону"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Джибути"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6885,7 +6921,8 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr ""
+"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6907,7 +6944,8 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr ""
+"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -7128,8 +7166,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
-"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
+"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -7213,8 +7251,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
-"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
+"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7390,7 +7428,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr ""
+"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7704,8 +7743,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
-"18–20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
+"20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -8519,6 +8558,12 @@ msgid "Fast"
 msgstr "Быстрый"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8847,6 +8892,12 @@ msgstr "Последующий вопрос"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Последующая переписка остается конфиденциальной."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9796,6 +9847,12 @@ msgid "Good privacy policy"
 msgstr "Хорошая политика конфиденциальности"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
 msgctxt "shortbelieve"
 msgid "Goodies"
@@ -10253,7 +10310,8 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr ""
+"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10938,6 +10996,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "При вводе запросов на создание изображений соблюдайте %1$s Duck.ai."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Тайловая"
@@ -10978,7 +11042,8 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11868,7 +11933,8 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr ""
+"Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11928,7 +11994,8 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr ""
+"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -14358,7 +14425,8 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr ""
+"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14555,7 +14623,8 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr ""
+"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14732,7 +14801,8 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr ""
+"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15815,6 +15885,12 @@ msgid "Poor formatting"
 msgstr "Плохое форматирование"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
@@ -16257,7 +16333,8 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr ""
+"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16604,19 +16681,22 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
+msgstr ""
+"Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
+msgstr ""
+"Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
+msgstr ""
+"Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -18339,7 +18419,8 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr ""
+"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18523,7 +18604,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18543,7 +18625,8 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18628,7 +18711,8 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr ""
+"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18724,7 +18808,8 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr ""
+"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18975,7 +19060,8 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr ""
+"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19600,7 +19686,8 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr ""
+"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19694,7 +19781,8 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr ""
+"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19847,7 +19935,8 @@ msgstr "Произошла ошибка при загрузке этого об�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr ""
+"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -19949,7 +20038,8 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr ""
+"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -21043,8 +21133,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
-"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
+"помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21053,8 +21143,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
-"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
+"помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21375,7 +21465,8 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr ""
+"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21510,7 +21601,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr ""
+"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21696,7 +21788,8 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr ""
+"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21783,7 +21876,8 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr ""
+"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21871,7 +21965,8 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr ""
+"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22018,7 +22113,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr ""
+"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22091,7 +22187,8 @@ msgstr "Сегодня"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Переключитесь на приватный чат с ИИ или %1$sотключите его в настройках%2$s."
+msgstr ""
+"Переключитесь на приватный чат с ИИ или %1$sотключите его в настройках%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22160,6 +22257,12 @@ msgstr "Слишком много результатов из этого ист�
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Слишком медленно"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22447,11 +22550,13 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr ""
+"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr ""
+"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22588,20 +22693,28 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr ""
+"Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr ""
+"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Попробуйте использовать меньше ключевых слов."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22783,7 +22896,8 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr ""
+"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22973,7 +23087,8 @@ msgstr "Активировать переключатель Duck.ai"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr ""
+"Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -23180,14 +23295,15 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr ""
+"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
-"https://duckduckgo.com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23197,15 +23313,16 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr ""
+"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
-"системами...%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
+"%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23219,7 +23336,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr ""
+"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23460,8 +23578,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
-"ИИ-моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
+"моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23703,7 +23821,8 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr ""
+"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23837,7 +23956,8 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr ""
+"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -24171,7 +24291,8 @@ msgstr "Обои"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Хотите иметь быстрый доступ к приватному ИИ-чату на странице новой вкладки?"
+msgstr ""
+"Хотите иметь быстрый доступ к приватному ИИ-чату на странице новой вкладки?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24383,7 +24504,8 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr ""
+"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24424,7 +24546,8 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr ""
+"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24530,7 +24653,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr ""
+"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24937,7 +25061,8 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr ""
+"Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25215,7 +25340,8 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr ""
+"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25759,7 +25885,8 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr ""
+"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25788,7 +25915,8 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr ""
+"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25833,7 +25961,8 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr ""
+"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25851,25 +25980,29 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr ""
+"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
@@ -26122,7 +26255,8 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr ""
+"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26190,7 +26324,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
+msgstr ""
+"Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26312,7 +26447,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr ""
+"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26334,8 +26470,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
-"ИИ-моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
+"моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26369,8 +26505,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
-"Duck.ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ru_RU/LC_MESSAGES/duckduckgo.po
+++ b/locales/ru_RU/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -256,8 +255,7 @@ msgstr "Лайков: %1$s"
 #. Disclaimer text shown bellow chat input on mobile, avoid long text if possible. Example: 'GPT-3 may display inaccurate or offensive information.'
 msgctxt "Disclaimer bellow chat input - mobile"
 msgid "%s may display inaccurate or offensive information."
-msgstr ""
-"ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
+msgstr "ИИ-модель %1$s может предложить неточную или оскорбительную информацию."
 
 # smartling.placeholder_format=C
 #. Label showing how many members a discussion has. To be displayed on a card about that discussion.
@@ -514,15 +512,13 @@ msgstr "%1$sПодробнее%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
+msgstr "%1$sПодробнее%2$s о конфиденциальном хранении чатов на сервере DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
+msgstr "%1$sПодробнее%2$s о том, как чаты хранятся в тайне на вашем устройстве."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -1013,8 +1009,8 @@ msgid ""
 msgstr ""
 "Функция AI Chat позволяет анонимно общаться с нашим чат-ботом на базе "
 "сторонних моделей ИИ. Если отключить эту функцию, она не будет отображаться "
-"в поиске DuckDuckGo Search, но останется доступной по ссылке %1$sduckduckgo."
-"com/aichat%2$s."
+"в поиске DuckDuckGo Search, но останется доступной по ссылке "
+"%1$sduckduckgo.com/aichat%2$s."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1130,8 +1126,7 @@ msgstr "Не добавлять в браузер"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "ATB related (not displayed on settings page)"
-msgstr ""
-"Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
+msgstr "Связано с параметром «Добавить в браузер» (отсутствует на странице настроек)"
 
 # smartling.placeholder_format=C
 #. Golf rankings column: average points
@@ -1995,8 +1990,8 @@ msgid ""
 msgstr ""
 "Позволяет %1$s выполнить поиск в Интернете, чтобы улучшить ответы на "
 "релевантные запросы. Отправляет в поисковую систему только сгенерированные "
-"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s по-"
-"прежнему имеют %3$sнулевую видимость провайдера%4$s."
+"ИИ запросы с ограниченным сроком хранения данных. Запросы и ответы %2$s "
+"по-прежнему имеют %3$sнулевую видимость провайдера%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2543,10 +2538,9 @@ msgstr ""
 "интеллекта. Вы можете самостоятельно проконтролировать, как часто будут "
 "появляться ответы Assist: «никогда» (интерфейс Assist полностью исключается "
 "из поисковых запросов), «по запросу» (ответы ИИ отображаются при нажатии "
-"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или "
-"«часто» (чаще и в отношении более широкого спектра запросов). Пока что "
-"ответы на базе ИИ предоставляются только на территории США (на английском "
-"языке)."
+"кнопки «Ассистент»), «иногда» (только при высокой релевантности) или «часто» "
+"(чаще и в отношении более широкого спектра запросов). Пока что ответы на "
+"базе ИИ предоставляются только на территории США (на английском языке)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2979,6 +2973,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Перед сохранением этого отчета DuckDuckGo удалит загруженные файлы и "
+"сгенерированные изображения, а также обезличит ваш чат, удалив персональные "
+"данные, такие как имена, адреса электронной почты и метаданные, позволяющие "
+"установить личность."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3114,8 +3112,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
 msgid "Block list is not exhaustive and may contain inaccuracies."
-msgstr ""
-"Список блокировки не является исчерпывающим и может содержать неточности."
+msgstr "Список блокировки не является исчерпывающим и может содержать неточности."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -4027,11 +4024,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними чат-"
-"моделями на базе ИИ от OpenAI, Anthropic и других компаний. При отключении "
-"этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка «Чат» и "
-"ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, посетив "
-"его страницу напрямую: %1$shttps://duck.ai%2$s."
+"Чат (на сервисе Duck.ai) позволяет анонимно общаться со сторонними "
+"чат-моделями на базе ИИ от OpenAI, Anthropic и других компаний. При "
+"отключении этой настройки из интерфейса DuckDuckGo Search исчезнут кнопка "
+"«Чат» и ссылки на чат-сервис. Вы по-прежнему можете воспользоваться чатом, "
+"посетив его страницу напрямую: %1$shttps://duck.ai%2$s."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4292,8 +4289,7 @@ msgstr "Проверьте орфографию"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
+msgstr "Последнюю информацию по этому сбою можно отследить в сабреддите DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4731,8 +4727,7 @@ msgstr "Нажмите %1$sНастройки%2$s в выпадающем мен
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
+msgstr "Выберите %1$sИспользовать текущие страницы%2$s, затем %3$sНажмите OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5507,8 +5502,7 @@ msgstr "Копировать"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
+msgstr "Скопируйте и вставьте %1$sabout:preferences#search%2$s в адресную строку"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5561,8 +5555,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки Duck."
-"ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
+"Скопируйте код с другого устройства. Перейдите в раздел %1$sНастройки "
+"Duck.ai › Чаты › Sync & Backup › Синхронизировать с другим устройством%2$s и "
 "повторите попытку."
 
 # smartling.placeholder_format=C
@@ -5684,8 +5678,7 @@ msgstr "Создать ссылку для доступа"
 #. Prompt sent to the AI when the user taps the "Generate a shopping list" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Create a shopping list with quantities from this recipe."
-msgstr ""
-"Создай список покупок с указанием количества ингредиентов из этого рецепта."
+msgstr "Создай список покупок с указанием количества ингредиентов из этого рецепта."
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed in the input field when starting a new image generation session.
@@ -6405,8 +6398,7 @@ msgstr "Диктовка в Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
+msgstr "Диктовка анонимизируется и никогда не используется для обучения моделей ИИ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6558,7 +6550,7 @@ msgstr "Не нравится источник"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Не нравится визуальный стиль"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6674,7 +6666,7 @@ msgstr "Джибути"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Не следует инструкциям"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6921,8 +6913,7 @@ msgctxt "Full sentence for drafting a social media post"
 msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
-msgstr ""
-"Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
+msgstr "Предложи несколько вариантов поста для соцсетей с приглашением на вечеринку."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6944,8 +6935,7 @@ msgstr "Подготовь пост для соцсетей"
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Drag %sThis Button%s on top of the home icon:"
-msgstr ""
-"Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
+msgstr "Переместите %1$sЭту кнопку%2$s на верхнюю часть значка домашней страницы:"
 
 # smartling.placeholder_format=C
 #. Indicates this is the number of draws for this team in e.g. soccer
@@ -7166,8 +7156,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai позволяет вести приватные беседы с популярными ИИ-моделями. При "
-"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы по-"
-"прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
+"отключении этой настройки кнопки Duck.ai и ссылки будут скрыты, но вы "
+"по-прежнему можете перейти на %1$sduck.ai%2$s и использовать инструмент "
 "напрямую."
 
 # smartling.placeholder_format=C
@@ -7251,8 +7241,8 @@ msgid ""
 "models, privacy focused AI, no account AI chat"
 msgstr ""
 "Duck.ai, DuckDuckGo AI, приватный чат-бот, бесплатный чат с ИИ, анонимный "
-"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, ИИ-"
-"модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
+"чат с ИИ, ИИ-чат без регистрации, OpenAI, Anthropic, Llama, Mistral, "
+"ИИ-модели с открытым кодом, конфиденциальный ИИ, чат с ИИ без учетной записи"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7428,8 +7418,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
+msgstr "Сервис DuckDuckGo AI Chat временно недоступен. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7743,8 +7732,8 @@ msgid ""
 msgstr ""
 "Каждый раз, когда вы просите нас порекомендовать парольную фразу, мы "
 "запрашиваем с серверов DuckDuckGo длинный список случайных слов. Затем в "
-"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум 18–"
-"20 символов."
+"браузере мы наугад выбираем из списка 4–5 составных слов длиной минимум "
+"18–20 символов."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -8561,7 +8550,7 @@ msgstr "Быстрый"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Быстрое создание изображений"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8897,7 +8886,7 @@ msgstr "Последующая переписка остается конфид�
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Инструкции соблюдены"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9850,7 +9839,7 @@ msgstr "Хорошая политика конфиденциальности"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Хороший визуальный стиль"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10310,8 +10299,7 @@ msgstr "Ответ пригодился"
 #. The title of a menu that shows other applications DuckDuckGo has made.
 msgctxt "showcase_aria_dropdown"
 msgid "Here are some things that we made that you might like."
-msgstr ""
-"Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
+msgstr "Мы сделали несколько приложений, которые могут вас заинтересовать. Вот они!"
 
 # smartling.placeholder_format=C
 #. shown after the DuckDuckGo extension is installed
@@ -10999,7 +10987,7 @@ msgstr "При вводе запросов на создание изображ�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Качество изображения"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11042,8 +11030,7 @@ msgstr "Изображения по запросу «%1$s»"
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for images has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Images for %s blocked by safe search"
-msgstr ""
-"Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Изображения по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the image results for a certain query, ex. Images for <b>beach</b>
@@ -11933,8 +11920,7 @@ msgstr "Подробнее об активной защите конфиденц
 # smartling.placeholder_format=C
 msgctxt "showcase_newsletter"
 msgid "Learn about online privacy right in your inbox."
-msgstr ""
-"Получайте рекомендации о защите персональных данных на электронную почту."
+msgstr "Получайте рекомендации о защите персональных данных на электронную почту."
 
 # smartling.placeholder_format=C
 #. Link to a page with more information about how DuckDuckGo settings are managed.
@@ -11994,8 +11980,7 @@ msgstr "Подробнее о работе этой функции"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
+msgstr "Узнайте, почему важно ограничивать отслеживание ваших действий в интернете."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -14425,8 +14410,7 @@ msgstr "Оман"
 #. http://i.imgur.com/zQWKLIm.png
 msgctxt "settings"
 msgid "Omits objectionable (mostly adult) material"
-msgstr ""
-"Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
+msgstr "Исключает из выдачи нежелательные материалы (в основном — \"для взрослых\")"
 
 # smartling.placeholder_format=C
 msgid "On"
@@ -14623,8 +14607,7 @@ msgstr "Открыть сайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
+msgstr "Убедитесь, что %1$sгеолокация%2$s (в одноименном разделе) %3$sвключена%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14801,8 +14784,7 @@ msgstr "Открыть панель «Как работает Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
+msgstr "Откройте меню Safari и выберите пункт «%1$sНастройки для DuckDuckGo...%2$s»"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15888,7 +15870,7 @@ msgstr "Плохое форматирование"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Низкое качество изображения"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16333,8 +16315,7 @@ msgstr "Приватные чаты без сохранения"
 #. The device location shared is is not logged by us
 msgctxt "precise_user_location"
 msgid "Private to us and secured on your device"
-msgstr ""
-"Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
+msgstr "Ваши данные остаются конфиденциальными и надежно хранятся на вашем устройстве"
 
 # smartling.placeholder_format=C
 #. Heading above the group of Pro-tier locked models in the model picker dropdown, when the user is on the Plus tier.
@@ -16681,22 +16662,19 @@ msgstr "Аналитическая ИИ-модель со средним уро�
 #. Second, dimmer line of the highlight tooltip shown under the 'Try reasoning' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Reasoning can give better responses to complex questions."
-msgstr ""
-"Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
+msgstr "Рассуждения позволяют получить более обдуманные ответы на сложные вопросы."
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты достигаются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
+msgstr "Более глубокие рассуждения, но лимиты расходуются в 2–5 раз быстрее. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -18419,8 +18397,7 @@ msgstr ""
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
 msgctxt "Sync feature benefit description"
 msgid "Securely stored on DuckDuckGo's server with end-to-end encryption."
-msgstr ""
-"Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
+msgstr "Надежно хранится на сервере DuckDuckGo с применением сквозного шифрования."
 
 # smartling.placeholder_format=C
 #. List item explaining that synced chats are stored with end-to-end encryption on DuckDuckGo's server and only the user can access them.
@@ -18604,8 +18581,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s и нажмите %3$sУстанов
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
+msgstr "Выберите %1$sDuckDuckGo%2$s поисковой системой по умолчанию в выпадающем меню"
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
@@ -18625,8 +18601,7 @@ msgstr "Выберите %1$sDuckDuckGo%2$s в списке поисковых �
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s under the%sDefault Search Engine%s section"
-msgstr ""
-"Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sDuckDuckGo%2$s в разделе%3$sПоисковая система по умолчанию%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user were in the settings menu they can change their default search engine.
@@ -18711,8 +18686,7 @@ msgstr "Выберите %1$sНастройки%2$s, затем %3$sДополн
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sDefault search engine%s"
-msgstr ""
-"Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
+msgstr "Выберите %1$sНастройки%2$s, а затем %3$sПоисковая система по умолчанию%4$s"
 
 #  Chrome/Firefox on Android
 # smartling.placeholder_format=C
@@ -18808,8 +18782,7 @@ msgstr "Выбранный текст со страницы %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
+msgstr "Выделенный текст слишком длинный. Попробуйте выбрать фрагмент покороче."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19060,8 +19033,7 @@ msgstr "Поделиться"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
+msgstr "Поделитесь DuckDuckGo и помогите друзьям вернуть свою конфиденциальность!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19686,8 +19658,7 @@ msgstr "Показывает поисковые подсказки при вво
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
+msgstr "Показывает преимущества приватного поиска с DuckDuckGo на стартовой странице"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19781,8 +19752,7 @@ msgstr "Поиск по сайту временно недоступен. Мы �
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Sites you block will be hidden from all your search results"
-msgstr ""
-"Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
+msgstr "Сайты, которые ты заблокируешь, будут скрыты из всех твоих результатов поиска"
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes full name (tooltip)
@@ -19935,8 +19905,7 @@ msgstr "Произошла ошибка при загрузке этого об�
 #. Error message indicating that the user's settings weren't able to be saved.
 msgctxt "cloudsave"
 msgid "Something went wrong saving to the server, please try again."
-msgstr ""
-"Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
+msgstr "Что-то пошло не так при сохранении на сервер, пожалуйста, попробуйте снова."
 
 # smartling.placeholder_format=C
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
@@ -20038,8 +20007,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
+msgstr "При отображении результатов произошла ошибка. %1$sПовторить попытку%2$s"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -21133,8 +21101,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном приложении — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -21143,8 +21111,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с ИИ-"
-"помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
+"Берите Duck.ai с собой повсюду. Получайте быстрый доступ к чату с "
+"ИИ-помощником прямо в нашем бесплатном браузере — где бы вы ни находились."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -21465,8 +21433,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
+msgstr "Поставщик не хранит этот чат и связанные с ним данные на своих серверах."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21601,8 +21568,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
+msgstr "Эта ИИ-модель больше недоступна. Попробуйте запустить чат с другой моделью."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21788,8 +21754,7 @@ msgstr ""
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
+msgstr "Формат не поддерживается. Прикрепите изображение в JPG, PNG, WebP или GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21876,8 +21841,7 @@ msgstr "Для нормальной работы данной странице �
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
+msgstr "Содержимое страницы будет отправлено в Duck.ai вместе с вашим сообщением."
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21965,8 +21929,7 @@ msgstr "Здесь это видео пока недоступно. Его мо�
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
+msgstr "Эта страница не использует безопасное зашифрованное соединение (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22113,8 +22076,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
+msgstr "Чтобы продолжить, примите положения разделов «%1$s» и «%2$s» сервиса Duck.ai."
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22187,8 +22149,7 @@ msgstr "Сегодня"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Переключитесь на приватный чат с ИИ или %1$sотключите его в настройках%2$s."
+msgstr "Переключитесь на приватный чат с ИИ или %1$sотключите его в настройках%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22262,7 +22223,7 @@ msgstr "Слишком медленно"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Слишком долго генерируется"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22550,13 +22511,11 @@ msgstr "Чтобы не получать подобные сообщения, п
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
+msgstr "Попробуйте %1$s — нашу первую ИИ-модель с нулевой видимостью для поставщика."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
-msgstr ""
-"Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
+msgstr "Попробуйте %1$sDuck.ai%2$s — приватный чат с искусственным интеллектом:"
 
 # smartling.placeholder_format=C
 #. Button text to retry loading an explore more question that failed
@@ -22693,16 +22652,14 @@ msgstr ""
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Для более точных результатов попробуйте использовать анонимную геопозицию."
+msgstr "Для более точных результатов попробуйте использовать анонимную геопозицию."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
+msgstr "Попробуйте поэкспериментировать с каждой моделью: они дадут разные ответы."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22714,7 +22671,7 @@ msgstr "Попробуйте использовать меньше ключев�
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Попробовать бесплатно"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22896,8 +22853,7 @@ msgstr "Новинки платформы: ИИ-модели с открытым
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Попробуйте начать с готовых запросов или введите собственный вариант ниже."
+msgstr "Попробуйте начать с готовых запросов или введите собственный вариант ниже."
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -23087,8 +23043,7 @@ msgstr "Активировать переключатель Duck.ai"
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Precise Location” for more accurate results."
-msgstr ""
-"Для получения более точных результатов выберите вариант «Точная геопозиция»."
+msgstr "Для получения более точных результатов выберите вариант «Точная геопозиция»."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -23295,15 +23250,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
+msgstr "Под %1$sОткрыть с%2$s выберите %3$sОпределенная страница или страницы%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"В меню %1$sПри запуске > Домашняя страница%2$s введите: https://duckduckgo."
-"com"
+"В меню %1$sПри запуске > Домашняя страница%2$s введите: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23313,16 +23267,15 @@ msgstr "В меню %1$sНастройки поиска%2$s выберите %3$
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
+msgstr "В разделе %1$sпоиска в адресной строке%2$s выберите %3$sДобавить новый%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
 msgstr ""
-"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми системами..."
-"%4$s"
+"Под разделом %1$sПоиск%2$s нажмите на %3$sУправление поисковыми "
+"системами...%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23336,8 +23289,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
+msgstr "В разделе поиска нажмите на выпадающий список и выберите %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23578,8 +23530,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми ИИ-"
-"моделями, обновите браузер DuckDuckGo."
+"Чтобы активировать подписку в Duck.ai и пользоваться продвинутыми "
+"ИИ-моделями, обновите браузер DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23821,8 +23773,7 @@ msgstr "Используйте DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
+msgstr "Пользуйтесь DuckDuckGo Private Search на вашем iPad, iPhone, или Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23956,8 +23907,7 @@ msgstr "Видеоролики заблокированы в рамках без
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result for videos has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
 msgid "Videos for %s blocked by safe search"
-msgstr ""
-"Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
+msgstr "Видеоролики по запросу «%1$s» заблокированы в рамках безопасного поиска."
 
 # smartling.placeholder_format=C
 #. Title for the section that showcases the video results for a certain query, ex. Videos for <b>japan</b>
@@ -24291,8 +24241,7 @@ msgstr "Обои"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Хотите иметь быстрый доступ к приватному ИИ-чату на странице новой вкладки?"
+msgstr "Хотите иметь быстрый доступ к приватному ИИ-чату на странице новой вкладки?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24504,8 +24453,7 @@ msgstr "Мы не отслеживаем вас. Никогда."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
+msgstr "Никакой слежки за вами. Вот краткий обзор нашей Политики конфиденциальности."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24546,8 +24494,7 @@ msgstr "Мы не следим за вами, ни в режиме приват�
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don’t track you. That’s our Privacy Policy in a nutshell…"
-msgstr ""
-"Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
+msgstr "Мы не шпионим за вами. Вот краткий обзор нашей политики конфиденциальности…"
 
 # smartling.placeholder_format=C
 #. Displayed when the user's voice chat session is ended because of being inactive for too long.
@@ -24653,8 +24600,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
+msgstr "Пока вы гуляете по Интернету, мы не даем трекерам собирать ваши данные."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -25061,8 +25007,7 @@ msgstr "Чему я научусь на этом курсе?"
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the main counterarguments or criticisms of this?"
-msgstr ""
-"Каковы основные контраргументы или критические замечания по этому поводу?"
+msgstr "Каковы основные контраргументы или критические замечания по этому поводу?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What does this answer?" page-suggestion chip.
@@ -25340,8 +25285,7 @@ msgstr "На какие бренды обратить внимание нови�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
+msgstr "При активации этой настройки Duck.ai будет показывать быстрые ответы в чате."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25885,8 +25829,7 @@ msgstr ""
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
-msgstr ""
-"Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
+msgstr "Сервис %1$sDuck.ai%2$s также умеет отвечать на вопросы и резюмировать текст."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -25915,8 +25858,7 @@ msgstr ""
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
 msgctxt "Third party map app picker feedback dialog"
 msgid "You can change this any time in %sSearch Settings%s"
-msgstr ""
-"Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
+msgstr "Вы в любой момент можете изменить свой выбор в %1$sнастройках поиска%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
@@ -25961,8 +25903,7 @@ msgstr "Вы можете продолжить чат, используя сво
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
+msgstr "Теперь на этом устройстве можно хранить до 100 чатов. Общайтесь больше!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -25980,29 +25921,25 @@ msgstr "Число файлов, прикрепляемых к одной бес
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time"
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has select more images than are allowed to be uploaded. Placeholder is the number of images that are allowed. E.g. You can only attach 3 images per chat
 msgctxt "Error message when input exceeds image upload limit"
 msgid "You can only attach %s images at a time."
-msgstr ""
-"Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых за один раз, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation"
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more images across the conversation than allowed. Placeholder is the maximum number of images. E.g. You can only attach 5 images per conversation
 msgctxt "Error message when total image count exceeds conversation limit"
 msgid "You can only attach %s images per conversation."
-msgstr ""
-"Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
+msgstr "Число изображений, прикрепляемых к одной беседе, ограничено: максимум %1$s."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more open browser tabs than are allowed on a single prompt. Placeholder is the maximum number of tabs. E.g. You can only attach 3 tabs at a time.
@@ -26255,8 +26192,7 @@ msgstr "Вы исчерпали голосовой лимит на сегодн�
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
 msgid "You've reached your dictation usage limit. Try again later."
-msgstr ""
-"Вы достигли лимита использования функции диктовки. Повторите попытку позже."
+msgstr "Вы достигли лимита использования функции диктовки. Повторите попытку позже."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26324,8 +26260,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
+msgstr "Ваши чаты Duck.ai синхронизируются с использованием сквозного шифрования."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26447,8 +26382,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
+msgstr "Ваши чаты сохраняются в секрете и не используются для обучения моделей ИИ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26470,8 +26404,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения ИИ-"
-"моделей."
+"Ваши чаты конфиденциальны. Мы не храним их и не используем для обучения "
+"ИИ-моделей."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26505,8 +26439,8 @@ msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
 msgstr ""
-"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в Duck."
-"ai."
+"Ваши чаты импортированы. Продолжай с того места, где ты остановился, в "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/sc_IT/LC_MESSAGES/duckduckgo.po
+++ b/locales/sc_IT/LC_MESSAGES/duckduckgo.po
@@ -2384,6 +2384,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5289,6 +5300,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Iscarta"
@@ -5378,6 +5394,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6862,6 +6883,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7121,6 +7147,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7871,6 +7902,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8814,6 +8850,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12797,6 +12838,11 @@ msgstr "Polacu"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17927,6 +17973,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18287,6 +18338,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Proa prus pagu paràulas crae."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,8 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -203,8 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
-"ප්‍රකාරයකට මාරු වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -221,8 +221,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
-"වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -231,8 +230,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
-"නැවත උත්සාහ කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -335,9 +334,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
-"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
-"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
+"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
+"නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -423,8 +422,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
-"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -435,8 +434,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
+"ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -449,8 +448,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
-"%6$sහරි%7$sක්ලික් කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
+"කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -458,8 +457,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
-"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
+"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -479,8 +478,7 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
-"%1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -513,8 +511,7 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
-"ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -533,8 +530,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
-"සහ නැවත උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -886,8 +883,7 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -895,8 +891,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
-"ම කතාබස් කළ හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -950,8 +946,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
-"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
+"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -959,8 +955,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -968,8 +964,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
-"නැවත නැවුම් කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1013,10 +1009,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
-"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
-"Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
+"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
+"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1077,10 +1072,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
-"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
-"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
-"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
+"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
+"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
+"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1277,8 +1272,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
-"නොමිලේ ආකෘතියකට මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
+"මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1314,8 +1309,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
-"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
+"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1323,8 +1318,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
-"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
+"කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1395,8 +1390,7 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
-"කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1673,8 +1667,7 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය "
-"හැක. %1$s"
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1682,9 +1675,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
-"%1$s"
+msgstr "උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1862,8 +1853,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
-"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
+"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1916,8 +1907,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
-"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
+"ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1956,8 +1947,7 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
-"ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1989,10 +1979,9 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
-"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
-"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
-"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
+"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
+"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2000,8 +1989,7 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
-"අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2139,8 +2127,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2149,8 +2136,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
-"නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2164,9 +2150,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
-"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
-"අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
+"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2213,8 +2198,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
-"විටම කරුණු මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
+"මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2341,8 +2326,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
-"සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2351,8 +2335,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
-"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
+"කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2390,9 +2374,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
-"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
-"වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
+"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2534,14 +2517,12 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
-"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
-"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
-"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
-"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
-"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
-"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
+"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
+"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
+"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2553,12 +2534,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
-"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
-"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
+"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
+"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
+"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
+"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2584,8 +2564,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය "
-"ගුප්ත කේතනය කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
+"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය ගුප්ත කේතනය "
+"කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2706,9 +2686,7 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr ""
-"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
-"තිබිය හැක."
+msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2733,9 +2711,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
-"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
-"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
+"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
+"පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2744,17 +2722,15 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
-"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
-"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
+"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
+"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr ""
-"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
-"ධාවනය කරන්න."
+msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2954,8 +2930,20 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
-"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
+"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3085,8 +3073,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය "
-"සමඟ තවත් වාරික ආරක්ෂණ ලබා ගන්න."
+"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය සමඟ තවත් වාරික "
+"ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3346,18 +3334,16 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
-"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
-"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
-"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
-"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3365,9 +3351,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
-"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
-"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
+"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3474,11 +3459,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
-"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
-"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
-"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
-"බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
+"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
+"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
+"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3486,8 +3470,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
-"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3496,8 +3480,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
-"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
+"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3532,9 +3516,7 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
-"හැකිද?"
+msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3997,11 +3979,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
-"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
-"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
-"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
+"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
+"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
+"ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4057,8 +4039,7 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4066,8 +4047,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
-"පුද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4148,8 +4129,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"කතාබස් DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර "
-"ඇත. ඔබට හැර වෙන කිසිවෙකුට, අපට පවා, ඔබගේ දත්ත දැකිය නොහැක."
+"කතාබස් DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට, අපට පවා, ඔබගේ දත්ත දැකිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4158,8 +4139,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
-"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4171,11 +4152,10 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
-"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
+"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
+"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4198,9 +4178,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
-"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
-"සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
+"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4208,8 +4187,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
-"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
+"කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4365,8 +4344,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන "
-"40කට වඩා වැඩි ගණනකින් තෝරා ගන්න."
+"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන 40කට වඩා වැඩි "
+"ගණනකින් තෝරා ගන්න."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4383,9 +4362,7 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr ""
-"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
-"තෝරන්න"
+msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4566,9 +4543,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
-"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
-"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
+"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
+"ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4578,9 +4555,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
-"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
-"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
+"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4589,8 +4565,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
-"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
+"ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4599,9 +4575,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
-"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
-"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
+"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
+"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4675,8 +4651,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
-"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
+"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4706,8 +4682,7 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
-"කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4769,9 +4744,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4782,9 +4756,8 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
-"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
-"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
+"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4853,8 +4826,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
-"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
+"%3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4862,8 +4835,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
-"ඉහළ දකුණු කෙළවරේ තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
+"තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5064,8 +5037,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
-"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
+"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5337,8 +5310,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
-"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
-"ඒවා මකා දමන්න."
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් ඒවා මකා "
+"දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5521,8 +5494,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & "
-"Backup › වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
+"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & Backup › "
+"වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5581,8 +5554,7 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
-"කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5697,8 +5669,7 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
-"බැලිය හැකිය."
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5944,8 +5915,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
-"කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6262,8 +6232,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ "
-"කතාබස් වෙත එක් කර ඇති පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
+"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ කතාබස් වෙත එක් කර ඇති "
+"පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6360,8 +6330,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
-"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6379,8 +6349,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
-"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
+"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6510,6 +6480,12 @@ msgid "Dislike source"
 msgstr "මූලාශ්‍රය අකමැති වීම"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "නැති කරන්න"
@@ -6620,6 +6596,12 @@ msgid "Djibouti"
 msgstr "ජිබූටි"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6705,8 +6687,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
-"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
+"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6715,8 +6697,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
-"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
+"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6832,8 +6814,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
-"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6842,8 +6824,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
-"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
+"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6864,8 +6846,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6874,8 +6856,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
-"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -7007,9 +6989,8 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
-"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
-"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
+"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7019,9 +7000,8 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
-"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
-"කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
+"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7030,8 +7010,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
+"කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -7047,9 +7027,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
-"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
-"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
+"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
+"කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7064,8 +7044,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
-"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
+"අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7080,8 +7060,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
-"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
+"කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7102,9 +7082,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
-"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
-"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
+"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
+"පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7115,11 +7095,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
-"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
-"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
-"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
+"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
+"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7134,8 +7113,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
-"භාවිතා කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
+"කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7149,8 +7128,7 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
-"පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7184,10 +7162,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
-"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
-"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
-"කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
+"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
+"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7215,13 +7192,12 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
-"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
-"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
-"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
-"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
-"පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
+"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
+"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
+"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
+"(ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7230,10 +7206,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7242,10 +7217,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
-"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
-"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
-"සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
+"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
+"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7257,12 +7231,11 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
-"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
-"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
-"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
+"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
+"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
+"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7276,15 +7249,13 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
-"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
-"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
-"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
-"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
-"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
-"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
-"වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
+"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
+"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
+"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
+"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7292,8 +7263,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
-"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
+"පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7302,8 +7273,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
-"මෙම කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7312,8 +7283,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7322,8 +7293,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
-"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
+"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7349,9 +7320,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
-"කරන්න."
+msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7507,8 +7476,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
-"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
+"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7516,8 +7485,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
-"%2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
+"වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7526,8 +7495,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
-"වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7536,9 +7504,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
-"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
-"කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
+"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7550,11 +7517,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
-"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
-"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
-"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
-"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
+"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
+"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
+"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
+"ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7574,8 +7541,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
-"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
+"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7667,9 +7634,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
-"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
-"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
+"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
+"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7745,9 +7712,7 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
-"කරයි."
+msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7885,8 +7850,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
-"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7897,9 +7862,7 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
-"කරන්න"
+msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7931,8 +7894,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
-"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
+"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8108,8 +8071,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
-"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
+"ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8236,9 +8199,7 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr ""
-"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
-"නිෂ්පාදන."
+msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8326,9 +8287,7 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr ""
-"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
-"කරන්න."
+msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8480,6 +8439,12 @@ msgid "Fast"
 msgstr "වේගවත්"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8523,9 +8488,7 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
-"කිරීම් බලපායි."
+msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8534,18 +8497,15 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
-"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
-"බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
+"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
-"කරන්න."
+msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8640,8 +8600,7 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
-"%1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8719,9 +8678,7 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
-"පවතී."
+msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8785,8 +8742,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
-"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
+"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8804,6 +8761,12 @@ msgstr "පසු විපරම් ප්‍රශ්නය"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "පසු විපරම් පෞද්ගලිකව පවතී."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9021,8 +8984,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
-"ස්ථාපනය කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
+"කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9308,8 +9271,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ "
-"Identity Theft Restoration."
+"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ Identity Theft "
+"Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9401,8 +9364,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, "
-"සහ Identity Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, සහ "
+"Identity Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9411,8 +9374,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity "
-"Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity Theft "
+"Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9421,8 +9384,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
-"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
+"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9433,8 +9396,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
-"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
+"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9478,8 +9441,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි "
-"සඳහා විකල්ප ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි සඳහා විකල්ප "
+"ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9488,8 +9451,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal "
-"Information Removal සහ Identity Theft Restoration."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal Information "
+"Removal සහ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9497,8 +9460,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft "
-"Restoration ලබා ගන්න."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9539,9 +9502,7 @@ msgstr "යෙදුම ලබා ගන්න"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr ""
-"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
-"ගන්න.%2$s"
+msgstr "YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9600,9 +9561,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
+"පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9611,9 +9572,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
-"යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
+"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9623,9 +9583,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
+"කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9635,10 +9595,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
-"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
-"කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9647,8 +9606,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න%4$s වෙත යන්න."
+"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9663,8 +9622,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
-"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9673,8 +9632,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
-"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
+"වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9741,6 +9700,12 @@ msgstr "හොඳ නිර්මාණයක්"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "හොඳ රහස්‍යතා ප්‍රතිපත්තිය"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10363,8 +10328,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
-"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
+"කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10391,8 +10356,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
-"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
+"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10406,8 +10371,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
-"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
+"අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10457,8 +10422,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
-"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
+"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10606,8 +10571,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
-"කෙසේද සහ මා කුමක් කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
+"කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10729,8 +10694,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
-"කැමති මොනවාද සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
+"සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10765,8 +10730,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
-"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
+"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10776,9 +10741,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
-"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
-"අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
+"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10793,8 +10757,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
-"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
+"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10803,8 +10767,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
-"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
+"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10813,17 +10777,14 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
-"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
-"සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
+"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
-"කරන්න%2$s"
+msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10833,17 +10794,15 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
-"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
+"යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr ""
-"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
-"කරන්න)."
+msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10881,6 +10840,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "රූපමය ප්‍රේරක විධාන Duck.ai %1$s සමඟ අනුකූල විය යුතුය."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10972,8 +10937,7 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
-"වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10986,8 +10950,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
-"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
+"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10998,8 +10962,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11014,8 +10978,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
-"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
+"ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11026,8 +10990,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
-"සලකුණ යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
+"යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11354,8 +11318,7 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
-"සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11424,10 +11387,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
-"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
-"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
-"නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
+"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
+"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11436,8 +11398,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
-"වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11509,9 +11470,7 @@ msgstr "උපාංග දෙකෙහිම Sync & Backup විවෘතව �
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr ""
-"එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව "
-"තබා ගන්න."
+msgstr "එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -12152,9 +12111,7 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
-"කරයි"
+msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12340,7 +12297,8 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr ""
+"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12705,9 +12663,7 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr ""
-"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
-"උත්සාහ කරන්න."
+msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12938,9 +12894,7 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
-"හැක."
+msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13493,10 +13447,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
-"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
-"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
-"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
+"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
+"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
+"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14331,8 +14285,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
-"%4$s icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
+"icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14362,8 +14316,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF "
-"ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14391,8 +14345,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
-"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
+"පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14418,9 +14372,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
-"දක්වා ඇත."
+msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14435,8 +14387,7 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14767,8 +14718,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
-"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
+"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14782,8 +14733,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ "
-"තවත් ප්‍රිමියම් ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ තවත් ප්‍රිමියම් "
+"ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14791,8 +14742,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
-"කරන්නේ හෝ බෙදා හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
+"හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14800,9 +14751,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
-"Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
+"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15055,8 +15005,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
-"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
+"යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15212,9 +15162,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර "
-"අඩවිවලින් සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු "
-"කරන්නෙමු."
+"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර අඩවිවලින් "
+"සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15285,10 +15234,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
-"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
-"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
+"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
+"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15297,10 +15245,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
-"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15310,10 +15257,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
-"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
-"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
-"පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
+"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15346,8 +15292,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
-"කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15356,8 +15301,7 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
-"එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15378,8 +15322,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
-"අනුගමනය කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15467,9 +15411,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15477,25 +15419,19 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
-"සම්පූර්ණ කරන්න."
+msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
-"(විකල්ප)"
+msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15516,8 +15452,7 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
-"මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15526,8 +15461,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15536,8 +15471,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
-"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
+"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15748,12 +15683,16 @@ msgid "Poor formatting"
 msgstr "දුර්වල ආකෘතිකරණය"
 
 # smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr ""
-"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
-"නිර්නාමික කර ඇත."
+msgstr "ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16311,8 +16250,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
-"පෙළ මෙහි ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
+"ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16541,9 +16480,7 @@ msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා "
-"වේ. %1$s"
+msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා වේ. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16599,8 +16536,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16609,8 +16546,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
-"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
+"උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16620,9 +16557,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
-"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
-"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
+"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
+"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16763,9 +16700,7 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr ""
-"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
-"කරයි"
+msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16906,8 +16841,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
-"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
+"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17015,8 +16950,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
-"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
+"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -17024,9 +16959,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
-"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
-"දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
+"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17090,9 +17024,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
-"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
-"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
+"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
+"ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17100,8 +17034,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
-"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
+"හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17110,9 +17044,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
-"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
-"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
+"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
+"තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17204,9 +17138,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17215,9 +17148,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
-"කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17227,10 +17159,9 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
-"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
-"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
-"යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
+"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
+"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17655,8 +17586,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
-"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
+"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17829,8 +17760,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
-"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
+"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17839,8 +17770,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
-"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
+"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17926,13 +17857,12 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
-"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
-"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
-"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
-"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
-"කලාපවල උප කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
+"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
+"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
+"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
+"කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17940,8 +17870,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
-"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
+"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17950,10 +17880,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
-"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
-"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
-"කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
+"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
+"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18074,8 +18003,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
-"“ducks” සෘජුවම සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
+"සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18094,8 +18023,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
-"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
+"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18103,8 +18032,7 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
-"භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18116,11 +18044,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
-"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
-"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
-"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
-"නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
+"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
+"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
+"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18223,8 +18150,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18233,8 +18160,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18243,8 +18170,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
-"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
+"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18253,8 +18180,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
+"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18269,8 +18196,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
-"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
+"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18494,8 +18421,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
-"වල) තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
+"තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18560,8 +18487,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
-"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
+"විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18683,8 +18610,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
-"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
+"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18807,8 +18734,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
-"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
+"Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18915,8 +18842,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
-"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
+"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -19018,8 +18945,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
-"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
+"සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -19068,9 +18995,8 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා "
-"කරගන්න. සැකසීමට සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට "
-"පහසුය."
+"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා කරගන්න. සැකසීමට "
+"සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට පහසුය."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19197,8 +19123,7 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
-"කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19436,8 +19361,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
+"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19445,8 +19370,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
-"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
+"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19484,8 +19409,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
-"පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19826,8 +19750,7 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
-"උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19836,16 +19759,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
-"ඇති බවට වග බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
+"බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
-"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
+"උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19854,16 +19777,15 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
-"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
+"කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
-"උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20267,8 +20189,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
-"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
+"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20336,9 +20258,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
-"කරනවාද?"
+msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20674,9 +20594,7 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
-"යවනු ඇත"
+msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20731,8 +20649,7 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
-"කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20741,8 +20658,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup ඔබේ කතාබස්වල වැඩි ප්‍රමාණයක් සුරකින අතර ඒවා ඔබගේ සියලු උපාංග "
-"හරහා සමමුහුර්ත කරයි."
+"Sync & Backup ඔබේ කතාබස්වල වැඩි ප්‍රමාණයක් සුරකින අතර ඒවා ඔබගේ සියලු උපාංග හරහා "
+"සමමුහුර්ත කරයි."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20791,9 +20708,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
-"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
-"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
+"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -20802,14 +20719,12 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
-"ස්ථානයේ අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
+"අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
-"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
-"කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
+"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20948,8 +20863,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
-"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් ප්‍රවේශයක් සඳහා "
+"එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20958,8 +20873,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
-"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20983,8 +20898,7 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
-"සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21205,9 +21119,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
-"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
-"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
+"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
+"ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21216,8 +21130,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
-"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
+"සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21226,8 +21140,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Duck.ai ටොගලය ඔබට පුද්ගලික සෙවීම සහ AI කතාබස් අතර ඉක්මනින් මාරු වීමට ඉඩ "
-"සලසයි, DuckDuckGo මගින් නිර්නාමික කර ඇත."
+"Duck.ai ටොගලය ඔබට පුද්ගලික සෙවීම සහ AI කතාබස් අතර ඉක්මනින් මාරු වීමට ඉඩ සලසයි, "
+"DuckDuckGo මගින් නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21257,8 +21171,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
-"හැක්කේ ඔබට පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21279,9 +21193,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
-"සුරකින්නේ නැත."
+msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21340,8 +21252,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
-"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
+"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21356,8 +21268,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
-"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
+"රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21376,9 +21288,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
-"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
-"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
+"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
+"බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21416,8 +21328,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
-"කිරීමට උත්සාහ කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21426,8 +21338,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
-"කතාබහක් ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
+"ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21466,9 +21378,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
-"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
-"විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
+"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21478,8 +21389,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
-"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
+"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21488,8 +21399,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
-"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
+"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21500,8 +21411,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
-"(වැඩි විස්තර සඳහා %4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
+"%4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21518,8 +21429,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට "
-"නොහැකි වනු ඇත. අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
+"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට නොහැකි වනු ඇත. "
+"අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21625,8 +21536,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
-"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ කතාබස්වල ඉහළින්ම තබා "
+"ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21635,8 +21546,7 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
-"භාවිතා කරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21657,8 +21567,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
-"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
+"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21667,8 +21577,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
-"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
+"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21705,8 +21615,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
-"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
+"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21715,8 +21625,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21726,9 +21636,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
-"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
-"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
+"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
+"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21779,9 +21689,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
-"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
-"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
+"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
+"හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21790,8 +21700,7 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
-"හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21929,8 +21838,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
-"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
+"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21940,9 +21849,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
-"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
-"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
+"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
+"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21951,8 +21860,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
-"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
+"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21960,8 +21869,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
-"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
+"දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21983,17 +21892,15 @@ msgstr "අද"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"පුද්ගලික AI කතාබස් සඳහා ටොගල් කරන්න, නැතහොත් %1$sසැකසුම් තුළින් අක්‍රිය "
-"කරන්න%2$s."
+msgstr "පුද්ගලික AI කතාබස් සඳහා ටොගල් කරන්න, නැතහොත් %1$sසැකසුම් තුළින් අක්‍රිය කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
-"එය අක්‍රිය කරන්න.%3$s"
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් එය අක්‍රිය කරන්න."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22054,6 +21961,12 @@ msgstr "මෙම මූලාශ්‍රයෙන් ප්‍රතිඵල 
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "මන්දගාමී වැඩියි"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22167,8 +22080,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
-"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
+"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22216,8 +22129,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22226,8 +22139,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
-"ශාලාවට යන්නේ කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
+"කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22474,9 +22387,7 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
-"කරන්න."
+msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22489,15 +22400,19 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
-"දෙනු ඇත."
+msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "කුඩා වචන ප්‍රමාණයක් සමග උත්සහ කරන්න."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22709,8 +22624,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22719,8 +22634,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
+"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22921,8 +22836,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
-"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
+"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -23052,8 +22967,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
-"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
+"Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -23061,8 +22976,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
-"https://duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23178,8 +23093,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
-"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
+"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23337,8 +23252,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
-"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
+"යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23463,16 +23378,15 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
-"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
+"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
-"උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23568,9 +23482,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
-"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
-"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
+"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23625,8 +23539,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
-"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
+"ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23634,8 +23548,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
-"මේ කේතය භාවිතා කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23759,9 +23673,8 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai වෙතින් බෙදාගත් සංවාදයක් බලන්න - DuckDuckGo වෙතින් නොමිලේ, පුද්ගලික "
-"AI කතාබස්. එය ඔබේම කතාබස්වලට සුරැක පෞද්ගලිකත්වය රැක ගනිමින් අඛණ්ඩව ඉදිරියට "
-"යන්න."
+"Duck.ai වෙතින් බෙදාගත් සංවාදයක් බලන්න - DuckDuckGo වෙතින් නොමිලේ, පුද්ගලික AI කතාබස්. එය "
+"ඔබේම කතාබස්වලට සුරැක පෞද්ගලිකත්වය රැක ගනිමින් අඛණ්ඩව ඉදිරියට යන්න."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23796,8 +23709,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
+"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23806,8 +23719,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
-"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
+"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23816,8 +23729,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"වෙළෙඳ දැන්වීම් බැලීමේ පුද්ගලිකත්වය DuckDuckGo මගින් ආරක්ෂා කරයි. වෙළෙඳ "
-"දැන්වීම් මත ක්ලික් කිරීම් Yelp ප්‍රචාරණ ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"වෙළෙඳ දැන්වීම් බැලීමේ පුද්ගලිකත්වය DuckDuckGo මගින් ආරක්ෂා කරයි. වෙළෙඳ දැන්වීම් මත ක්ලික් කිරීම් "
+"Yelp ප්‍රචාරණ ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23829,8 +23742,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23839,8 +23752,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23849,8 +23762,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
-"උපදෙස් පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
+"පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23865,9 +23778,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
-"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
-"සමමුහුර්ත කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
+"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
+"කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23877,9 +23790,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
-"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
+"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
+"PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23901,10 +23814,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
-"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
-"කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
+"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
+"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23957,8 +23869,7 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
-"භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24108,8 +24019,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
-"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
+"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24129,10 +24040,9 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
-"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
-"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
-"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
+"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
+"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24144,9 +24054,7 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
-"හැකිය."
+msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24158,9 +24066,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
-"විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24172,17 +24080,15 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
-"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
-"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
+"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
-"හැකිය."
+msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24190,8 +24096,7 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
-"කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24207,9 +24112,7 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr ""
-"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
-"නැත."
+msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24221,8 +24124,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
-"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
+"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24236,8 +24139,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
-"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
+"අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24246,8 +24149,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
-"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
+"ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24287,8 +24190,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
-"වලට විකිණීමට කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
+"කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24314,8 +24217,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට "
-"අමතරව VPN එකක් සහ තවත් දේ ලබා ගන්න."
+"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට අමතරව VPN එකක් "
+"සහ තවත් දේ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24324,8 +24227,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
-"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
+"ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24350,8 +24253,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
-"දත්ත සූරාකෑමෙන් නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24360,8 +24263,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
-"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
+"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24370,16 +24273,15 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, "
-"භාවිතයට පහසු උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
+"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, භාවිතයට පහසු "
+"උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
-"රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24400,15 +24302,13 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
-"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
+"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
-"කරන්නෙමු."
+msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24417,8 +24317,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි "
-"ස්කෑන් කර, ඔබ ගැන සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
+"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි ස්කෑන් කර, ඔබ ගැන "
+"සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24427,8 +24327,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
-"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
+"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24437,8 +24337,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
-"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
+"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24453,8 +24353,7 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
-"මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24463,8 +24362,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
-"පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24573,8 +24471,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
-"කතාබහේ යෙදිය හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
+"හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24588,8 +24486,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
-"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
+"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24598,9 +24496,8 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
-"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
+"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24610,17 +24507,15 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
-"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
-"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
+"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
+"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
-"පුළුවන්."
+msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24688,8 +24583,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
-"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
+"ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24704,8 +24599,7 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
-"ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24726,8 +24620,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
-"විකල්ප මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
+"මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24752,11 +24646,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
-"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
-"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
-"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
-"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
+"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
+"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
+"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24992,8 +24885,7 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
-"වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25094,8 +24986,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
-"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
+"මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25296,9 +25188,8 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
-"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
-"කරන්න."
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු කිරීමට භාවිත "
+"නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25307,8 +25198,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස්වලින් "
-"%1$sක් දක්වා මෙම උපාංගයේ සුරැකෙනු ඇත."
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස්වලින් %1$sක් දක්වා මෙම "
+"උපාංගයේ සුරැකෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25316,8 +25207,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
-"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස් මෙම "
-"උපාංගයේ සුරැකෙනු ඇත."
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස් මෙම උපාංගයේ සුරැකෙනු "
+"ඇත."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25332,8 +25223,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් "
-"ඉවත් කිරීමට ඔබේ උපාංගයෙන්ම ක්‍රියා කරයි."
+"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් ඉවත් කිරීමට ඔබේ "
+"උපාංගයෙන්ම ක්‍රියා කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25600,9 +25491,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25611,8 +25500,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
-"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
+"සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25626,8 +25515,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
-"තුළ එය අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
+"අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25636,22 +25525,21 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
+"අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
-"හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
-"ද භාාවිත කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
+"කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25665,8 +25553,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
-"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
+"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25687,8 +25575,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
-"පළමු සමූහය මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
+"මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25781,8 +25669,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
-"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
+"අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25846,8 +25734,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
-"පුළුල් පරිශීලන සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
+"සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25856,8 +25744,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
-"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
+"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25879,9 +25767,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25891,9 +25779,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
-"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
-"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
+"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25906,9 +25794,7 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr ""
-"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
-"ලැබෙනු ඇත."
+msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25923,8 +25809,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
-"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
+"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25937,8 +25823,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
-"ගැනීමට ඉඟි ලබා ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -26014,9 +25900,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
-"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -26026,9 +25911,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
-"නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
+"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -26042,9 +25926,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
-"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
-"කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
+"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26104,8 +25987,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත."
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -26115,9 +25998,8 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
-"ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26127,9 +26009,8 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
-"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
-"හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
+"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26154,8 +26035,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
-"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
+"වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26163,8 +26044,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
-"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
+"නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26172,9 +26053,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
-"හැකිය."
+msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26187,8 +26066,7 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
-"භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26202,8 +26080,7 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26211,8 +26088,7 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
-"කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26220,8 +26096,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26229,8 +26105,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
-"පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26245,9 +26121,8 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
-"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
-"ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
+"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26287,8 +26162,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
-"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
+"[%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26331,10 +26206,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
-"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
-"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
-"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
+"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
+"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26349,9 +26223,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
-"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
-"සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
+"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26365,8 +26238,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
-"වේලාවක ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
+"ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26398,8 +26271,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
-"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26408,9 +26281,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
-"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
-"දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26438,8 +26310,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
-"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
+"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26448,8 +26320,7 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
-"කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26458,8 +26329,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
-"සමඟ මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
+"මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26467,9 +26338,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
-"ගන්න."
+msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26484,8 +26353,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
-"දිගටම කරගෙන යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/si_LK/LC_MESSAGES/duckduckgo.po
+++ b/locales/si_LK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: si_LK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,8 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -203,8 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ Pro සමඟ පමණි. කතාබහ දිගටම කරගෙන යාමට මෙම බ්‍රවුසරයේ ඔබේ "
-"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ ප්‍රකාරයකට මාරු "
-"වන්න."
+"DuckDuckGo ග්‍රාහකත්වය නැවත උත්ශ්‍රේණිගත කරන්න, නැතහොත් Plus හෝ නොමිලේ "
+"ප්‍රකාරයකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -221,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s ලබා ගත හැක්කේ DuckDuckGo දායකත්වයක් සමඟ පමණි. චැට් දිගටම කරගෙන යාමට මෙම "
-"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු වන්න."
+"බ්‍රව්සරයේ ඔබේ දායකත්වය නැවත සක්‍රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට මාරු "
+"වන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,8 +231,8 @@ msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
 msgstr ""
-"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව නැවත උත්සාහ "
-"කරන්න."
+"%1$s තාවකාලිකව ලබා ගත නොහැක. කරුණාකර වෙනත් ආකෘතියකට මාරු වන්න නැතිනම් පසුව "
+"නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -334,9 +335,9 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් අදහස් කරන්නේ ආකෘති "
-"සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට "
-"නොහැකි බවයි."
+"%1$s ක් රියාත්මක වන්නේ විශ්වාසදායක ක් රියාත්මක කිරීමේ පරිසරයක ය. මෙයින් "
+"අදහස් කරන්නේ ආකෘති සපයන්නාට පවා ඔබේ විමසීම් හෝ ආකෘතියේ ප්‍රතිචාර දැකීමට හෝ "
+"මෙම කතාබහ ඔවුන්ගේ සර්වරවල සුරැකීමට නොහැකි බවයි."
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -422,8 +423,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
-"යාමට ආකෘති මාරු කළ හැකි ය."
+"%1$s දින %2$sකින් (%3$s) Duck.ai හැර යනු ඇත. ඊට පසු, ඔබට මෙම කතාබහ දිගටම "
+"කරගෙන යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -434,8 +435,8 @@ msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
 msgstr ""
-"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන යාමට "
-"ආකෘති මාරු කළ හැකි ය."
+"%1$s දින 1කින් Duck.ai හැර යනු ඇත (%2$s). ඊට පසු, ඔබට මෙම කතාබහ දිගටම කරගෙන "
+"යාමට ආකෘති මාරු කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -448,8 +449,8 @@ msgstr "%1$s වචන"
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව %6$sහරි%7$sක්ලික් "
-"කරන්න"
+"%1$sක්ලික් කරන්න %2$sඑක් කරන්න%3$sපරීක්ෂා කරන්න %4$sඉඩ දෙන්න%5$s, අනතුරුව "
+"%6$sහරි%7$sක්ලික් කරන්න"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -457,8 +458,8 @@ msgstr ""
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි ලකුණ "
-"දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
+"%1$sAllow%2$s %3$sක්ලික් කරන්න %4$sAdd%5$s ක්ලික් කරන්න %6$sAllow%7$s මත හරි "
+"ලකුණ දමන්න, ඉන්පසුව %8$sOkay%9$s ක්ලික් කරන්න"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -478,7 +479,8 @@ msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
 msgstr ""
-"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට %1$sමෙතන ක්ලික් කරන්න%2$s."
+"මෙයට ප්‍රතිඵලයක් තිබෙන්නටම අවශ්‍යයැයි සිතෙනවානම්, නැවත් උත්සාහ කිරීමට "
+"%1$sමෙතන ක්ලික් කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -511,7 +513,8 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර ඉගෙන ගන්න."
+"%1$sDuckDuckGo සර්වරයේ කතාබස් පෞද්ගලිකව ගබඩා වන ආකාරය පිළිබඳ%2$s වැඩිදුර "
+"ඉගෙන ගන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -530,8 +533,8 @@ msgstr "මුල් තිරයේ ඇති DuckDuckGo යෙදුම් න
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
 msgstr ""
-"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s සහ නැවත "
-"උත්සාහ කරන්න."
+"%1$sඅපොයි!%2$s%3$sකුමක් හෝ වැරැද්දක් සිදු විය. කරුණාකර %4$sනැවුම් කරන්න%5$s "
+"සහ නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -883,7 +886,8 @@ msgstr "පැය 6ක පරිශීලන සීමාවට ළඟා වී
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -891,8 +895,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "6-hour usage limit reached. You can keep chatting by using your daily limit."
 msgstr ""
-"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට ම කතාබස් කළ "
-"හැකි ය."
+"පැය 6ක පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබේ දෛනික සීමාව භාවිතා කිරීමෙන් ඔබට දිගට "
+"ම කතාබස් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Cricket scorecard: sixes abbreviation
@@ -946,8 +950,8 @@ msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
 msgstr ""
-"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. කරුණාකර ඔබේ "
-"සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
+"ජාල ගැටලුවක් හේතුවෙන් Search Assist මගින් පිළිතුරක් ජනනය කිරීම වැළකී ඇත. "
+"කරුණාකර ඔබේ සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -955,8 +959,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
 msgstr ""
-"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"AI Chat හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -964,8 +968,8 @@ msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
 msgstr ""
-"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව නැවත නැවුම් "
-"කරන්න."
+"Duck.ai හි නව අනුවාදයක් ලබා ගත හැකි ය! දිගටම කරගෙන යාමට කරුණාකර මෙම පිටුව "
+"නැවත නැවුම් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1009,9 +1013,10 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. මෙය "
-"ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. මෙම සැකසුම ක්‍රියා "
-"විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI Chat වෙත ප්‍රවේශ විය හැකිය."
+"AI Chat ඔබට 3පාර්ශවයේ AI Chat ආකෘති සමඟ නිර්නාමික සංවාද පැවැත්වීමට ඉඩ සලසයි. "
+"මෙය ක්‍රියා විරහිත කිරීමෙන් DuckDuckGo Search AI Chat විශේෂාංගය සඟවනු ඇත. "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$sduckduckgo.com/aichat%2$s AI "
+"Chat වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1072,10 +1077,10 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ වෙතත්, අපි පසු විපරම් "
-"ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය වෙත සබැඳෙමු, එය OpenAI සහ "
-"Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය දක්වන අපගේ පෞද්ගලික AI බලයෙන් "
-"ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"AI සහය සහිත පිළිතුරු දැනට සෘජුවම පසු විපරම් ප්‍රශ්නවලට සහය නොදක්වයි. කෙසේ "
+"වෙතත්, අපි පසු විපරම් ප්‍රශ්න සඳහා %1$sDuck.ai%2$s පිරිනමමු, තවද බොහෝ විට එය "
+"වෙත සබැඳෙමු, එය OpenAI සහ Anthropic, සහ තවත් දෑ වෙතින් චැට් ආකෘති සඳහා සහය "
+"දක්වන අපගේ පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1272,8 +1277,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් නොමිලේ ආකෘතියකට "
-"මාරු වන්න."
+"චැට් දිගටම කරගෙන යාමට මෙම බ්රව්සරයේ ඔබේ %1$s නැවත සක්රිය කරන්න, නැත්නම් "
+"නොමිලේ ආකෘතියකට මාරු වන්න."
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1309,8 +1314,8 @@ msgstr "දැන්වීම"
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
 msgstr ""
-"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය මගින් වන අතර ඒවා "
-"ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
+"වෙළඳ දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ %1$sහි වෙළඳ දැන්වීම් ජාලය "
+"මගින් වන අතර ඒවා ඔබේ හැසිරීම මත පදනම්ව තීරණ ගැනීමට භාවිත කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1318,8 +1323,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය විසිනි, ඒවා ඔබව පැතිකඩ "
-"කිරීමට භාවිතා නොකෙරේ."
+"දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoft හි දැන්වීම් ජාලය "
+"විසිනි, ඒවා ඔබව පැතිකඩ කිරීමට භාවිතා නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1390,7 +1395,8 @@ msgstr "DuckDuckGo දිගුව එක් කරන්න"
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
 msgstr ""
-"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් කරන්න:"
+"එක් බාගැනීමකින් DuckDuckGo Privacy Essentials ඔබේ බ්‍රවුසරය වෙත නොමිලේ එක් "
+"කරන්න:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1667,7 +1673,8 @@ msgctxt ""
 msgid ""
 "Advanced models can reach usage limits 2–5x sooner than other models. %s"
 msgstr ""
-"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය හැක. %1$s"
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2–5 ගුණයක් වේගයෙන් පරිශීලන සීමාවලට ළඟා විය "
+"හැක. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the model picker warning that advanced models consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Advanced models can use limits 2-5x faster than other models. <a>Learn More</a>'.
@@ -1675,7 +1682,9 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. %1$s"
+msgstr ""
+"උසස් ආකෘති අනෙකුත් ආකෘතිවලට වඩා 2-5 ගුණයකින් වේගයෙන් සීමාවන් භාවිතා කළ හැක. "
+"%1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -1853,8 +1862,8 @@ msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
-"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo හෝ ආකෘති "
-"සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
+"සියලුම කතාබස් DuckDuckGo විසින් නිර්නාමික කර ඇති අතර, ඔබේ සංවාද DuckDuckGo "
+"හෝ ආකෘති සැපයුම්කරුවන් විසින් චැට් ආකෘති පුහුණු කිරීමට භාවිත කරනු නොලැබේ"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1907,8 +1916,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, ඔබගේ IP ලිපිනය) "
-"ඉවත් කරනු ලැබේ."
+"AI සැපයුම්කරුට කතාබහක් යැවීමට පෙර සියලුම පුද්ගලික පාර-දත්ත (උදාහරණයක් ලෙස, "
+"ඔබගේ IP ලිපිනය) ඉවත් කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1947,7 +1956,8 @@ msgctxt "voice chat"
 msgid ""
 "Allow DuckDuckGo microphone access in System Settings to use voice chat."
 msgstr ""
-"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය ලබා දෙන්න."
+"හඬ කතාබස් භාවිතා කිරීමට පද්ධති සැකසීම් තුළ DuckDuckGo මයික්‍රෆෝනයට ප්‍රවේශය "
+"ලබා දෙන්න."
 
 # smartling.placeholder_format=C
 #. Tells users which icon to press in their browser. Part of a list of instructions on how to enable location service.
@@ -1979,9 +1989,10 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ දෙයි. සීමිත දත්ත "
-"රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් පමණක් යවයි. %2$s සහිත විමසීම් සහ "
-"ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
+"අදාළ විමසීම්වලට ප්‍රතිචාර වැඩි දියුණු කිරීම සඳහා වෙබයේ සෙවීමට %1$s හට ඉඩ "
+"දෙයි. සීමිත දත්ත රඳවා ගැනීමක් සහිත සෙවුම් යන්ත්‍රයකට AI-ජනනය කරන ලද විමසුම් "
+"පමණක් යවයි. %2$s සහිත විමසීම් සහ ප්‍රතිචාර වලට තවමත් %3$sසැපයුම්කරුගේ "
+"දෘශ්‍යතාව ශුන්‍ය වේ%4$s."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -1989,7 +2000,8 @@ msgid ""
 "Allows Cloud Save key to be stored locally on device (required to use Cloud "
 "Save)"
 msgstr ""
-"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට අවශ්‍ය වේ)"
+"Cloud Save යතුර උපාංගයේ දේශීයව ගබඩා කිරීමට ඉඩ දෙයි (Cloud Save භාවිතා කිරීමට "
+"අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. Pending title indicating near completion.
@@ -2127,7 +2139,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2136,7 +2149,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා නිර්නාමික ප්රවේශය."
+"%1$s, %2$s සහ විවෘත මූලාශ්ර %3$s සහ %4$sඇතුළු ජනප්රිය AI ආකෘති සඳහා "
+"නිර්නාමික ප්රවේශය."
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2150,8 +2164,9 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. එය කොපමණ වාර ගණනක් "
-"පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම අක්‍රිය කරන්න."
+"වෙබ් අන්තර්ගතය මත පදනම්ව සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරයි. "
+"එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරන්න, නැතහොත් එය සම්පූර්ණයෙන්ම "
+"අක්‍රිය කරන්න."
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2198,8 +2213,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම විටම කරුණු "
-"මට කියන්න"
+"Duck.ai අනුගමනය කිරීමට ඔයාට අවශ්‍ය ඕනෑම අමතර උපදෙසක්. උදා. තාරාවන් ගැන හැම "
+"විටම කරුණු මට කියන්න"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2326,7 +2341,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, සියලුම කතා මකා දමනු ඇත."
+"ඔබට ඉතිහාසය අක්‍රිය කිරීමට අවශ්‍ය බව විශ්වාසද? මෙය පින් කළ කතා ඇතුළුව, "
+"සියලුම කතා මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2335,8 +2351,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද ඕනෑම මෑත "
-"කාලීන කතාබස් ද මකා දමනු ඇත."
+"ඔබට මෑත කාලීන කතාබස් අක්‍රිය කළ යුතු බවට ඔබට විශ්වාස ද? මෙය දැනට සුරකින ලද "
+"ඕනෑම මෑත කාලීන කතාබස් ද මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2374,8 +2390,9 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම රැස්කර හෝ හුවමාරුකර "
-"නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු වේ."
+"අපගේ රහස්‍යතා ප්‍රතිපත්තියට අනුව, අපි කිසිදු පෞද්ගලික තොරතුරක් අප විසින්ම "
+"රැස්කර හෝ හුවමාරුකර නොගන්නෙමු. මෙම සියලු රහස්‍යතා ආරක්ෂාව ඔබගේ උපාංගයේ සිදු "
+"වේ."
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2517,12 +2534,14 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා AI-සහය සහිත "
-"පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් Assist පෙනී සිටීමට අවශ්‍ය දැ යි "
-"ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම "
-"මත (ඔබ Assist බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
-"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
-"පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
+"Assist යනු අදාළ වෙබ් අන්තර්ගතය සාරාංශ කිරීම මත පදනම්ව සමහර සෙවුම් සඳහා "
+"AI-සහය සහිත පිළිතුරු නිර්නාමිකව ජනනය කළ හැකි සේවාවකි. ඔබට කොපමණ වාරයක් "
+"Assist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් (සෙවුම් "
+"ප්‍රතිඵලවලින් Assist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), ඉල්ලුම මත (ඔබ Assist "
+"බොත්තම ක්ලික් කළහොත් AI-සහාය සහිත පිළිතුරු පමණක් පෙන්වයි), සමහර විට (ඉහළ "
+"අදාළ වන විට AI-සහය සහිත පිළිතුරු පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක "
+"සෙවුම් මත නිතර පෙන්වයි). දැනට, AI සහය සහිත පිළිතුරු ලබා ගත හැක්කේ එක්සත් "
+"ජනපද (ඉංග්‍රීසි) කලාපයේ පමණි."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2534,11 +2553,12 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් විමසුම් "
-"සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා "
-"වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-"
-"බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව "
-"ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"Assist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති විකල්ප විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා AI සහය සහිත පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු "
+"කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ "
+"තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිත කරයි. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
+"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2564,8 +2584,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය ගුප්ත කේතනය "
-"කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
+"DuckDuckGo VPN මගින් අවන්හලක, ගුවන් තොටුපළක හෝ හෝටලයක දී, ඔබේ සම්බන්ධතාවය "
+"ගුප්ත කේතනය කර Wi-Fi මත ඔබේ IP ලිපිනය සඟවයි."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2686,7 +2706,9 @@ msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදන
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid ""
 "Auto-generated based on listed sources. Responses may contain inaccuracies."
-msgstr "ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් තිබිය හැක."
+msgstr ""
+"ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වේ. ප්‍රතිචාරවල සාවද්‍ය තැන් "
+"තිබිය හැක."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI) on mobile
@@ -2711,9 +2733,9 @@ msgid ""
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර "
-"වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල "
-"පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව Assist පෙන්වයි. Assist හට නිර්නාමිකව සමහර "
+"සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, Assist "
+"ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2722,15 +2744,17 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව සමහර සෙවීම් "
-"වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, DuckAssist ලබා ගත "
-"හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
+"අදාළ සෙවීම් සඳහා ස්වයංක්‍රීයව DuckAssist පෙන්වයි. DuckAssist හට නිර්නාමිකව "
+"සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ හැක. දැනට, "
+"DuckAssist ලබා ගත හැක්කේ ඉංග්‍රීසි කලාපවල පමණි."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Autoplay short, silent video previews when you hover over video results."
-msgstr "ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව ධාවනය කරන්න."
+msgstr ""
+"ඔබ වීඩියෝ ප්‍රතිඵල මත සැරිසරන විට කෙටි, නිහඬ වීඩියෝ පෙරදසුන් ස්වයංක්‍රීයව "
+"ධාවනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Title for the menu listing free/degraded models available after the advanced-model usage limit has been reached.
@@ -2930,8 +2954,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත "
-"වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් නම්, ඊමේල් ලිපින සහ හඳුනාගත "
+"හැකි පාරදත්ත වැනි PII ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2944,6 +2968,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"මෙම වාර්තාව ගබඩා කිරීමට පෙර, DuckDuckGo විසින් උඩුගත කළ ගොනු සහ ජනනය කළ "
+"පින්තූර ඉවත් කරනු ඇති අතර, නම්, ඊමේල් ලිපින සහ හඳුනාගත හැකි පාරදත්ත වැනි PII "
+"ඉවත් කිරීම මගින් ඔබගේ සංවාදය නිර්නාමික කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3073,8 +3100,8 @@ msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
 msgstr ""
-"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය සමඟ තවත් වාරික "
-"ආරක්ෂණ ලබා ගන්න."
+"හානිකර වෙබ් අඩවි අවහිර කරන්න, ඔබේ IP ලිපිනය සඟවන්න, තව ද අපගේ ග්‍රාහකත්වය "
+"සමඟ තවත් වාරික ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3334,16 +3361,18 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
+"අපි රහස්‍යතා ආරක්ෂාව එක් කරන තුරු සාමාන්‍ය පරිදි බ්‍රවුස් කරන්න. අපි අපේ "
+"සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරය හා ගුප්ත කේතන බලාත්කුරුව එක් %1$s%2$s "
+"දිගුවක්%3$s වෙත ගොනු කර ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
-"අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. අපි අපේ සෙවුම් "
+"යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය හා ගුප්ත කේතන බලාත්කාරකය එක් %1$s%2$s "
+"දිගුවක%3$sට සම්පිණ්ඩනය කළෙමු."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3351,8 +3380,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන බ්‍රවුසර්%2$s සඳහා පුද්ගලික "
-"සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
+"සාමාන්‍ය පරිදි බ්‍රවුස්කරන්න, අපි අනික්වා ගැන බලා ගන්නෙමු. %1$sප්‍රධාන "
+"බ්‍රවුසර්%2$s සඳහා පුද්ගලික සෙවුම, නිරික්සුව අවහිර කිරීම හා අඩවි ගුප්ත කේතනය "
+"යන සියල්ල එකම බාගැනීමකින් ලබාගන්න."
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3459,10 +3489,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ බ්‍රව්සරයේ). ඔබේ සැකසීම් "
-"වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති "
-"දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි "
-"විටෙකත් ඔබගේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"පෙරනිමියෙන් සැකසීම් පුද්ගලික නොවන බ්‍රව්සර් කුකීස් තුළ ගබඩා කර ඇත (ඔබගේ "
+"බ්‍රව්සරයේ). ඔබේ සැකසීම් වඩාත් ස්ථිර ආකාරයකින් ගබඩා කිරීමට ඔබට නිර්ණාමික "
+"Cloud Save භාවිතා කළ හැකිය (ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක). පුද්ගලිකව හඳුනාගත "
+"හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර ඔබගේ මුර පදය කිසි විටෙකත් ඔබගේ "
+"බ්‍රව්සරයෙන් ඉවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
@@ -3470,8 +3501,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"කියවන විට ලිවීම සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔබගේ හඬ "
+"දත්ත OpenAI වෙත යැවීමට ඔබ එකඟ වෙයි. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3480,8 +3511,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත OpenAI වෙත "
-"යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
+"හඬ කතාබස් සක්‍රීය කිරීමෙන්, මෙම විශේෂාංගය භාවිතා කිරීම සඳහා ඔයාගේ හඬ දත්ත "
+"OpenAI වෙත යැවීමට ඔයා එකඟ වෙනවා. ආරම්භ කිරීමට පෙර අපේ %1$s බලන්න."
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3516,7 +3547,9 @@ msgstr "කැමරූන්"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ හැකිද?"
+msgstr ""
+"කුකුළු මස්, බ්‍රොකොලි සහ සහල් භාවිත කරමින් සරල වට්ටෝරු කිහිපයක් නිර්මාණය කළ "
+"හැකිද?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -3979,11 +4012,11 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික සංවාද "
-"කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. මෙම සැකසුම අක්‍රිය "
-"කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම "
-"ක්‍රියා විරහිත වූ විට ඔබට තවමත් %1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත "
-"ප්‍රවේශ විය හැකිය."
+"චැට් (අපගේ Duck.ai සේවාව හරහා) ඔබට 3 වන පාර්ශවයේ AI චැට් ආකෘති සමඟ නිර්නාමික "
+"සංවාද කිරීමට ඉඩ සලසයි, එය OpenAI, Anthropic සහ තවත් ආකෘති සඳහා සහය දක්වයි. "
+"මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි චැට් බොත්තම් සහ සබැඳි සඟවනු "
+"ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විට ඔබට තවමත් "
+"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් සෘජුව චැට් වෙත ප්‍රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4039,7 +4072,8 @@ msgstr "පෞද්ගලිකව චැට් කරන්න"
 msgctxt "Promotional text (mobile)"
 msgid "Chat privately on any website with Duck.ai built into our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්රවුසරයේ ඇති Duck.ai සමඟ ඕනෑම වෙබ් අඩවියක පෞද්ගලිකව කතාබහේ "
+"යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
@@ -4047,8 +4081,8 @@ msgctxt "Promotional text"
 msgid ""
 "Chat privately on any website with the Duck.ai sidebar in our free browser."
 msgstr ""
-"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක පුද්ගලිකව කතාබහේ "
-"යෙදෙන්න."
+"අපගේ ගාස්තු රහිත බ්‍රවුසරයේ ඇති Duck.ai පැති තීරුව සමඟ ඕනෑම වෙබ් අඩවියක "
+"පුද්ගලිකව කතාබහේ යෙදෙන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder text used in chat input for user’s messages. Example: 'Chat with GPT-3'
@@ -4129,8 +4163,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"කතාබස් DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
-"හැර වෙන කිසිවෙකුට, අපට පවා, ඔබගේ දත්ත දැකිය නොහැක."
+"කතාබස් DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර "
+"ඇත. ඔබට හැර වෙන කිසිවෙකුට, අපට පවා, ඔබගේ දත්ත දැකිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4139,8 +4173,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් ගබඩා කර ඇත. "
-"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
+"ඔබේ උපාංගයේ DuckDuckGo සර්වර හෝ වෙනත් දුරස්ථ සර්වර මත වෙනුවට දේශීයව චැට් "
+"ගබඩා කර ඇත. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මකා දැමෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4152,10 +4186,11 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් "
-"නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ "
-"කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ. "
+"කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ "
+"ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4178,8 +4213,9 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන සියලුම ගොනු "
-"%2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව සමාලෝචනය කරනු ලැබේ."
+"%1$s සමඟ කතාබස්වලට සැපයුම්කරු දෘශ්‍යතාව නොමැත, නමුත් Duck.ai වෙත උඩුගත කරන "
+"සියලුම ගොනු %2$s සඳහා අන්තර්ගත මධ්‍යස්ථකරණ සැපයුම්කරුවෙකු විසින් නිර්නාමිකව "
+"සමාලෝචනය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4187,8 +4223,8 @@ msgctxt "Sync file storage inline disclaimer body"
 msgid ""
 "Chats with attachments have stopped syncing. Free up storage to resume Sync."
 msgstr ""
-"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට ගබඩාවේ ඉඩ නිදහස් "
-"කරගන්න."
+"ඇමුණුම් සහිත කතාබස් සමමුහුර්ත වීම නැවතී ඇත. සමමුහුර්ත වීම නැවත ආරම්භ කිරීමට "
+"ගබඩාවේ ඉඩ නිදහස් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Message shown when we have no data from upstream to display
@@ -4344,8 +4380,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන 40කට වඩා වැඩි "
-"ගණනකින් තෝරා ගන්න."
+"හානිකර අඩවි සහ වංචා අවහිර කිරීමට උපකාරී වන ලොව පුරා පවතින සේවාදායක ස්ථාන "
+"40කට වඩා වැඩි ගණනකින් තෝරා ගන්න."
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4362,7 +4398,9 @@ msgstr "සේවාවක් තෝරන්න"
 msgctxt "settings"
 msgid ""
 "Choose which app to use when you need directions for a location search result"
-msgstr "ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම තෝරන්න"
+msgstr ""
+"ඔබට ස්ථාන සෙවුම් ප්‍රතිඵලයක් සඳහා උපදෙස් අවශ්‍ය විට භාවිත කළ යුතු යෙදුම "
+"තෝරන්න"
 
 # smartling.placeholder_format=C
 #. Accessible label for the citations popover dialog in Duck.ai chat responses.
@@ -4543,9 +4581,9 @@ msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන කතාබස් කාලය "
-"නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා ස්වයංක්‍රීයව මකා දැමිය හැකි "
-"ය."
+"බ්‍රවුසර දත්ත මකා දැමීමෙන් කතාබස් මකා දමනු ලැබේ. සමහර බ්‍රවුසර මෑත කාලීන "
+"කතාබස් කාලය නොසලකා තබා ගන්නා හෝ AI Chat භාවිත නොකිරීමෙන් දින 7කට පසු ඒවා "
+"ස්වයංක්‍රීයව මකා දැමිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4555,8 +4593,9 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, ඔබේ "
-"බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ ස්වයංක්‍රීයව මකා දැමිය හැකිය."
+"බ්‍රවුසර දත්ත මකා දැමීම මෑත කතාබස් මකා දමයි. Duck.ai භාවිත නොකර දින 7කට පසු, "
+"ඔබේ බ්‍රව්සරය මත පදනම්ව මෑත කතාබස් දින නියමයක් නොමැතිව සුරැකීමට හෝ "
+"ස්වයංක්‍රීයව මකා දැමිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4565,8 +4604,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ අවහිර ලැයිස්තුව අපගේ "
-"ගාස්තු රහිත බ්‍රවුසරයේ"
+"බ්රව්සර් දත්ත ඉවත් කිරීමෙන් ඔබගේ අවහිර කරන ලද වෙබ් අඩවි යළි සැකසේ. ඔබගේ "
+"අවහිර ලැයිස්තුව අපගේ ගාස්තු රහිත බ්‍රවුසරයේ"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4575,9 +4614,9 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ %1$sDuck.ai%2$s "
-"හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ ආයතනවලින් චැට් ආකෘතිවලට සහය "
-"දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
+"මාතෘකාවක් පිළිබඳව වැඩිදුරටත් විමසා බලන්න \"තවත්\" මත ක්ලික් කරන්න, සහ "
+"%1$sDuck.ai%2$s හරහා පසු විපරම් ප්‍රශ්න අසන්න OpenAI, Anthropic සහ තවත් බොහෝ "
+"ආයතනවලින් චැට් ආකෘතිවලට සහය දක්වන අපගේ පෞද්ගලික AI චැට් සේවය."
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4651,8 +4690,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ දකුණු පස "
-"%3$sgears icon%4$s මත ක්ලික් කරන්න)"
+"ඉහළ මෙනුවෙන් %1$sSafari%2$s මත ක්ලික් කරන්න (වින්ඩෝව්ස් වලදී, ඉහළ මෙනුවේ "
+"දකුණු පස %3$sgears icon%4$s මත ක්ලික් කරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4682,7 +4721,8 @@ msgstr "%1$sYes%2$s කලික් කරන්න"
 #. Tells the user where to click to open their browser's settings menu.
 msgid "Click %ssettings/hamburger icon %s on the Chrome toolbar (top right)."
 msgstr ""
-"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් කරන්න."
+"Chrom උපකරණ කොටුවේ (ඉහළ දකුණ) %1$ssettings/hamburger icon %2$s මත ක්ලික් "
+"කරන්න."
 
 #  Maxthon default search engine instruction
 # smartling.placeholder_format=C
@@ -4744,8 +4784,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4756,8 +4797,9 @@ msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
 msgstr ""
-"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත ඉවත් කරන නමුදු, ඔබ "
-"විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
+"%1$sමගේ දත්ත මකන්න%2$s ක්ලික් කරන්න හෝ තට්ටු කරන්න. මෙය ක්ලවුඩවලින් දත්ත "
+"ඉවත් කරන නමුදු, ඔබ විසින් %3$sසියලුම සැකසුම් යළි පිහිටුවන්න%4$s ක්ලික්/තට්ටු "
+"කරන තෙක් ඔබේ බ්‍රවුසරයේ පවතී."
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4826,8 +4868,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් මෙනුව ක්ලික් කර "
-"%3$sDuckDuckGo%4$s තෝරන්න."
+"ලිපින තීරුව %1$sහි භාවිතා කර ඇති සෙවුම් යන්ත්‍රය%2$s අසල ඇති ඩ්‍රොප් ඩවුන් "
+"මෙනුව ක්ලික් කර %3$sDuckDuckGo%4$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4835,8 +4877,8 @@ msgid ""
 "Click the icon of the ad blocker extension. It's usually in the upper right "
 "hand corner of your browser."
 msgstr ""
-"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ ඉහළ දකුණු කෙළවරේ "
-"තියෙනවා."
+"Ad blocker කිරීමේ දිගුවේ අයිකනය ක්ලික් කරන්න. එය සාමාන්යයෙන් ඔබේ බ්‍රව්සරයේ "
+"ඉහළ දකුණු කෙළවරේ තියෙනවා."
 
 #  Safari default search engine instruction
 # smartling.placeholder_format=C
@@ -5037,8 +5079,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු කිරීමට හැකියාව Cloud "
-"Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
+"මුරවදනක් ඇතුලත් කිරීම මඟින් ඔබගේ සැකසුම් ක්ලව්ඩයේ සුරෑකීම වඩාත් තහවුරු "
+"කිරීමට හැකියාව Cloud Save. එය සම්පූර්ණයෙන්ම ඔබගේ තේරීමකි."
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5310,8 +5352,8 @@ msgstr "දැන්වීම් අවහිර කිරීම දිගටම
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
 msgstr ""
-"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් ඒවා මකා "
-"දමන්න."
+"මෑත කාලීන කතාබස් මෙතැනින් දිගටම කරගෙන යන්න. නැතහොත් Fire Button භාවිතයෙන් "
+"ඒවා මකා දමන්න."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5494,8 +5536,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & Backup › "
-"වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
+"වෙනත් උපාංගයකින් කේතය පිටපත් කරගන්න. %1$sDuck.ai සැකසුම් › කතාබස් › Sync & "
+"Backup › වෙනත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න%2$s වෙත ගොස් නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -5554,7 +5596,8 @@ msgstr "කොස්ටාරිකාව"
 msgctxt "Error message when the recovery code fails to generate"
 msgid "Couldn't load your recovery code. Please close this and try again."
 msgstr ""
-"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ කරන්න."
+"ඔබේ ප් රතිසාධන කේතය පූරණය කළ නොහැකි විය. කරුණාකර මෙය වසා දාලා නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Pairs with a Retry button. Shown after two consecutive failed attempts to load the device list.
@@ -5669,7 +5712,8 @@ msgid ""
 "Creating a link makes a copy of the chat that can be viewed by anyone who "
 "opens it."
 msgstr ""
-"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය බැලිය හැකිය."
+"සබැඳියක් සෑදීමෙන් කතාබස්හි පිටපතක් සෑදෙන අතර, එය විවෘත කරන ඕනෑම අයෙකුට එය "
+"බැලිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Label below a video that's available under the Creative Commons license.
@@ -5915,7 +5959,8 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Daily usage limit reached. You can keep chatting by using your weekly limit."
 msgstr ""
-"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් කරගෙන යා හැකිය."
+"දෛනික පරිශීලන සීමාවට ළඟා විය. ඔබට ඔබේ සතිපතා සීමාව භාවිතා කරමින් කතාබස් "
+"කරගෙන යා හැකිය."
 
 # smartling.placeholder_format=C
 #. The name of the Danish language
@@ -6232,8 +6277,8 @@ msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
 msgstr ""
-"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ කතාබස් වෙත එක් කර ඇති "
-"පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
+"සබැඳියක් මකා දැමීමෙන් එය ක්‍රියා කිරීම නවත්වයි. සංවාදය විවෘත කර ඔවුන්ගේ "
+"කතාබස් වෙත එක් කර ඇති පුද්ගලයින් ඔවුන්ගේම පිටපතක් තබා ගනු ඇත."
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6330,8 +6375,8 @@ msgstr "Duck.ai අසා ලිවීම"
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
 msgstr ""
-"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට කිසිවිටෙකත් භාවිතා කරනු "
-"නොලැබේ."
+"කියවන විට ලිවීම අප විසින් නිර්නාමික කර ඇති අතර, එය AI ආකෘති පුහුණු කිරීමට "
+"කිසිවිටෙකත් භාවිතා කරනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6349,8 +6394,8 @@ msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
 msgstr ""
-"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා කරන බැවින්, "
-"ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
+"කථනය පාඨ බවට පරිවර්තනය කිරීම සඳහා “කියවන විට ලිවීම“ OpenAI ආකෘතියක් භාවිතා "
+"කරන බැවින්, ටයිප් නොකර Duck.ai මත කතාබස් කිරීමට ඔබට පුළුවන."
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6483,7 +6528,7 @@ msgstr "මූලාශ්‍රය අකමැති වීම"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "දෘශ්‍ය විලාසයට අකැමැති වීම"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6599,7 +6644,7 @@ msgstr "ජිබූටි"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "උපදෙස් අනුගමනය නොකිරීම"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6687,8 +6732,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන අතර AI-"
-"ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s කිසිදු AI විශේෂාංග ලබා නොදෙන "
+"අතර AI-ජනනය කරන ලද රූප පෙරහන් කරයි. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6697,8 +6742,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ AI රූප "
-"පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI අවශ්‍ය නැද්ද? %1$snoai.duckduckgo.com%2$s වෙත යන්න AI විශේෂාංග නොමැතිව සහ "
+"AI රූප පෙරහන් කර සෙවීම සඳහා. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6814,8 +6859,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for "
 "ceiling fan repair services."
 msgstr ""
-"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"සිවිලිම් විදුලි පංකා අළුත්වැඩියා සේවා සඳහා උපුටා දැක්වීමක් ඉල්ලා සිටින "
+"විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion asking for an email draft to a vendor requesting a quote for home refrigerator repair services.
@@ -6824,8 +6869,8 @@ msgid ""
 "Draft a concise and detailed email to a vendor requesting a quote for home "
 "refrigerator repair services."
 msgstr ""
-"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට සංක්ෂිප්ත හා "
-"සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
+"ගෘහ ශීතකරණ අළුත්වැඩියා සේවා සඳහා මිල කැඳවීමක් ඉල්ලා සිටින විකුණුම්කරුවෙකුට "
+"සංක්ෂිප්ත හා සවිස්තරාත්මක විද්‍යුත් තැපෑලක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Draft a cover letter", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -6846,8 +6891,8 @@ msgid ""
 "Draft a few options for a social media post inviting people to my upcoming "
 "party."
 msgstr ""
-"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප කිහිපයක් කෙටුම්පත් "
-"කරන්න."
+"මගේ ඉදිරි සාදයට පුද්ගලයන්ට ආරාධනා කරන සමාජ මාධ්‍ය පළ කිරීමක් සඳහා විකල්ප "
+"කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for drafting a few options for a blog post title about strategies to increase team collaboration.
@@ -6856,8 +6901,8 @@ msgid ""
 "Draft a few options for a title of a post I’m writing about strategies to "
 "increase team collaboration."
 msgstr ""
-"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් සඳහා විකල්ප "
-"කිහිපයක් කෙටුම්පත් කරන්න."
+"කණ්ඩායම් සහයෝගීතාව වැඩි කිරීම සඳහා උපාය මාර්ග ගැන මම ලියන තනතුරක මාතෘකාවක් "
+"සඳහා විකල්ප කිහිපයක් කෙටුම්පත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for drafting a social media post.
@@ -6989,8 +7034,9 @@ msgid ""
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
 msgstr ""
-"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. සැකසුම් තුළ පිටු "
-"ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
+"ඔබ නරඹන පිටුව පිළිබඳ ප්‍රශ්නවලට පිළිතුරු දීමට Duck.ai හට දැන් උදව් කළ හැක. "
+"සැකසුම් තුළ පිටු ස්වයංක්‍රීයව ඇමිණීමට ඔබ තෝරා නොගන්නේ නම්, පිටු අන්තර්ගතය "
+"ඇතුළත් වන්නේ ඔබ එය අමුණන විට පමණි."
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7000,8 +7046,9 @@ msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
 msgstr ""
-"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ බ්‍රවුසර "
-"සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය කර නැවත උත්සාහ කරන්න."
+"ඔබගේ කතාබස් සුරැකීම සඳහා Duck.ai දේශීය ගබඩාවට පිවිසිය නොහැක. කරුණාකර ඔබගේ "
+"බ්‍රවුසර සැකසුම් පරීක්ෂා කරන්න, නැතහොත් කිනම් හෝ දිගුවක් වේ නම්, එය අක්‍රිය "
+"කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7010,8 +7057,8 @@ msgid ""
 "Duck.ai has reached the maximum number of messages for one day. Please "
 "continue this chat tomorrow."
 msgstr ""
-"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම "
-"කරගෙන යන්න."
+"Duck.ai එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම "
+"කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
@@ -7027,9 +7074,9 @@ msgid ""
 "company for anyone who wants to take back control of their personal "
 "information."
 msgstr ""
-"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය නැවතත් සියතට "
-"ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන ස්වාධීන සමාගමක් ලෙස අපි "
-"කටයුතු කරමු."
+"Duck.ai නිර්මාණය කර ඇත්තේ DuckDuckGo විසිනි. තම පුද්ගලික තොරතූරුවල පාලනය "
+"නැවතත් සියතට ගැනීමට උවමනා ඔ්නෑම අයකු සඳහා සේවය කරන අන්තර්ජාල ආරක්ෂාව සලසන "
+"ස්වාධීන සමාගමක් ලෙස අපි කටයුතු කරමු."
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -7044,8 +7091,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් පිටුවක් සමගින් "
-"අන්තර්ජාලයේ: https://duck.ai"
+"Duck.ai තවමත් DuckDuckGo නිෂ්පාදනයක්, නමුත් දැන් මතක තබා ගැනීමට පහසු මුල් "
+"පිටුවක් සමගින් අන්තර්ජාලයේ: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7060,8 +7107,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s නිර්නාමික "
-"කේතය %2$s වෙත ඊමේල් කරන්න"
+"Duck.ai තාවකාලිකව ලබා ගත නොහැක. මෙය දිගටම පවතින්නේ නම්, කරුණාකර මෙම %1$s "
+"නිර්නාමික කේතය %2$s වෙත ඊමේල් කරන්න"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7082,9 +7129,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. එය අක්‍රිය "
-"කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව ම %1$sduck.ai%2$s වෙත "
-"පිවිසිය හැකි ය."
+"Duck.ai මගින් ඔබට ජනප්‍රිය AI ආකෘති සමඟ පෞද්ගලිකව කතාබස් කිරීමට ඉඩ ලබා දේ. "
+"එය අක්‍රිය කිරීමෙන් Duck.ai බොත්තම් සහ සබැඳි සැඟවෙනු ඇති නමුත් ඔබට තවමත්ඍජුව "
+"ම %1$sduck.ai%2$s වෙත පිවිසිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7095,10 +7142,11 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI චැට් ආකෘති "
-"සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය කිරීමෙන් DuckDuckGo Search හි "
-"Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට "
-"%1$shttps://duck.ai%2$s වෙත පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
+"Duck.ai මඟින් OpenAI, Anthropic සහ වෙනත් අයගේ ආකෘති ඇතුළුව 3වන පාර්ශවීය AI "
+"චැට් ආකෘති සමඟ නිර්නාමික සංවාද කිරීමට ඔබට ඉඩ සලසයි. මෙම සැකසුම අක්‍රිය "
+"කිරීමෙන් DuckDuckGo Search හි Duck.ai බොත්තම් සහ සබැඳි සඟවනු ඇත. කෙසේ වෙතත්, "
+"මෙම සැකසුම ක්‍රියා විරහිත වූ විටත් ඔබට %1$shttps://duck.ai%2$s වෙත "
+"පිවිසීමෙන් Duck.ai වෙත ප්‍රවේශ විය හැක හැකිය."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7113,8 +7161,8 @@ msgid ""
 "Duck.ai might have lost your recent chats. You can still use Duck.ai as "
 "usual."
 msgstr ""
-"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai භාවිතා "
-"කරන්න පුළුවන්."
+"Duck.ai තුළ ඔබේ මෑත කතාබස් නොතිබීමට ඉඩ ඇත. ඔයාට තවමත් සාමාන්‍ය පරිදි Duck.ai "
+"භාවිතා කරන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7128,7 +7176,8 @@ msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
 msgstr ""
-"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා පරීක්ෂා කර නැත."
+"Duck.ai ප්‍රතිචාර විශේෂිත මූලාශ්‍ර මත පදනම් නොවී ඇත හෝ නිරවද්‍යතාව සඳහා "
+"පරීක්ෂා කර නැත."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7162,9 +7211,10 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI කතාබහ, "
-"ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, විවෘත මූලාශ්‍ර AI "
-"ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI කතාබස්"
+"Duck.ai, DuckDuckGo AI, පුද්ගලික AI චැට්බොට්, නොමිලේ AI කතාබස්, නිර්නාමික AI "
+"කතාබහ, ලියාපදිංචි වීමක් නොමැති AI කතාබස්, OpenAI, Anthropic, Llama, Mistral, "
+"විවෘත මූලාශ්‍ර AI ආකෘති, පෞද්ගලිකත්වය කේන්ද්‍ර කරගත් AI, ගිණුමක් නොමැති AI "
+"කතාබස්"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7192,12 +7242,13 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා සාරාංශගත කළ "
-"හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා ගත හැකිය: කිසි විටෙකත් "
-"(සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම "
-"ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට (ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත නිතර නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද "
-"(ඉංග්‍රීසි) කලාපයේ පමණි."
+"DuckAssist හට නිර්නාමිකව සමහර සෙවීම් වලට ප්‍රතිචාර වශයෙන් තොරතුරු සොයා බලා "
+"සාරාංශගත කළ හැක. කොපමණ වාරයක් DuckAssist පෙනී සිටීමට අවශ්‍ය දැ යි ඔබට තෝරා "
+"ගත හැකිය: කිසි විටෙකත් (සෙවුම් ප්‍රතිඵලවලින් DuckAssist UI සම්පූර්ණයෙන්ම "
+"ඉවත් කරයි), On-demand (ඔබ සහාය බොත්තම ක්ලික් කළහොත් පමණක් පෙන්වයි), සමහර විට "
+"(ඉතා අදාළ වන විට පමණක් පෙන්වයි), හෝ බොහෝ විට (පුළුල් පරාසයක සෙවුම් මත නිතර "
+"නිතර පෙන්වයි). දැනට, DuckAssist ලබා ගත හැක්කේ එක්සත් ජනපද (ඉංග්‍රීසි) කලාපයේ "
+"පමණි."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7206,9 +7257,10 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි %1$sDuckDuckGo AI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"%1$sDuckDuckGo AI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7217,9 +7269,10 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි DuckDuckGo %1$sAI "
-"Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic වෙතින් වන චැට් ආකෘති සඳහා සහය "
-"දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් සේවාවක් වේ."
+"DuckAssist ට පසුවිපරම් ප්‍රශ්නවලට පිළිතුරු දිය නොහැක, කෙසේ වෙතත්, අපි "
+"DuckDuckGo %1$sAI Chat%2$s සේවය ද ලබා දෙන්නෙමු, එය OpenAI සහ Anthropic "
+"වෙතින් වන චැට් ආකෘති සඳහා සහය දක්වන පෞද්ගලික AI බලයෙන් ක්‍රියාත්මක වන චැට් "
+"සේවාවක් වේ."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7231,11 +7284,12 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව "
-"සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් "
-"ක්‍රියාත්මක වන ස්වාභාවික භාෂා තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ "
-"අන්තර්ගතයන් මත පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා විකිපීඩියාව සහ ඒ ආශ්‍රිත අඩවි පිරික්සන අතර පසුව එම "
+"තොරතුරු වල සාරාංශයක් ජනනය කිරීම සඳහා AI බලයෙන් ක්‍රියාත්මක වන ස්වාභාවික භාෂා "
+"තාක්ෂණය භාවිතා කරයි. එහි ප්‍රතිචාර දැනට විකිපීඩියාව සහ අදාළ අන්තර්ගතයන් මත "
+"පදනම් වී ඇති අතර නිරවද්‍යතාව සඳහා පරීක්ෂා කර නොමැති බව කරුණාවෙන් සලකන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7249,13 +7303,15 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට නිර්නාමික ව සෙවුම් "
-"විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් "
-"කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති "
-"ස්වාභාවික භාෂා තාක්ෂණය භාවිත කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට "
-"සෘජුවම සම්බන්ධ වන අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
-"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් ස්වයංක්රීයව ජනනය වන "
-"අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම වැදගත්ය."
+"DuckAssist යනු අපගේ සෙවුම් ප්‍රතිඵලවල ඇති නව විශේෂාංගයක් වන අතර එයට "
+"නිර්නාමික ව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කළ හැකිය. මෙය සිදු කිරීම සඳහා, "
+"එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව සොයාගත් අදාළ තොරතුරු මත "
+"පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI-බලැති ස්වාභාවික භාෂා තාක්ෂණය භාවිත "
+"කරයි. DuckAssist ප්‍රතිචාර සෑම විටම මූලාශ්‍ර එකකට හෝ දෙකකට සෘජුවම සම්බන්ධ වන "
+"අතර, පිළිතුර පැමිණි ස්ථානය උපුටා දක්වයි, එබැවින් ඔබට පහසුවෙන් ගොස් වඩාත් "
+"සවිස්තරාත්මක තොරතුරු ලබා ගත හැකිය. ප්රතිචාර උපුටා දක්වන ලද මූලාශ්රවලින් "
+"ස්වයංක්රීයව ජනනය වන අතර %1$sවෙබ් කැටි ගැසීම%2$s මත පදනම් වන බව මතක තබා ගැනීම "
+"වැදගත්ය."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7263,8 +7319,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර නිරවද්‍යතාව සඳහා "
-"පරීක්‍ෂා කර නොමැත."
+"DuckAssist ප්‍රතිචාර ලැයිස්තුගත මූලාශ්‍ර මත පදනම්ව ස්වයංක්‍රීයව ජනනය වන අතර "
+"නිරවද්‍යතාව සඳහා පරීක්‍ෂා කර නොමැත."
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7273,8 +7329,8 @@ msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
 msgstr ""
-"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට මෙම "
-"කතාබස් දිගටම කරගෙන යන්න."
+"DuckDuckGo AI Chat එක දවසකට උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වෙලා ඇත. කරුණාකර හෙට "
+"මෙම කතාබස් දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7283,8 +7339,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7293,8 +7349,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s සහ %3$s "
-"%4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
+"DuckDuckGo AI Chat පුද්ගලික AI බලැති චැට් සේවාවක් වන අතර එය දැනට %1$s %2$s "
+"සහ %3$s %4$s චැට් මාදිලි සඳහා සහාය දක්වයි."
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7320,7 +7376,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ කරන්න."
+msgstr ""
+"DuckDuckGo AI Chat තාවකාලිකව නොමැත. කරුණාකර පිටුව නැවුම් කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7476,8 +7534,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත වැනි PII "
-"ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
+"DuckDuckGo නම, විද්‍යුත් තැපැල් ලිපින, දුරකථන අංක සහ හඳුනාගත හැකි පාර-දත්ත "
+"වැනි PII ස්වයංක්‍රීයව ඉවත් කිරීමෙන් මෙම වාර්තා නිර්නාමික කරයි."
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7485,8 +7543,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai %2$s වෙත එකඟ "
-"වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ Duck.ai "
+"%2$s වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7495,7 +7553,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s වෙත එකඟ වෙයි."
+"DuckDuckGo ඔබගේ කතාබස් නිර්නාමික කරයි. '%1$s' ක්ලික් කිරීමෙන් ඔබ අපගේ %2$s "
+"වෙත එකඟ වෙයි."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7504,8 +7563,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල DuckDuckGo ට්‍රැකර් අවහිර "
-"කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය කිරීමට උත්සාහ කරයි."
+"ගූගල් සහ ෆේස්බුක් වැනි සමාගම්වල ට්‍රැකර් ඇතුළු ඔබ පිවිසෙන වෙබ් අඩවි වල "
+"DuckDuckGo ට්‍රැකර් අවහිර කරයි, බොහෝ විට වෙනත් වෙබ් අඩවි වල ඔබව නිරීක්ෂණය "
+"කිරීමට උත්සාහ කරයි."
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7517,11 +7577,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය උපාංගයේ පමණක් "
-"ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ ප්‍රතිඵල වැඩි දියුණු කිරීම "
-"සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ "
-"පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන "
-"ගන්න%2$s."
+"DuckDuckGo සැලසුම අනුව පුද්ගලිකයි. ඔබ ස්ථානය සක්‍රීය කරන විට, එය ඔබේ දේශීය "
+"උපාංගයේ පමණක් ගබඩා වේ. ඔබ සොයන විට, ඔබේ උපාංගය එය අප වෙත යවයි, එම සෙවුමේ "
+"ප්‍රතිඵල වැඩි දියුණු කිරීම සඳහා අපි එය භාවිතා කරමු, පසුව ඔබ නිර්නාමික වන "
+"පරිදි අපි එය වහාම ඉවත දමමු. %1$sඔබේ පුද්ගලිකත්වය ආරක්ෂා කිරීමට අප මෙම "
+"තාක්ෂණය කෙසේ නිර්මාණය කර ඇතිදැයි යන්න තවදුරටත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7541,8 +7601,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල ලබා දීමට "
-"අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
+"DuckDuckGo භාවිතා කරන්නේ ඔබගේ ආසන්න ස්ථානය පමණි. ඔබට වඩා සමීප හොඳ ප්‍රතිඵල "
+"ලබා දීමට අපට අවශ්‍ය වන්නේ එපමණයි. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7634,9 +7694,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු අහඹු වචන "
-"ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 ක් තෝරා ගනිමු, මුරපදය අවම "
-"වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
+"ඔබ මුරපද යෝජනාවක් ඉල්ලා සිටින සෑම අවස්ථාවකම, DuckDuckGo සර්වර වලින් අපට දිගු "
+"අහඹු වචන ලැයිස්තුවක් ලැබේ. බ්‍රව්සරයේ දී, අපි එම ලැයිස්තුවෙන් අහඹු වචන 4-5 "
+"ක් තෝරා ගනිමු, මුරපදය අවම වශයෙන් අක්ෂර 18-20 ක් වත් ඇති බව සහතික කරමු."
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7712,7 +7772,9 @@ msgstr "රූපය සංස්කරණය කෙරේ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය කරයි."
+msgstr ""
+"ඔබේ පණිවිඩය සංස්කරණය කිරීමෙන් පහත ප්‍රතිචාරය ඉවත් කර නව ප්‍රතිචාරයක් ජනනය "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7850,8 +7912,8 @@ msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
 msgstr ""
-"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම විටම ඔබේ අදහස වෙනස් "
-"කළ හැකිය."
+"වඩාත් නිවැරදි ප්‍රතිඵල සඳහා නිර්නාමික ස්ථානය සක්‍රීය කරන්න. ඔබට පසුව සෑම "
+"විටම ඔබේ අදහස වෙනස් කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -7862,7 +7924,9 @@ msgstr "Duck.ai මත අසා ලිවීම සක් රීය කරන�
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය කරන්න"
+msgstr ""
+"නිර්නාමික පිහිටීම භාවිතා කිරීම සඳහා ඔබේ උපාංගය මත පිහිටීම් සැකසුම් සක්‍රිය "
+"කරන්න"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -7894,8 +7958,8 @@ msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
 msgstr ""
-"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් තවමත් ඔබේ සෙවුම් සහ නිශ්චිත "
-"ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
+"නිර්නාමික ස්ථානය සක්‍රිය කිරීම වඩාත් නිවැරදි ප්‍රතිඵල ලබා දෙන නමුත් ඉන් "
+"තවමත් ඔබේ සෙවුම් සහ නිශ්චිත ස්ථානය DuckDuckGo වෙත පෞද්ගලිකව තබා ගනී."
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -8071,8 +8135,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ නව මුරදය යටතේ "
-"ඔබගේ දත්ත සුරකිනු ඇත."
+"නව මුරපදයක් ඇතුලත් කර %1$sසැකසුම් සුරකින්න%2$s ක්ලික්/තට්ටු කරන්න. මෙය ඔබගේ "
+"නව මුරදය යටතේ ඔබගේ දත්ත සුරකිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8199,7 +8263,9 @@ msgstr "සිතියම පුළුල් කරන්න"
 #. Subtitle for the Collaborations promotional card at the bottom of search results. Describes the branded merchandise line. 'Give a duck' is a wordplay on the DuckDuckGo brand name.
 msgctxt "SERP footer content"
 msgid "Expertly crafted products for people who give a duck about privacy."
-msgstr "පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද නිෂ්පාදන."
+msgstr ""
+"පෞද්ගලිකත්වය ගැන සැලකිල්ලක් දක්වන අය සඳහා විශේෂඥ ලෙස නිර්මාණය කරන ලද "
+"නිෂ්පාදන."
 
 # smartling.placeholder_format=C
 #. Replaces the 'Expires <date>' line once the share has passed its expiry. The link no longer resolves, but the row stays until the user deletes it.
@@ -8287,7 +8353,9 @@ msgstr "මෙය සරලව පැහැදිලි කරන්න"
 #. Prompt sent to the AI when the user taps the "Explain this repo" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Explain what this repository does and how to use it."
-msgstr "මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි කරන්න."
+msgstr ""
+"මෙම සංචිතය කරන්නේ කුමක් ද යන්න සහ එය භාවිතා කරන්නේ කෙසේ ද යන්න පැහැදිලි "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Label to show if song lyrics contain explicit content
@@ -8442,7 +8510,7 @@ msgstr "වේගවත්"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "වේගවත් රූප ජනනය"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8488,7 +8556,9 @@ msgstr "ප්‍රතිපෝෂණය සාර්ථකව යවන ලද
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් බලපායි."
+msgstr ""
+"ඔබේ වැනි ප්‍රතිචාර සෘජුවම අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු "
+"කිරීම් බලපායි."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8497,15 +8567,18 @@ msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
 msgstr ""
-"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් සෘජුවම බලපායි. ඔබ බෙදාගත් "
-"ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම බලාපොරොත්තු වෙමි."
+"ඔබේ වැනි ප්‍රතිචාර අපගේ නිෂ්පාදන යාවත්කාලීන කිරීම් සහ වැඩිදියුණු කිරීම් "
+"සෘජුවම බලපායි. ඔබ බෙදාගත් ගැටලුවටත් අපට විසඳුමක් සොයාගත හැකි යැයි මම "
+"බලාපොරොත්තු වෙමි."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් කරන්න."
+msgstr ""
+"පහත සැකසුම් සකස් කිරීමට නිදහස් වන්න. ඉන්පසු කේතය ඔබේ වෙබ් අඩවියට පිටපත් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8600,7 +8673,8 @@ msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
 msgstr ""
-"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. %1$sවැඩිදුර දැනගන්න%2$s"
+"රූප සෙවුම් ප්‍රතිඵලවලින් දන්නා AI අයාචිත අඩවි පෙරහන් කර ඉවත් කරයි. "
+"%1$sවැඩිදුර දැනගන්න%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8678,7 +8752,9 @@ msgstr "ඔබට සමීප ප්‍රතිඵල සොයා ගන්�
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව පවතී."
+msgstr ""
+"ඔබට අසල ප්‍රතිඵල සොයා ගන්න. %1$sඔබේ ස්ථානය පුද්ගලිකව, ආරක්ෂිතව සහ නිර්නාමිකව "
+"පවතී."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8742,8 +8818,8 @@ msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
 msgstr ""
-"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට මෙනු විකල්පයක් "
-"තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
+"DuckDuckGo සඳහා දැන්වීම් අවහිරකරණය අක්‍රීය කිරීමට උපදෙස් අනුගමනය කරන්න. ඔයාට "
+"මෙනු විකල්පයක් තෝරන්න හෝ බොත්තමක් ක්ලික් කරන්න වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8766,7 +8842,7 @@ msgstr "පසු විපරම් පෞද්ගලිකව පවතී."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "උපදෙස් අනුගමනය කළා"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8984,8 +9060,8 @@ msgid ""
 "strong>."
 msgstr ""
 "Mac හි යෙදුම් මෙනු තීරුවෙන්, <strong>DuckDuckGo</strong> තෝරන්න &gt; "
-"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන ස්ථාපනය "
-"කරන්න</strong> තෝරන්න."
+"<strong>යාවත්කාලීන සඳහා පරීක්ෂා කරන්න...</strong>, ඉන්පසු <strong>යාවත්කාලීන "
+"ස්ථාපනය කරන්න</strong> තෝරන්න."
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9271,8 +9347,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ Identity Theft "
-"Restoration."
+"DuckDuckGo VPN, උසස් Duck.ai ලබා ගන්න පුද්ගලික තොරතුරු ඉවත් කිරීම සහ "
+"Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9364,8 +9440,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, සහ "
-"Identity Theft Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN, විකල්ප උසස් AI කතාබහ, Personal info Removal, "
+"සහ Identity Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9374,8 +9450,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity Theft "
-"Restoration ලබා ගන්න."
+"වේගවත්, ලොග් වීම අනවශ්‍ය VPN එකක්, විකල්ප උසස් AI චැට් එකක් සහ Identity "
+"Theft Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9384,8 +9460,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත දායක වීමෙන් Duck."
-"ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ඇතුළත් වන DuckDuckGo වෙත "
+"දායක වීමෙන් Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9396,8 +9472,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo දායකත්වයක් සමඟ "
-"Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
+"අපගේ VPN සහ අනෙකුත් ප්‍රිමියම් පෞද්ගලිකත්ව ආරක්ෂණ ද ඇතුළත් වන DuckDuckGo "
+"දායකත්වයක් සමඟ Duck.ai හි උසස් AI ආකෘති වෙත ප්‍රවේශය ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9441,8 +9517,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි සඳහා විකල්ප "
-"ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN එක, ඉහළ චැට් සීමාවන් සහිත උසස් AI මාදිලි "
+"සඳහා විකල්ප ප්‍රවේශය සහ තවත් ප්‍රිමියම් ආරක්ෂණ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9451,8 +9527,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal Information "
-"Removal සහ Identity Theft Restoration."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai ලබා ගන්න, Personal "
+"Information Removal සහ Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9460,8 +9536,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft Restoration ලබා "
-"ගන්න."
+"අපගේ ආරක්ෂිත, ලොග් වීම අනවශ්‍ය VPN, උසස් Duck.ai, සහ Identity Theft "
+"Restoration ලබා ගන්න."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9502,7 +9578,9 @@ msgstr "යෙදුම ලබා ගන්න"
 #. Body text in a popover that promotes our ability to block youtube ads, the strong tag is used to highglight and style the text
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
-msgstr "YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා ගන්න.%2$s"
+msgstr ""
+"YouTube මත දැන්වීම් අවහිර කිරීමට %1$sනොමිලේ DuckDuckGo බ්‍රවුසරය ලබා "
+"ගන්න.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9561,9 +9639,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න › පාඨමය කේතය "
-"පිටපත් කරන්න%4$sවෙත යන්න"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න › පාඨමය කේතය පිටපත් කරන්න%4$sවෙත යන්න"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9572,8 +9650,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත ගොස් "
-"%3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත යන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් හෝ DuckDuckGo යෙදුමෙන් %1$sDuck.ai සැකසුම්%2$s වෙත "
+"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$sවෙත "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9583,9 +9662,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත ගොස් මෙම "
-"කේතය ස්කෑන් කරන්න:"
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත ගොස් මෙම කේතය ස්කෑන් කරන්න:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9595,9 +9674,10 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo යෙදුම වෙත "
-"ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. "
-"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයේ %1$sDuck.ai සැකසුම්%2$s වෙත යන්න, නැතහොත් DuckDuckGo "
+"යෙදුම වෙත ගොස් %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
+"කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR කේතය ස්කෑන් "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9606,8 +9686,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග සමමුහුර්ත "
-"කරන්න%4$s වෙත යන්න."
+"%1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් උපාංගයක් සමග "
+"සමමුහුර්ත කරන්න%4$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9622,8 +9702,8 @@ msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
 msgstr ""
-"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන සේවා\" සක්‍රිය කර "
-"ඇති බවට වග බලා ගන්න."
+"%1$sසැකසුම්> පෞද්ගලිකත්වය සහ ආරක්ෂාව > ස්ථාන සේවා%2$s වෙත ගොස් \"ස්ථාන "
+"සේවා\" සක්‍රිය කර ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9632,8 +9712,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් %3$sDuckDuckGo%4$s "
-"වෙත පහළට අනුචලනය කරන්න."
+"%1$sසැකසුම් > පෞද්ගලිකත්වය > අවසර කළමනාකරු > ස්ථාන%2$s වෙත ගොස් "
+"%3$sDuckDuckGo%4$s වෙත පහළට අනුචලනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9705,7 +9785,7 @@ msgstr "හොඳ රහස්‍යතා ප්‍රතිපත්තිය"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "මනා දෘශ්‍ය විලාසය"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10328,8 +10408,8 @@ msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
 msgstr ""
-"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist පිළිතුරුවල ප්‍රධාන "
-"කරුණු ඉස්මතු කරයි."
+"වැදගත් තොරතුරු වේගයෙන් සොයා ගැනීමට ඔබට උපකාර කිරීම සඳහා Search Assist "
+"පිළිතුරුවල ප්‍රධාන කරුණු ඉස්මතු කරයි."
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10356,8 +10436,8 @@ msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
 msgstr ""
-"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ සුරකින්න."
-"%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
+"ඔබගේ යතුරුපුවරුවේ %1$sReturn%2$s බොත්තම ඔබා %3$sDuckDuckGo ලැයිස්තුවේ "
+"සුරකින්න.%4$sඉන්පසුව %5$sMake Default%6$s මත ක්ලික් කරන්න"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10371,8 +10451,8 @@ msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
 msgstr ""
-"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ රහස්‍යතා ආරක්ෂාව "
-"අහිමි වේ."
+"නවත්වන්න! එය නැවත වෙනස් කිරීමෙන් DuckDuckGo දිගුව අක්‍රීය වන අතර ඔබට අපගේ "
+"රහස්‍යතා ආරක්ෂාව අහිමි වේ."
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10422,8 +10502,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය කරනු ලබන අතර ඔබව "
-"පැතිකඩ කිරීමට භාවිත නොකෙරේ."
+"හෝටල් දැන්වීම් ක්ලික් කිරීම් Tripadvisor හි දැන්වීම් ජාලය මගින් කළමනාකරණය "
+"කරනු ලබන අතර ඔබව පැතිකඩ කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10571,8 +10651,8 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ කෙසේද සහ මා කුමක් "
-"කිව යුතුද?"
+"ඔවුන්ගේ නිරන්තර පැන්සල් තට්ටු කිරීම ගැන සගයෙකුට උපායශීලීව ප්‍රවේශ විය යුත්තේ "
+"කෙසේද සහ මා කුමක් කිව යුතුද?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10694,8 +10774,8 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම කැමති මොනවාද "
-"සහ ඇයි?"
+"සුළඟේ නම කියන පොතට මම කැමතියි. තවත් හොඳ පොත්/කතා මාලා කිහිපයක් එයට වඩාත්ම "
+"කැමති මොනවාද සහ ඇයි?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10730,8 +10810,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > 'පිහිටීම හා "
-"රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, %1$sසැකසුම් > සාමාන්‍ය > යළි සකසන්න > "
+"'පිහිටීම හා රහස්‍යතාව යළි සකසන්න'%2$s වෙත යන්න."
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10741,8 +10821,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > සැකසුම් > අඩවි සැකසුම් > "
-"පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා අවසර දී ඇති ද යන්න දැනගන්න."
+"බ්‍රවුසර් පිහිටීම දිගටම ලද නොහැකි නම්, ඔබේ බ්‍රවුසරයෙන් %1$s⋮ > මෙනුව > "
+"සැකසුම් > අඩවි සැකසුම් > පිහිටීම%2$s වෙත ගොස්, DuckDuckGo වෙත ප්‍රවේශය සඳහා "
+"අවසර දී ඇති ද යන්න දැනගන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10757,8 +10838,8 @@ msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
 msgstr ""
-"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther Search "
-"Engines%4$s ලැයිස්තුවට එකතු කරන්න"
+"ඔබට %1$sDuckDuckGo%2$s දැක ගැනීමට නොහැකිනම්, ඔබට සිදුවෙනවා එය %3$sOther "
+"Search Engines%4$s ලැයිස්තුවට එකතු කරන්න"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10767,8 +10848,8 @@ msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
 msgstr ""
-"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් ඇත්නම්, ඔබට කෙලින්ම "
-"%1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
+"අපගේ චැට් සපයන්නන් හෝ කිසියම් විශේෂිත චැට් ප්‍රතිචාරයක් ගැන ඔබට කනස්සල්ලක් "
+"ඇත්නම්, ඔබට කෙලින්ම %1$s සහ %2$s සහාය පිටු වෙත ළඟා විය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10777,14 +10858,17 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා ගැනීමට මෙම "
-"කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස සුරැකිය හැකි ය."
+"ඔබට ඔබගේ උපාංගවලට ප්‍රවේශය අහිමි වුවහොත්, ඔබගේ සුරකින ලද කතාබස් නැවත ලබා "
+"ගැනීමට මෙම කේතය අවශ්‍ය වනු ඇත. ඔබට මෙම කේතය ඔබගේ උපාංගයට පෙළ ගොනුවක් ලෙස "
+"සුරැකිය හැකි ය."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු කරන්න%2$s"
+msgstr ""
+"ඔබට තවමත් අවශ්‍යයනම් අපිට උදවු කරන්න, %1$sDuckDuckGo ව්‍යාප්ත කරන්න උදවු "
+"කරන්න%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10794,15 +10878,17 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ %1$s හෝ %2$s "
-"යන පිටපත් භාවිතා කරන්න."
+"ඔබට DuckDuckGo ජාවාස්ක්‍රිප්ට් නැතුව භාවිතා කිරීමට අවශ්‍යයනම්, කරුණාකර අපගේ "
+"%1$s හෝ %2$s යන පිටපත් භාවිතා කරන්න."
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
-msgstr "ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත කරන්න)."
+msgstr ""
+"ඔබට අවශ්‍යයනම්, අලුත් කවුළු හා ටැබ් සඳහා මුල් පිටුවක් තෝරා ගන්න (සමග විවෘත "
+"කරන්න)."
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10845,7 +10931,7 @@ msgstr "රූපමය ප්‍රේරක විධාන Duck.ai %1$s ස�
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "රූප ගුණත්වය"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10937,7 +11023,8 @@ msgctxt "settings"
 msgid ""
 "Improves result legibility with updated URL format, placement, and color"
 msgstr ""
-"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය වැඩි දියුණු කරයි"
+"යාවත්කාලීන කළ URL ආකෘතිය, ස්ථානගත කිරීම සහ වර්ණය සමඟ ප්‍රතිඵල වලංගු භාවය "
+"වැඩි දියුණු කරයි"
 
 # smartling.placeholder_format=C
 #. A label that appears in front of the name of a company that DuckDuckGo has partnered with. For example, 'In partnership with Wikipedia'
@@ -10950,8 +11037,8 @@ msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
-"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් කිරීම් අපගේ සර්වරය හරහා "
-"හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
+"සමහර පැරණි බ්‍රව්සර් වලදී, සෙවුම් කාන්දු වීම වැළැක්වීම සඳහා ඔබේ ක්ලික් "
+"කිරීම් අපගේ සර්වරය හරහා හරවා යැවීම අවශ්‍ය වේ. %1$sතවත් ඉගෙන ගන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10962,8 +11049,8 @@ msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
 msgstr ""
-"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් උපාංගයක් සමග "
-"සමමුහුර්ත කරන්න” වෙත යන්න."
+"DuckDuckGo බ්‍රවුසරයේ, සැකසුම් › Sync & Backup වෙත ගොස්, පසුව “වෙනත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” වෙත යන්න."
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10978,8 +11065,8 @@ msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
 msgstr ""
-"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන ගැනීමට හැකියි අප "
-"ගබඩා කරන්නේ කුමන දත්තද කියා."
+"විනිවිදභාවය පිළිබඳ උනන්දුව නිසා, මෙම දත්ත කේතනය වී නැත: ඔබට නිසැකයෙන්ම දැන "
+"ගැනීමට හැකියි අප ගබඩා කරන්නේ කුමන දත්තද කියා."
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -10990,8 +11077,8 @@ msgstr "ඉහළ ඇති මෙනුවෙන් %1$sTools%2$s > %3$sSetting
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
 msgstr ""
-"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි සලකුණ "
-"යොදන්න"
+"උද්දීපනය වන කොටුවෙන්, %1$sMake this my default search provider%2$s මත හරි "
+"සලකුණ යොදන්න"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11318,7 +11405,8 @@ msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
 msgstr ""
-"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය සාරාංශගත කරන්න."
+"මේ ස්ථානය හොඳ ද? සමාලෝචන සහ ශ්‍රේණිගත කිරීම් මත පදනම්ව එහි කීර්තිනාමය "
+"සාරාංශගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11387,9 +11475,10 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි දැන්වීම් ජාලය "
-"හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් "
-"නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු නොකෙරේ."
+"ඔබගේ සෙවුම් පද වලට අදාලත්වය මත අයිතම ශ්‍රේණිගත කර ඇති අතර Microsoft හි "
+"දැන්වීම් ජාලය හරහා බෙදා හරිනු ලැබේ. ක්ලික් කිරීම් සෘජුවම වෙළෙන්දා පිවිසීමේ "
+"පිටු වෙත යොමු කරන අතර දැන්වීම් මෙන් නොව, DuckDuckGo මෙම ප්‍රතිඵල සඳහා හිලවු "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11398,7 +11487,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත වේ."
+"අහඹු අකුරු සහ අංක 10 ට වඩා වචන 4-5 මතක තබා ගැනීම පහසු වන අතර, වඩාත් ආරක්ෂිත "
+"වේ."
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11470,7 +11560,9 @@ msgstr "උපාංග දෙකෙහිම Sync & Backup විවෘතව �
 msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
-msgstr "එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව තබා ගන්න."
+msgstr ""
+"එකවර උපාංග 5ක් දක්වා ඔබගේ සියලුම යෙදුම් සහ මාර්ගගත ක්‍රියාකාරකම් පුද්ගලිකව "
+"තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -12111,7 +12203,9 @@ msgstr "අනුචලනය කරන විට තවත් පින්ත�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය කරයි"
+msgstr ""
+"අනුචලනය කරන විට පින්තූර, වීඩියෝ හා සාප්පු සවාරි තුළ වැඩිපුර ප්‍රතිඵල පූරණය "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -12297,8 +12391,7 @@ msgstr "සියළුම වචන වල අක්ෂර වින්‍ය�
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Make sure to check %s\"Make this my default search provider\"%s"
-msgstr ""
-"%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
+msgstr "%1$s\"Make this my default search provider\"%2$s මත හරි ලකුණ දැමුවාදැයි බලන්න"
 
 # smartling.placeholder_format=C
 #. Message prompting users to check the spelling of their search term.
@@ -12663,7 +12756,9 @@ msgstr "මයික්රොනීසියාව"
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
 msgid ""
 "Microphone access was denied. Please allow microphone access and try again."
-msgstr "මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත උත්සාහ කරන්න."
+msgstr ""
+"මයික්‍රෆෝන ප්‍රවේශය ප්‍රතික්ෂේප විය. කරුණාකර මයික්‍රෆෝන ප්‍රවේශය ඉඩ දී නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. The Microsoft brand name.
@@ -12894,7 +12989,9 @@ msgstr "මාසික සීමාවට ළඟා විය"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා හැක."
+msgstr ""
+"මාසික පරිශීලන සීමාවට ළඟා වී තිබේ. ඔබට %1$sට පසුව මෙම කතාබහ දිගටම කරගෙන යා "
+"හැක."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13447,10 +13544,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව "
-"විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු "
-"ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර "
-"තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
+"ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම "
+"සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo "
+"සේවාදායකයක ගබඩා කරනු ලැබේ. කතාබස් ඉතිහාසය අක්‍රිය කිරීමෙන් පින් කළ කතාබස් "
+"මැකෙනු ඇති අතර නව විමසීම් සහ ප්‍රතිචාර තාවකාලිකව ගබඩා කිරීම අක්‍රිය කරනු ඇත."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14285,8 +14382,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the %4$s "
-"icon > Settings%5$s"
+"මැක් වල, %1$sClick Maxthon > Preferences%2$s, වින්ඩෝව්ස් වල, %3$sClick the "
+"%4$s icon > Settings%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14316,8 +14413,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "වෙනත් උපාංගයක %1$sDuck.ai සැකසුම්%2$s › %3$sකතාබස් › Sync & Backup › වෙනත් "
-"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ ඇති QR "
-"කේතය ස්කෑන් කරන්න."
+"උපාංගයක් සමග සමමුහුර්ත කරන්න%4$s වෙත යන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF "
+"ගොනුවේ ඇති QR කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14345,8 +14442,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. පිටු %1$s ක් හෝ ඊට අඩු "
-"පිටු ඇති ගොනු උඩුගත කරන්න."
+"අමුණා ඇති ගොනුවලින් එකක අපට ක්‍රියාත්මක කළ හැකි ප්‍රමාණයට වඩා පිටු තිබේ. "
+"පිටු %1$s ක් හෝ ඊට අඩු පිටු ඇති ගොනු උඩුගත කරන්න."
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14372,7 +14469,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව දක්වා ඇත."
+msgstr ""
+"ඔබ වෙනස් කර ඇති සැකසුම් පමණයි. ඒවා %1$sURL පරාමිතීන්%2$s පිටුවේ සවිස්තරව "
+"දක්වා ඇත."
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14387,7 +14486,8 @@ msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
 msgstr ""
-"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"අපොයි! මෙම පෙළ පරිවර්තනය කිරීමේදී අනපේක්ෂිත දෝෂයක් ඇතිවිය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14718,8 +14818,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් නිරීක්ෂණය කරයි. අපි ඔබව "
-"කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
+"ඔබ පුද්ගලික ගවේෂණ මාදිලියේ සිටියදී පවා වෙනත් සෙවුම් යන්ත්‍ර ඔබගේ සෙවීම් "
+"නිරීක්ෂණය කරයි. අපි ඔබව කාල පරිච්ඡේද — ක් නිරීක්ෂණය නොකරමු."
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14733,8 +14833,8 @@ msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
 msgstr ""
-"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ තවත් ප්‍රිමියම් "
-"ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
+"අපගේ වේගවත්, ලොග් වීම අනවශ්‍ය VPN, ඉහළ සීමාවන් සහිත වඩා සුහුරු AI චැට් සහ "
+"තවත් ප්‍රිමියම් ආරක්ෂණ සමඟින් පැමිණේ.‍ සියල්ල ඇතුළත් එකම ග්‍රාහකත්වයක්."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14742,8 +14842,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු කරන්නේ හෝ බෙදා "
-"හරින්නේ නැත."
+"අපගේ පෞද්ගලිකත්වය සමිබන්ද ප්‍රතිපත්තිය සරලයි: අපි ඔබගේ පෞද්ගලික තොරතුරු එකතු "
+"කරන්නේ හෝ බෙදා හරින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14751,8 +14851,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු අවහිරකාරකය, "
-"ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & Android%2$sහි ලද හැක."
+"ජංගම දුරකථන සඳහා වන අපගේ පුද්ගලික බ්‍රවුසරය අපගේ සෙවුම් යාන්ත්‍රණය, නිරික්සු "
+"අවහිරකාරකය, ගුප්තකේතන බලාත්කාරකය හා තවත් දැයින් සන්නද්ධව තිබේ. %1$siOS & "
+"Android%2$sහි ලද හැක."
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -15005,8 +15106,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ සම්බන්ධ නොකරන බැවින් මුරපද "
-"යථාවත් කර ගත නොහැක."
+"අපි ඔබගේ IP ලිපිනය, බ්‍රව්සර් ඇඟිලි සලකුණු හෝ වෙනත් තොරතුරු ගොනුව සමඟ "
+"සම්බන්ධ නොකරන බැවින් මුරපද යථාවත් කර ගත නොහැක."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15162,8 +15263,9 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර අඩවිවලින් "
-"සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු කරන්නෙමු."
+"Personal Information Removal මගින් ඔබේ තොරතුරු ඒවා අලෙවි කරන දත්ත තැරැව්කාර "
+"අඩවිවලින් සොයා ගනියි. අනතුරුව අපි ඔබ වෙනුවෙන් ඒවා ඉවත් කර ගැනීමට කටයුතු "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15234,9 +15336,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ "
-"ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම "
-"සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙසත් සම්පූර්ණ වාක්‍යයකින් ලියා ඇති විට AI-සහය සහිත "
+"පිළිතුරු ස්වයංක්‍රීයව දිස්වීමේ ඉඩකඩ වැඩි වන අතර බොහෝ විට හොඳ පිළිතුරු ලැබේ. "
+"ඒවා ක්‍රියා විරහිත කිරීමට සහ Assist බොත්තම සැඟවීමට %1$sසෙවුම් සැකසුම්%2$s "
+"වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15245,9 +15348,10 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් "
-"කිරීමට හෝ එය ක්‍රියා විරහිත කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. "
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය ක්‍රියා විරහිත "
+"කිරීමට,%1$sDuckAssist%2$s සැකසුම් වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15257,9 +15361,10 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් DuckAssist දිස්වීමට වැඩි "
-"ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට "
-"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
+"ඔබේ සෙවුම ප්‍රශ්නයක් ලෙස සහ සම්පූර්ණ වාක්‍යයක් තුළ වාක්‍ය කණ්ඩ කිරීමෙන් "
+"DuckAssist දිස්වීමට වැඩි ඉඩක් ඇති අතර බොහෝ විට වඩා හොඳ පිළිතුරු ලබා දෙයි. එය "
+"නිවා දැමීමට සහ Assist බොත්තම සැඟවීමට %1$sDuckAssist සැකසුම්%2$s වෙත "
+"පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15292,7 +15397,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
 msgstr ""
-"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් කිරීමට තෝරන්න."
+"GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් සමඟ කතාබස් "
+"කිරීමට තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15301,7 +15407,8 @@ msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
 msgstr ""
-"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI එකක් තෝරන්න."
+"කතාබස් කිරීම සඳහා GPT-5 mini, Claude Haiku 4.5, Mistral වැනි ජනප්‍රිය AI "
+"එකක් තෝරන්න."
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15322,8 +15429,8 @@ msgstr "විශේෂ වූ ප්‍රශ්නයක් තෝරා ග�
 msgid ""
 "Pick your ad blocker and follow the instructions to allow ads on DuckDuckGo."
 msgstr ""
-"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් අනුගමනය "
-"කරන්න."
+"ඔබේ දැන්වීම් අවහිරකාරකය තෝරාගෙන DuckDuckGo හි දැන්වීම්වලට ඉඩ දීම සඳහා උපදෙස් "
+"අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Text for a button that pins a chat, as in it will it will add the chat to the pinned chats list.
@@ -15411,7 +15518,9 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15419,19 +15528,25 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය සම්පූර්ණ කරන්න."
+msgstr ""
+"මෙම සෙවුම මිනිසෙකු විසින් කරන ලද බව තහවුරු කිරීමට කරුණාකර පහත අභියෝගය "
+"සම්පූර්ණ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is harmful or illegal. (optional)"
-msgstr "කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය හානිකර හෝ නීතිවිරෝධී වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. (විකල්ප)"
+msgstr ""
+"කතාබස් ප්‍රතිචාරය නීතිවිරෝධී හෝ හානිකර වන්නේ මන්ද යන්න පැහැදිලි කරන්න. "
+"(විකල්ප)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15452,7 +15567,8 @@ msgid ""
 "Please note: starting a new chat with any model will delete your current "
 "chat session."
 msgstr ""
-"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය මකා දමනු ඇත."
+"කරුණාකර සලකන්න: ඕනෑම ආකෘතියක් සමඟ නව චැට් ආරම්භ කිරීම ඔබේ වර්තමාන චැට් සැසිය "
+"මකා දමනු ඇත."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15461,8 +15577,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය හානිකර හෝ නීති විරෝධී වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15471,8 +15587,8 @@ msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
 msgstr ""
-"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) අලවා අන්තර්ගතය "
-"නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
+"කරුණාකර ඔබේ පණිවිඩය සහ ගැටලුකාරී ප්‍රතිදානය (ඕනෑම පුද්ගලික තොරතුරක් ඉවත් කර) "
+"අලවා අන්තර්ගතය නීති විරෝධී හෝ හානිකර වන්නේ මන්දැ යි යන්න විස්තර කරන්න."
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15686,13 +15802,15 @@ msgstr "දුර්වල ආකෘතිකරණය"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "රූප ගුණත්වය බාල වීම"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
 msgctxt "new tab page"
 msgid "Popular AI models available. No account needed. Chats anonymized by us."
-msgstr "ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් නිර්නාමික කර ඇත."
+msgstr ""
+"ජනප්‍රිය AI ආකෘති ලබා ගත හැක. ගිණුමක් අවශ්‍ය නොවේ. කතාබස් අප විසින් "
+"නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text when onboarding users, describing that Duck.ai supports last AI models. Example: 'Popular AI models from: GPT, Claude, Mistral, Llama'
@@ -16250,8 +16368,8 @@ msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
 msgstr ""
-"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම පෙළ මෙහි "
-"ඇතුලත් කරන්න.]"
+"පහත දැක්වෙන පාඨය වඩාත් සංක්ෂිප්ත කිරීම සඳහා යෝජනා කිහිපයක් ලබා දෙන්න. [ඔබේම "
+"පෙළ මෙහි ඇතුලත් කරන්න.]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16480,7 +16598,9 @@ msgstr "තර්කනය මඟින් සංකීර්ණ ප්‍රශ
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා වේ. %1$s"
+msgstr ""
+"තර්කනය වඩාත් සවිස්තරාත්මකයි, නමුත් 2-5 ගුණයක් වේගයෙන් පරිශීලන සීමාවන්ට ළඟා "
+"වේ. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16536,8 +16656,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16546,8 +16666,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත වෙනුවට ඔබේ "
-"උපාංගයේ දේශීයව ගබඩා කර ඇත."
+"මෑත කාලීන කතාබස් DuckDuckGo සේවාදායකයන් හෝ වෙනත් දුරස්ථ සේවාදායකයන් මත "
+"වෙනුවට ඔබේ උපාංගයේ දේශීයව ගබඩා කර ඇත."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16557,9 +16677,9 @@ msgid ""
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
-"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති වුවහොත් "
-"කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර සංකේතනය කර යැවීමෙන් පසු "
-"තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
+"මෑත කතාබස් ඔබගේ උපාංගයේ දේශීයව ගබඩා කර ඇත. ඔබගේ අන්තර්ජාල සම්බන්ධතාවය නැති "
+"වුවහොත් කතාබහක් නැවත ලබා ගැනීමට උපකාර කිරීම සඳහා, නව විමසීම් සහ ප්‍රතිචාර "
+"සංකේතනය කර යැවීමෙන් පසු තාවකාලිකව DuckDuckGo සේවාදායකයක ගබඩා කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16700,7 +16820,9 @@ msgctxt "settings"
 msgid ""
 "Reduces extra space in and around results and reduces size of result title "
 "text"
-msgstr "ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු කරයි"
+msgstr ""
+"ප්‍රතිඵල තුළ සහ අවට අමතර ඉඩ අඩු කරමින් ප්‍රතිඵල මාතෘකාවේ පෙළ ප්‍රමාණය අඩු "
+"කරයි"
 
 # smartling.placeholder_format=C
 #. Label for the input field where users specify how they want to be referred to. Example: 'Refer to me as John'
@@ -16841,8 +16963,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ &quot;Reload&quot; "
-"බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
+"උපදෙස් අනුගමනය කරමින් හෝ ඔබේ බ්‍රවුසරයේ &quot;Refresh&quot; හෝ "
+"&quot;Reload&quot; බොත්තම ක්ලික් කරමින් DuckDuckGo නැවත පූරණය කරන්න."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16950,8 +17072,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" බොත්තම ඉවත් කරයි. "
-"හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Ask\" "
+"බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -16959,8 +17081,9 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි \"Generate\" බොත්තම ඉවත් "
-"කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව දර්ශනය වේ."
+"අදාළ සෙවීම් වලට ප්‍රතිචාර වශයෙන් පිළිතුරු ස්වයංක්‍රීයව දිස්වන පරිදි "
+"\"Generate\" බොත්තම ඉවත් කරයි. හැඹිලි සහිත පිළිතුරු සෑම විටම ස්වයංක්‍රීයව "
+"දර්ශනය වේ."
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -17024,9 +17147,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට DuckDuckGo වෙත යවනු "
-"ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු "
-"ලැබේ."
+"වාර්තා නිර්නාමික වන අතර අපගේ සෙවුම් සේවාව වැඩිදියුණු කිරීමට උදවු කිරීමට "
+"DuckDuckGo වෙත යවනු ලැබේ. ඔබේ නිර්නාමික ප්‍රතිපෝෂණය ඔවුන්ගේ සේවා වැඩිදියුණු "
+"කිරීමට උදවු කිරීමට %1$s සමඟ ද බෙදා ගනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17034,8 +17157,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත "
-"හැකි තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු "
+"පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17044,9 +17167,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට ඉල්ලා ඇති සියලු "
-"පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි "
-"තොරතුරු ඇතුළත් නොකරන්න."
+"DuckDuckGo වෙත යවන වාර්තා වලට මෙම පිටු පැටවීමේදී ඔබ අපෙන් පරිවර්තනය කිරීමට "
+"ඉල්ලා ඇති සියලු පෙළ ඇතුළත් වන අතර, ඒවා නිර්නාමික වේ. කරුණාකර ඔබේ ප්‍රතිචාරයේ "
+"කිසිදු පුද්ගලික හෝ හඳුනාගත හැකි තොරතුරු ඇතුළත් නොකරන්න."
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17138,8 +17261,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. AI-සහය සහිත පිළිතුරු අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17148,8 +17272,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. DuckAssist අපගේ %1$sසේවා "
+"කොන්දේසි%2$s යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -17159,9 +17284,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන හෝ වෙනත් වෘත්තීය "
-"උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය කර ඇති අතර සාවද්‍යතා අඩංගු "
-"විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s යටතේ පවතී."
+"ප්‍රතිචාර අධ්‍යාපනික අරමුණු සඳහා පමණක් වන අතර වෛද්‍ය, නීතිමය, මූල්‍ය, ආයෝජන "
+"හෝ වෙනත් වෘත්තීය උපදෙස් ලෙස අදහස් නොකෙරේ. ඒවා වෙබ් අන්තර්ගතය මත පදනම්ව ජනනය "
+"කර ඇති අතර සාවද්‍යතා අඩංගු විය හැක. Search Assist අපගේ %1$sසේවා කොන්දේසි%2$s "
+"යටතේ පවතී."
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17586,8 +17712,8 @@ msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
 msgstr ""
-"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ මෑත කාලීන "
-"කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
+"ගුප්ත කේතිත ආචයනය සමඟ තවත් බොහෝ දේ සඳහා විකල්පය සමඟින්, ඔබගේ උපාංගයේ ඔබගේ "
+"මෑත කාලීන කතාබස් 30ක් දක්වා ස්ථානීයව සුරකින්න."
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17760,8 +17886,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු %3$sChange%4$s "
-"ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
+"පහලට අනුචලනය කර %1$sSearch in the address bar%2$s සොයන්න. ඉන්පසු "
+"%3$sChange%4$s ක්ලික් කරන්න (හෝ %5$sAdd new%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17770,8 +17896,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත ක්ලික් කරන්න "
-"(හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
+"පහලට අනුචලනය කර %1$sලිපින තීරුව සොයන්න%2$s සොයා ගන්න. %3$sවෙනස් කරන්න%4$s මත "
+"ක්ලික් කරන්න (හෝ %5$sඅළුතින්%6$s එකතු කරන්න)."
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17857,12 +17983,13 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන විශේෂාංගයකි. මෙය සිදු කිරීම "
-"සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI "
-"භාවිත කරයි. ඔබට එය කොපමණ වාර ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, "
-"ඉල්ලූ-විට (Assist ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
-"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන කලාපවල උප "
-"කණ්ඩායමක පමණි."
+"Search Assist යනු සෙවුම් විමසුම් සඳහා නිර්නාමිකව පිළිතුරු ජනනය කරන "
+"විශේෂාංගයකි. මෙය සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතයන් සඳහා වෙබ් ස්කෑන් කරන "
+"අතර පසුව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි. ඔබට එය කොපමණ වාර "
+"ගණනක් පෙනී සිටීමට අවශ්‍යද යන්න තෝරා ගත හැක: කිසි විටෙකත්, ඉල්ලූ-විට (Assist "
+"ක්ලික් කළ විට පමණක්), සමහර විට (දැඩිව අදාළ වන විට), හෝ බොහෝ විට (පුළුල් "
+"පරාසයක සෙවුම් මත). දැනට, Search Assist ලබා ගත හැක්කේ ඉංග්‍රීසි කතා කරන "
+"කලාපවල උප කණ්ඩායමක පමණි."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17870,8 +17997,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක තොරතුරු සොයාගැනීමට "
-"Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
+"මෙම ප්‍රශ්නය සඳහා පිළිතුරක් උත්පාදනය කිරීම සඳහා ප්‍රමාණවත් විශ්වාසදායක "
+"තොරතුරු සොයාගැනීමට Search Assist හට නොහැකි විය. තවත් සෙවීමක් කරන්න."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17880,9 +18007,10 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප විශේෂාංගයකි. "
-"%1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් කර පසුව සොයාගත් තොරතුරු "
-"මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත කරයි."
+"Search Assist යනු නිර්නාමිකව සෙවුම් විමසුම් සඳහා පිළිතුරු ජනනය කරන විකල්ප "
+"විශේෂාංගයකි. %1$sමෙය%2$s සිදු කිරීම සඳහා, එය අදාළ අන්තර්ගතය සඳහා වෙබ් ස්කෑන් "
+"කර පසුව සොයාගත් තොරතුරු මත පදනම්ව කෙටි පිළිතුරක් ජනනය කිරීම සඳහා AI භාවිත "
+"කරයි."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -18003,8 +18131,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ “ducks” සෘජුවම "
-"සොයාගත හැක."
+"%1$s කෙටිමං භාවිතයෙන් වෙනත් අඩවි සොයන්න: ”!w ducks” සෙවීමකින් විකිපීඩියාවේ "
+"“ducks” සෘජුවම සොයාගත හැක."
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18023,8 +18151,8 @@ msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
-"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් සෙවුම එක් කරන්න, "
-"නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
+"අපගේ යෙදුම හෝ දිගුව භාවිතයෙන් සොයන්න, ඔබේ ප්‍රියතම බ්‍රවුසරයට පුද්ගලික වෙබ් "
+"සෙවුම එක් කරන්න, නැතහොත් %1$sduckduckgo.com%2$s වෙතින් ඍජුවම සෙවීම් කරන්න."
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18032,7 +18160,8 @@ msgctxt "settings"
 msgid ""
 "Search queries are included in URL (if off, searches will use POST requests)"
 msgstr ""
-"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් භාවිතා කරනු ඇත)"
+"සෙවුම් විමසුම් URL එකෙහි අන්තර්ගතයි (සංවෘත කර ඇත්නම්, සෙවුම් POST ඉල්ලීම් "
+"භාවිතා කරනු ඇත)"
 
 # smartling.placeholder_format=C
 #. Describes how cookies are used to store user settings privately and securely.
@@ -18044,10 +18173,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර ගබඩා තුළ ගබඩා කර ඇත, "
-"නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත "
-"කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් "
-"ඔබේ බ්‍රව්සරයෙන් ඉවත් නොවේ."
+"සෙවුම් සැකසුම් ඔබේ බ්‍රව්සරයේ පුද්ගලික නොවන බ්‍රව්සර් කුකීස් සහ අභ්‍යන්තර "
+"ගබඩා තුළ ගබඩා කර ඇත, නමුත් ඔබට ඔබගේ සැකසුම් නිර්නාමිකව ක්ලවුඩයේ ඇති දුරස්ථ "
+"සර්වරයක ගබඩා කිරීමට Cloud Save භාවිත කළ හැක. පුද්ගලිකව හඳුනාගත හැකි තොරතුරු "
+"ක්ලවුඩය තුළ ගබඩා නොවන අතර, ඔබේ මුරපදය කිසි විටෙකත් ඔබේ බ්‍රව්සරයෙන් ඉවත් "
+"නොවේ."
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -18150,8 +18280,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18160,8 +18290,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිතා කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වෙන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18170,8 +18300,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් ආරක්ෂිතව ගබඩා "
-"කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර අපගේ සේවාදායකයේ සීමාවක් නැති කතාබස් "
+"ආරක්ෂිතව ගබඩා කර, ඔබ සමකාලීන කරන ලද සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18180,8 +18310,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා කර, "
-"ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
+"මුල සිට අග දක්වා ම සංකේතනය භාවිත කර ඔබේ කතාබස් ආරක්ෂිතව අපගේ සේවාදායකයේ ගබඩා "
+"කර, ඔබේ සියලුම උපාංගවලින් ඒවාට ප්‍රවේශ වන්න."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18196,8 +18326,8 @@ msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
 msgstr ""
-"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට හැර වෙන "
-"කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
+"DuckDuckGo සර්වරයේ මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ ආරක්ෂිතව ගබඩා කර ඇත. ඔබට "
+"හැර වෙන කිසිවෙකුට ඔබගේ දත්ත දැකිය නොහැක, අපටවත් නොවේ."
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18421,8 +18551,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් වල) "
-"තෝරන්න"
+"%1$sOpera > Preferences%2$s (මැක් වල) හෝ %3$sOpera > Options%4$s (වින්ඩෝව්ස් "
+"වල) තෝරන්න"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18487,8 +18617,8 @@ msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
 msgstr ""
-"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් අනෙකුත් "
-"විකල්ප වලින් එකක් තෝරන්න)"
+"%1$sUse this webpage as your only home page%2$s තෝරන්න (හෝ ඔබ කැමතිනම් "
+"අනෙකුත් විකල්ප වලින් එකක් තෝරන්න)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18610,8 +18740,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත විමසුමක් යවයි. මෙම "
-"උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
+"ඔබේ පණිවිඩ සහ ප්‍රතිචාර දැක්විය යුතු ආකාරය පිළිබඳ උපදෙස් සමඟ AI ආකෘති වෙත "
+"විමසුමක් යවයි. මෙම උපදෙස් ඔබේ සියලුම සංවාද සඳහා ඉදිරියට අදාළ වනු ඇත."
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18734,8 +18864,8 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක කිරීමෙන් පසු Sync & "
-"Backup පිහිටුුවන්න."
+"ඔබේ කතාබස් උපාංග අතර සමමුහුර්තව තබා ගැනීමට කතාබස් ඉතිහාසය ක්‍රියාත්මක "
+"කිරීමෙන් පසු Sync & Backup පිහිටුුවන්න."
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18842,8 +18972,8 @@ msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
 msgstr ""
-"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. Duck.ai කිසි "
-"විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
+"අදාළත්වය වැඩි දියුණු කිරීම සඳහා AI ආකෘති සමඟ නගර මට්ටමේ ස්ථානයක් බෙදා ගන්න. "
+"Duck.ai කිසි විටෙකත් ඔබේ නිශ්චිත ස්ථානය අපට හෝ AI ආකෘතිවලට හෙළි නොකරයි."
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18945,8 +19075,8 @@ msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
 msgstr ""
-"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ හානිකර වාර්තා "
-"සඳහා අවශ්‍ය වේ)"
+"ඔබේ කඩිනම් සහ කතාබස් ප්‍රතිචාරය DuckDuckGo සමග බෙදා ගන්න (නීති විරෝධී සහ "
+"හානිකර වාර්තා සඳහා අවශ්‍ය වේ)"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18995,8 +19125,9 @@ msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
 msgstr ""
-"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා කරගන්න. සැකසීමට "
-"සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට පහසුය."
+"අපගේ ලොග් වීම අනවශ්‍ය, වේගවත් VPN සමඟ ඔබේ අන්තර්ජාල ක්‍රියාකාරකම් ආරක්ෂා "
+"කරගන්න. සැකසීමට සරල වන අතර ඕනෑම වේලාවක ක්‍රියාත්මක කිරීමට සහ අක්‍රිය කිරීමට "
+"පහසුය."
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19123,7 +19254,8 @@ msgstr "DuckAssist <sup>BETA</sup> පෙන්වන්න"
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
 msgstr ""
-"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත කිරීමටද%2$s හැකිය.)"
+"DuckAssist නිතර නිතර පෙන්වන්න. (ඔබට සම්පූර්ණයෙන්ම %1$sඑය ක්‍රියා විරහිත "
+"කිරීමටද%2$s හැකිය.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19361,8 +19493,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවයි "
-"සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම පුද්ගලික බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවයි සහ සෙවුම් පෞද්ගලිකත්වයට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19370,8 +19502,8 @@ msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
 msgstr ""
-"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය කිරීම මතක් කිරීම සඟවන "
-"අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
+"DuckDuckGo හි සෙවීම් සැමවිටම ආරක්ෂිත බව මතක් කිරීමක් පෙන්වයි. මෙය අක්‍රිය "
+"කිරීම මතක් කිරීම සඟවන අතර සෙවුම් ආරක්ෂාවට කිසි විටෙකත් බලපාන්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19409,7 +19541,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන පණිවුඩ පෙන්වන්න"
+"DuckDuckGo පෞදගලිකත්වය සම්බන්ධ පුවත් ලිපි සඳහා ලියපදිංචිය ඉඳහිට මතක් කරන "
+"පණිවුඩ පෙන්වන්න"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19750,7 +19883,8 @@ msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
 msgstr ""
-"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් උත්සාහ කරන්න."
+"කනගාටුයි, උඩුගත කළ රූපය සැකසිය නොහැකි විය. කරුණාකර වෙනස් රූපයක් හෝ ආකෘතියක් "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19759,16 +19893,16 @@ msgid ""
 "Sorry, this code is invalid. Please make sure the correct code was entered "
 "or scanned."
 msgstr ""
-"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර ඇති බවට වග "
-"බලා ගන්න."
+"කනගාටුයි, මෙම කේතය අවලංගු වේ. කරුණාකර නිවැරදි කේතය ඇතුළත් කර හෝ ස්කෑන් කර "
+"ඇති බවට වග බලා ගන්න."
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI)
 msgid ""
 "Sorry, we couldn't generate a richer answer. You can try asking Duck.ai."
 msgstr ""
-"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට Duck.ai එකෙන් අහන්න "
-"උත්සාහ කළ හැක."
+"කණගාටුයි, අපට වඩාත් පොහොසත් පිළිතුරක් නිර්මාණය කරන්නට නොහැකි විය. ඔබට "
+"Duck.ai එකෙන් අහන්න උත්සාහ කළ හැක."
 
 # smartling.placeholder_format=C
 #. Inform the users that "something" went wrong and that they could try to refresh the page to resolve the error. Placeholders are for markup, please ignore.
@@ -19777,15 +19911,16 @@ msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
 msgstr ""
-"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ කිරීමට%1$sමෙහි ක්ලික් "
-"කරන්න%2$s ."
+"කණගාටුයි, මෙම ප්‍රතිඵල පෙන්වීමේදී අපට දෝෂයක් ඇති විය. නැවත උත්සාහ "
+"කිරීමට%1$sමෙහි ක්ලික් කරන්න%2$s ."
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
 msgstr ""
-"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න."
+"සමාවන්න, අපට ඔබේ ප්‍රතිපෝෂණ ඉදිරිපත් කිරීමට නොහැකි විය. කරුණාකර පසුව නැවත "
+"උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20189,8 +20324,8 @@ msgid ""
 "Subscribe to DuckDuckGo to unlock higher limits in Duck.ai, or come back "
 "later to create more images."
 msgstr ""
-"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය ලබාගන්න, නැතහොත් "
-"තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Duck.ai තුළ ඇති ඉහළ සීමාවන් අගුළු හැර ගැනීමට DuckDuckGo වෙත ග්‍රාහකත්වය "
+"ලබාගන්න, නැතහොත් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Description shown to free users who have reached their image generation limit, encouraging them to subscribe.
@@ -20258,7 +20393,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා කරනවාද?"
+msgstr ""
+"සැත්කමකින් සුවය ලැබූ කෙනෙකුට get-well කාඩ්පතක ලිවීමට වාක්ය ඛණ්ඩයක් යෝජනා "
+"කරනවාද?"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20594,7 +20731,9 @@ msgstr "%1$sවෙත මාරු විය"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට යවනු ඇත"
+msgstr ""
+"ආකෘතිය මාරු කිරීමෙන්, ඔබේ කතාබහ සපයන්නාගේ දෘශ්‍යතාව ශුන්‍ය නොවන ආකෘතියකට "
+"යවනු ඇත"
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -20649,7 +20788,8 @@ msgstr "Sync & Backup සක්‍රිය කරන ලදී!"
 msgctxt "Inactivity notice on the Sync & Backup recovery code screen"
 msgid "Sync & Backup data can't be recovered after 18 months of inactivity."
 msgstr ""
-"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය කළ නොහැක."
+"Sync & Backup දත්ත මාස 18ක කාලයක් තිස්සේ අකර්මණ්‍යව තිබූ පසු ඒවා ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the cross-device sync headline in sync-enabled chat history about modals.
@@ -20658,8 +20798,8 @@ msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
 msgstr ""
-"Sync & Backup ඔබේ කතාබස්වල වැඩි ප්‍රමාණයක් සුරකින අතර ඒවා ඔබගේ සියලු උපාංග හරහා "
-"සමමුහුර්ත කරයි."
+"Sync & Backup ඔබේ කතාබස්වල වැඩි ප්‍රමාණයක් සුරකින අතර ඒවා ඔබගේ සියලු උපාංග "
+"හරහා සමමුහුර්ත කරයි."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20708,9 +20848,9 @@ msgid ""
 msgstr ""
 "ප්‍රතිසාධන කේතය සමමුහුර්ත කරන්න\n"
 "\n"
-"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් උපාංග කිහිපයක් අතර "
-"සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
-"කර ගනී.\n"
+"ප්‍රතිසාධන කේතය මඟින් ඔබේ මුරපද, ස්වයංක්‍රීය පිරවීම් දත්ත සහ Duck.ai කතාබස් "
+"උපාංග කිහිපයක් අතර සමමුහුර්ත කිරීමට ඉඩ සලසන අතර, උපාංගයකට ප්‍රවේශය අහිමි "
+"වුවහොත් ඔබේ සමමුහුර්ත දත්ත ප්‍රතිසාධනය කර ගනී.\n"
 "\n"
 "මෙම තොරතුරු ආරක්ෂිතව තබා ගන්න.\n"
 "මෙම කේතයට ප්‍රවේශය ඇති ඕනෑම අයෙකුට ඔබේ සමමුහුර්ත දත්ත වෙත ප්‍රවේශ විය හැක.\n"
@@ -20719,12 +20859,14 @@ msgstr ""
 "\n"
 "මෙම කේතය ක්‍රියා කරන්නේ කෙසේ ද?\n"
 "1. ඔබේ බ්‍රවුසරයෙන් Duck.ai වෙත ගොස් Duck.ai සැකසුම් විවෘත කරන්න.\n"
-"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය කරන්න\" තෝරන්න\n"
-"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන ස්ථානයේ "
-"අලවන්න\n"
+"2. \"Sync & Backup සක්‍රීය කරන්න, තෝරා, ඉන්පසු \"සමමුහුර්ත දත්ත ප්‍රතිසාධනය "
+"කරන්න\" තෝරන්න\n"
+"3. ඉහත ප්‍රතිසාධන කේතය පිටපත් කර \"මෙහි ඔබේ කේතය අලවන්න\" යනුවෙන් දැක්වෙන "
+"ස්ථානයේ අලවන්න\n"
 "\n"
-"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි කාලයක් භාවිතා "
-"නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය කළ නොහැක."
+"ඔබ DuckDuckGo බ්‍රවුසරය Sync & Backup සක්‍රීය කර නොමැතිව මාස 18 කට වැඩි "
+"කාලයක් භාවිතා නොකරන්නේ නම්, ඔබගේ දත්ත සර්වරයෙන් මනා දමනු ලබන අතර ප්‍රතිසාධනය "
+"කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20863,8 +21005,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් ප්‍රවේශයක් සඳහා "
-"එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිටියත්, වඩාත් වේගවත් "
+"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ යෙදුම තුළම ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20873,8 +21015,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් වේගවත් "
-"ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
+"සෑම තැනකම ඔබ සමඟ Duck.ai රැගෙන යන්න. ඔබ කොතැනක සිට බ්‍රවුස් කළ ද වඩාත් "
+"වේගවත් ප්‍රවේශයක් සඳහා එය අපගේ නොමිලේ ලබා දෙන බ්‍රවුසරය තුළට ඇතුළත් කරගන්න."
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20898,7 +21040,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික සමීක්ෂණයට සහභාගි වන්න."
+"Duck.ai වඩා හොඳ කළ හැක්කේ කෙසේදැයි අපව දැනුවත් කිරීමට මෙම නිර්නාමික "
+"සමීක්ෂණයට සහභාගි වන්න."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21119,9 +21262,9 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද තොරතුරු තෙවන "
-"පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට "
-"ඇතුළත් වේ."
+"එයින් අදහස් වන්නේ ඔබගේ උපාංගය සහ මෙම සබැඳිය පිටුපස ඇති වෙබ් පිටුව අතර යවන ලද "
+"තොරතුරු තෙවන පාර්ශවයක් විසින් වළක්වාලීමේ අවදානම වැඩි බවයි. දුර්ලභ "
+"අවස්ථාවන්හි මුරපද හෝ ගෙවීම් විස්තර මෙයට ඇතුළත් වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -21130,8 +21273,8 @@ msgid ""
 "The Cloud Save bookmarklet allows any changes you make to your settings to "
 "automatically save in the cloud."
 msgstr ""
-"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් Cloud Save කුඩා පිටු "
-"සලකුණු මඟින් ඉඩ දෙයි."
+"වලාකුළු තුළ ස්වයංක්‍රීයව සුරැකීමට ඔබගේ සැකසුම් වල සිදුකරන ඕනෑම වෙනස්කමක් "
+"Cloud Save කුඩා පිටු සලකුණු මඟින් ඉඩ දෙයි."
 
 # smartling.placeholder_format=C
 #. Body text of the one-time Duck.ai promo card on the Chrome New Tab Page.
@@ -21140,8 +21283,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"Duck.ai ටොගලය ඔබට පුද්ගලික සෙවීම සහ AI කතාබස් අතර ඉක්මනින් මාරු වීමට ඉඩ සලසයි, "
-"DuckDuckGo මගින් නිර්නාමික කර ඇත."
+"Duck.ai ටොගලය ඔබට පුද්ගලික සෙවීම සහ AI කතාබස් අතර ඉක්මනින් මාරු වීමට ඉඩ "
+"සලසයි, DuckDuckGo මගින් නිර්නාමික කර ඇත."
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21171,8 +21314,8 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය හැක්කේ ඔබට "
-"පමණි."
+"සංකේතාංකන යතුර ඔබගේ බ්‍රවුසරයේ දේශීය ගබඩාවේ පමණක් සුරකින අතර, ඊට ප්‍රවේශ විය "
+"හැක්කේ ඔබට පමණි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider deletes all chat data within 30 days.
@@ -21193,7 +21336,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල සුරකින්නේ නැත."
+msgstr ""
+"ආකෘති සපයන්නා මෙම කතාබස් හෝ ඒ ආශ්‍රිත කිසිදු දත්තයක් ඔවුන්ගේ සර්වරවල "
+"සුරකින්නේ නැත."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21252,8 +21397,8 @@ msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
 msgstr ""
-"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය කර ඇති බවට වග බලා "
-"ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
+"මෙම කතාබහ අභ්‍යන්තරව සුරැකීමේදී දෝෂයක් සිදු විය. අභ්‍යන්තර දත්ත ගබඩා සක්‍රිය "
+"කර ඇති බවට වග බලා ගැනීම සඳහා කරුණාකර ඔබේ බ්‍රව්සර් සැකසුම් පරීක්ෂා කරන්න."
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21268,8 +21413,8 @@ msgid ""
 "There was still an error displaying the search results. Please wait a few "
 "minutes before you try again."
 msgstr ""
-"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර කරුණාකර මිනිත්තු කිහිපයක් "
-"රැඳී සිටින්න."
+"සෙවුම් ප්‍රතිඵල පෙන්වීමේ දෝෂයක් තවමත් පැවතිණි. ඔබ නැවත උත්සාහ කිරීමට පෙර "
+"කරුණාකර මිනිත්තු කිහිපයක් රැඳී සිටින්න."
 
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
@@ -21288,9 +21433,9 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් සහ DuckDuckGo "
-"ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම "
-"බ්‍රව්සර් අවසර භාවිතා කරයි."
+"සැඟවුණු ට්‍රැකර් අවහිර කිරීමෙන්, හැකි සෑම තැනකම සම්බන්ධතා සංකේතනය කිරීමෙන් "
+"සහ DuckDuckGo ඔබේ සුපුරුදු සෙවුම් යන්ත්‍රය බවට පත් කිරීමෙන් ඔබ පිවිසෙන වෙබ් "
+"අඩවි වලට පෞද්ගලිකත්වය එක් කිරීමට මෙම බ්‍රව්සර් අවසර භාවිතා කරයි."
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21328,8 +21473,8 @@ msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
 msgstr ""
-"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ කිරීමට උත්සාහ "
-"කරන්න."
+"මෙම AI ආකෘතිය තවදුරටත් ලබා ගත නොහැක. වෙනස් ආකෘතියක් සමඟ නව කතාබස් ආරම්භ "
+"කිරීමට උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21338,8 +21483,8 @@ msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
 msgstr ""
-"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව කතාබහක් "
-"ආරම්භ කරන්න."
+"මෙම AI ආකෘති අනුවාදය තවදුරටත් සහය නොදක්වයි. මෙම ආකෘතියේ නවතම අනුවාදය සමඟ නව "
+"කතාබහක් ආරම්භ කරන්න."
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21378,8 +21523,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත කරමිනි. AI "
-"කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා %4$s බලන්න)."
+"මෙම සංවාදය Duck.ai (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sගේ %3$s ආකෘතිය භාවිත "
+"කරමිනි. AI කතාබස් සාවද්‍ය හෝ අපහාසාත්මක තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි "
+"විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21389,8 +21535,8 @@ msgid ""
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI කතාබස් "
-"සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
+"බහු කතාබස් ආකෘති භාවිත කරමින් Duck.ai (%1$s) සමඟ මෙම සංවාදය ජනනය කරන ලදී. AI "
+"කතාබස් සාවද්‍ය හෝ අහිතකර තොරතුරු පෙන්විය හැකිය (වැඩි විස්තර සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21399,8 +21545,8 @@ msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
 msgstr ""
-"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ අහිතකර "
-"තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
+"මෙම සංවාදය Duck.ai හඬ කතාබස් (%1$s) සමඟින් ජනනය කරන ලදී. AI මඟින් සාවද්‍ය හෝ "
+"අහිතකර තොරතුරු සැපයිය හැකිය. (වැඩිදුර තොරතුරු සඳහා %2$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21411,8 +21557,8 @@ msgid ""
 "more info)."
 msgstr ""
 "මෙම සංවාදය DuckDuckGo AI Chat (%1$s) සමඟ ජනනය කරන ලද්දේ %2$sහි %3$s ආකෘතිය "
-"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය (වැඩි විස්තර සඳහා "
-"%4$s බලන්න)."
+"භාවිතා කරමිනි. AI කතාබස් සාවද්‍ය හෝ වැරදිසහගත තොරතුරු ප්‍රදර්ශනය කළ හැකිය "
+"(වැඩි විස්තර සඳහා %4$s බලන්න)."
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21429,8 +21575,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට නොහැකි වනු ඇත. "
-"අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
+"මෙම උපාංගයට අනෙකුත් උපාංගවල ඔබගේ සමමුහුර්ත දත්ත වෙත තවදුරටත් ප්‍රවේශ වීමට "
+"නොහැකි වනු ඇත. අවසාන කතාබස් %1$s තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21536,8 +21682,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ කතාබස්වල ඉහළින්ම තබා "
-"ගැනීමට පින් කරන්න තෝරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එහි මෙනුව (තිත් තුන) විවෘත කර, එය ඔබේ "
+"කතාබස්වල ඉහළින්ම තබා ගැනීමට පින් කරන්න තෝරන්න!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21546,7 +21692,8 @@ msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
 msgstr ""
-"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button භාවිතා කරන්න!"
+"මෙය හුදෙක් ආදර්ශ කතාබහක් පමණි. එය මකා දැමීමට පැති මෙනුවේ ඇති Fire Button "
+"භාවිතා කරන්න!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21567,8 +21714,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. අනෙකුත් ආකෘති "
-"සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු දින 30ක් ඇතුළත මෙම කතාබහ හා සම්බන්ධ දත්ත මකා දමයි. "
+"අනෙකුත් ආකෘති සපයන්නන් ශුන්‍ය දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21577,8 +21724,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. අනෙකුත් ආකෘති සපයන්නන් "
-"සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
+"මෙම ආකෘති සැපයුම්කරු මෙම කතාබහ හා සම්බන්ධ කිසිදු දත්තයක් ගබඩා නොකරයි. "
+"අනෙකුත් ආකෘති සපයන්නන් සීමිත දත්ත රඳවා ගැනීමේ ආකෘතියක් අනුගමනය කරයි."
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21615,8 +21762,8 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය සමඟ සුරකින "
-"අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
+"මෙය DuckDuckGo ආරක්ෂිත සේවාදායකයේ ඔබේ කතාබස් මුල සිට අග දක්වා ගුප්ත කේතනය "
+"සමඟ සුරකින අතර පසුව ඕනෑම බ්රවුසරයකින් ඒවාට ප්රවේශ විය හැකිය."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21625,8 +21772,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21636,9 +21783,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com බ්‍රව්සර දත්ත මකා "
-"දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ වෙතත්, අපට %1$s හි AI-සහය "
-"සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
+"මෙම සැකසුම ඔබේ බ්‍රව්සරයේ ගබඩා වේ, එයින් අදහස් වන්නේ ඔබ duckduckgo.com "
+"බ්‍රව්සර දත්ත මකා දැමුවහොත්, ඔබට නැවත AI සහාය සහිත පිළිතුරු දැකිය හැක. කෙසේ "
+"වෙතත්, අපට %1$s හි AI-සහය සහිත පිළිතුරු කිසිවිටෙකත් පෙන්වන ආරම්භක පිටුවක් ඇත."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21689,9 +21836,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup විසන්ධි කරයි. Sync "
-"& Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට "
-"හැකි වනු ඇත."
+"මින් ඔබගේ සියලුම Duck.ai කතාබස් මෙම බ්‍රව්සරයෙන් මකා දමා Sync & Backup "
+"විසන්ධි කරයි. Sync & Backup ට සම්බන්ධ කර ඇති අනෙකුත් බ්‍රව්සර්වලින් ඔයාට "
+"තවමත් ඔයාගේ කතාබස් වෙත ප්‍රවේශ වීමට හැකි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21700,7 +21847,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු හැරවිය නොහැක."
+"මෙය ඔයාගේ මෑත කාලීන කතාබස් සියල්ල මකා දමයි, ඒවා අමුණලා නැත්නම්. මෙය ආපසු "
+"හැරවිය නොහැක."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21838,8 +21986,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට අවශ්‍ය මාර්ගය "
-"තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
+"දිශාවන් මුද්‍රණය කිරීම සඳහා:%1$sසිතියම වෙත ආපසු යන්න.%2$sඔබට මුද්‍රණය කිරීමට "
+"අවශ්‍ය මාර්ගය තෝරන්න.%3$sමුද්‍රණ නිරූපකය ක්ලික් කරන්න.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21849,9 +21997,9 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත කිරීම සැකසීමේ දී සුරකින "
-"ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ "
-"PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
+"ඔබේ සමමුහුර්ත කළ දත්ත ප්‍රතිසාධනය කිරීම සඳහා ඔබ විසින් පළමු වරට සමමුහුර්ත "
+"කිරීම සැකසීමේ දී සුරකින ලද ප්‍රතිසාධන කේතය අවශ්‍ය වනු ඇත. මෙම කේතය ඔබ මුල් "
+"වරට සමමුහු සැකසීමට භාවිතා කළ උපාංගයේ PDF ගොනුවක් ලෙස සුරැකී තිබිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21860,8 +22008,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය නවතම "
-"අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
+"ඔබේ කතාබස් ඉතිහාසය Duck.ai වෙත මාරු කිරීමට, කරුණාකර ඔබේ DuckDuckGo බ්‍රවුසරය "
+"නවතම අනුවාදයට යාවත්කාලීන කර නැවත උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21869,8 +22017,8 @@ msgid ""
 "To use dictation, allow your browser to access the microphone in your system "
 "settings."
 msgstr ""
-"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ වීමට ඔබේ බ්‍රවුසරයට ඉඩ "
-"දෙන්න."
+"අසා ලිවීම භාවිත කිරීමට, ඔබේ පද්ධති සැකසුම් තුළින් මයික්‍රොෆෝනය වෙත ප්‍රවේශ "
+"වීමට ඔබේ බ්‍රවුසරයට ඉඩ දෙන්න."
 
 # smartling.placeholder_format=C
 msgid "Today"
@@ -21892,15 +22040,17 @@ msgstr "අද"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "පුද්ගලික AI කතාබස් සඳහා ටොගල් කරන්න, නැතහොත් %1$sසැකසුම් තුළින් අක්‍රිය කරන්න%2$s."
+msgstr ""
+"පුද්ගලික AI කතාබස් සඳහා ටොගල් කරන්න, නැතහොත් %1$sසැකසුම් තුළින් අක්‍රිය "
+"කරන්න%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් එය අක්‍රිය කරන්න."
-"%3$s"
+"පුද්ගලික AI කතාබස් උත්සාහ කිරීමට ටොගල් කරන්න, නැතහොත් %1$s %2$s මෙනුව තුළින් "
+"එය අක්‍රිය කරන්න.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -21966,7 +22116,7 @@ msgstr "මන්දගාමී වැඩියි"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "ජනනය වීම ඉතා මන්දගාමී ය"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22080,8 +22230,8 @@ msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
 msgstr ""
-"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ ප්‍රමාණයක් අවහිර "
-"කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
+"DuckDuckGo විසින් අවහිර කළ නිරීක්ෂණය කිරීමේ ප්‍රයත්න මෙහි දිස් වේ.අපි කොපමණ "
+"ප්‍රමාණයක් අවහිර කරනවාදැයි බැලීමට බ්‍රවුස් කරන්න."
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22129,8 +22279,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22139,8 +22289,8 @@ msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
 msgstr ""
-"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට ශාලාවට යන්නේ "
-"කෙසේද?\""
+"මෙම ඉංග්‍රීසි වාක්‍යය ප්‍රංශ භාෂාවට පරිවර්තනය කරන්න: \"මම ළඟම ඇති චිත්‍රපට "
+"ශාලාවට යන්නේ කෙසේද?\""
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22387,7 +22537,9 @@ msgstr "වෙනත් වචන සමග උත්සාහ කරන්න."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ කරන්න."
+msgstr ""
+"තවත් ප්‍රතිඵල දැකීමට DuckDuckGo හි ඔබේ දැන්වීම් අවහිරකරණය අබල කිරීමට උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
@@ -22400,7 +22552,9 @@ msgstr "වඩාත් නිවැරදි ප්‍රතිඵල සඳහ
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා දෙනු ඇත."
+msgstr ""
+"එක් එක් ආකෘතිය සමඟ අත්හදා බැලීමට උත්සාහ කරන්න - ඔවුන් විවිධ ප්‍රතිචාර ලබා "
+"දෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22412,7 +22566,7 @@ msgstr "කුඩා වචන ප්‍රමාණයක් සමග උත�
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "නොමිලේ අත්හදා බලන්න"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22624,8 +22778,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔයාගේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22634,8 +22788,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට %1$sDuckDuckGo "
-"No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"AI විශේෂාංග අක්‍රීය කිරීමට උත්සාහ කරනවා ද? ඔබේ සැකසුම් මතක තබා ගැනීමට "
+"%1$sDuckDuckGo No AI%2$s සෙවුම් දිගුව වෙත මාරු වෙන්න. %3$sවැඩිදුර දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22836,8 +22990,8 @@ msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
 msgstr ""
-"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත කිරීමෙන් සෙවීමක් සහ "
-"ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
+"DuckAssist පිළිතුරු උත්පාදනය වන විට ඒවා ටයිප් කරයි. මෙය ක්‍රියාවිරහිත "
+"කිරීමෙන් සෙවීමක් සහ ප්‍රදර්ශනය වන පිළිතුර අතර කෙටි ප්‍රමාදයක් ඇති විය හැක."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22967,8 +23121,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර %5$sSet "
-"Pages%6$s මත ක්ලික් කරන්න."
+"%1$sOn startup%2$s වලට පහළින්, %3$sOpen a specific page%4$s ක්ලික් කර "
+"%5$sSet Pages%6$s මත ක්ලික් කරන්න."
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22976,8 +23130,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: https://"
-"duckduckgo.com"
+"%1$sOn startup%2$s වලට පහළීන් ඇති, %3$sHomepage%4$s තෝරාගෙන ඇතුළු කරන්න: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23093,8 +23247,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා 2 ගුණයක් "
-"ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
+"Pro වෙත උත්ශ්‍රේණිගත කිරීමෙන් %1$s, වඩා ඉහළ AI තර්කනයක් සහ Plus සැලැස්මට වඩා "
+"2 ගුණයක් ඉහළ AI පරිශීලන සීමා අගුළු හැර ගන්න."
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23252,8 +23406,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට DuckDuckGo බ්‍රවුසරය "
-"යාවත්කාලීන කරන්න"
+"Duck.ai හි ඔබේ දායකත්වය සක්රිය කිරීමට සහ උසස් ආකෘති වෙත ප්‍රවේශ වීමට "
+"DuckDuckGo බ්‍රවුසරය යාවත්කාලීන කරන්න"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23378,15 +23532,16 @@ msgid ""
 "Upgrade to Pro to unlock 2x higher limits than Plus, or come back later to "
 "create more images."
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න, නැත්නම් තවත් "
-"රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් ඉහළ සීමාවන් අගුළු ඇරීමට Pro වෙත උත්ශ්‍රේණිගත "
+"කරන්න, නැත්නම් තවත් රූප නිර්මාණය කිරීමට පසුව නැවත එන්න."
 
 # smartling.placeholder_format=C
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
 msgstr ""
-"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත උත්ශ්‍රේණිගත කරන්න"
+"Plus ප්‍රකාරයට වඩා දෙගුණයකින් පුළුල් පරිශීලන සීමා අගුළු හැර ගැනීමට Pro වෙත "
+"උත්ශ්‍රේණිගත කරන්න"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23482,9 +23637,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, වංචාකරුවන් සහ "
-"සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය "
-"නොවේ."
+"ChatGPT, Claude, සහ අනෙකුත් AI පද්ධති පුද්ගලිකව භාවිත කරන්න. හැකර්වරුන්, "
+"වංචාකරුවන් සහ සමාගම් වලින් ඔබේ කතාබස් ආරක්ෂා කරගන්න. තොරතුරු රහසිගතව තබා "
+"ගන්න. ගාස්තු රහිතයි. ගිණුමක් අවශ්‍ය නොවේ."
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23539,8 +23694,8 @@ msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා කරන්න. එය "
-"ආරක්ෂිතව තබා ගන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ දත්ත ප්‍රතිසාධනය කිරීමට මේ කේතය "
+"භාවිතා කරන්න. එය ආරක්ෂිතව තබා ගන්න."
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23548,8 +23703,8 @@ msgctxt "Description for the recovery section inside Manage"
 msgid ""
 "Use this code to restore your saved chats if you lose access to your devices."
 msgstr ""
-"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට මේ කේතය භාවිතා "
-"කරන්න."
+"ඔබේ උපාංගවලට ප්‍රවේශය අහිමි වුණොත් ඔබේ සුරකින ලද කතාබස් ප්‍රතිසාධනය කිරීමට "
+"මේ කේතය භාවිතා කරන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to ask the user if they want to use their approximate location for more accurate results
@@ -23673,8 +23828,9 @@ msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
 msgstr ""
-"Duck.ai වෙතින් බෙදාගත් සංවාදයක් බලන්න - DuckDuckGo වෙතින් නොමිලේ, පුද්ගලික AI කතාබස්. එය "
-"ඔබේම කතාබස්වලට සුරැක පෞද්ගලිකත්වය රැක ගනිමින් අඛණ්ඩව ඉදිරියට යන්න."
+"Duck.ai වෙතින් බෙදාගත් සංවාදයක් බලන්න - DuckDuckGo වෙතින් නොමිලේ, පුද්ගලික "
+"AI කතාබස්. එය ඔබේම කතාබස්වලට සුරැක පෞද්ගලිකත්වය රැක ගනිමින් අඛණ්ඩව ඉදිරියට "
+"යන්න."
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23709,8 +23865,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් කළමනාකරණය කරනු "
-"ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් කළමනාකරණය කරනු ලබන්නේ Microsoftහි දැන්වීම් ජාලය විසිනි"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23719,8 +23875,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
 msgstr ""
-"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් කිරීම් TripAdvisor හි "
-"දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"දැන්වීම් බැලීම DuckDuckGo මගින් පුද්ගලිකත්වය ආරක්ෂා කරයි. දැන්වීම් ක්ලික් "
+"කිරීම් TripAdvisor හි දැන්වීම් ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23729,8 +23885,8 @@ msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
 msgstr ""
-"වෙළෙඳ දැන්වීම් බැලීමේ පුද්ගලිකත්වය DuckDuckGo මගින් ආරක්ෂා කරයි. වෙළෙඳ දැන්වීම් මත ක්ලික් කිරීම් "
-"Yelp ප්‍රචාරණ ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
+"වෙළෙඳ දැන්වීම් බැලීමේ පුද්ගලිකත්වය DuckDuckGo මගින් ආරක්ෂා කරයි. වෙළෙඳ "
+"දැන්වීම් මත ක්ලික් කිරීම් Yelp ප්‍රචාරණ ජාලය විසින් කළමනාකරණය කරනු ලැබේ."
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23742,8 +23898,8 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist සැකසුම්%2$s "
-"වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sAssist "
+"සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23752,8 +23908,8 @@ msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
 msgstr ""
-"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට %1$sDuckAssist "
-"සැකසුම්%2$s වෙත පිවිසෙන්න."
+"මෙම විශේෂාංගය ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය අක්‍රිය කිරීමට "
+"%1$sDuckAssist සැකසුම්%2$s වෙත පිවිසෙන්න."
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23762,8 +23918,8 @@ msgid ""
 "Visit %sDuckDuckGo.com%s on your tablet or phone and follow the provided "
 "instructions."
 msgstr ""
-"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති උපදෙස් "
-"පිළිපදින්න."
+"%1$sDuckDuckGo.com%2$s වෙතට ඔබගේ දුරකථනයෙන් හෝ ටැබ්ලට් එකෙන් පැමිණ සපයා ඇති "
+"උපදෙස් පිළිපදින්න."
 
 # smartling.placeholder_format=C
 #. Primary button to visit Duck.ai.
@@ -23778,9 +23934,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync & "
-"Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ සමමුහුර්ත "
-"කරන්න%8$s තෝරන්න."
+"ඔබගේ අනෙක් බ්‍රව්සරයෙන් Duck.ai වෙත පිවිස %1$sDuck.ai සැකසීම්%2$s > %3$sSync "
+"& Backup%4$s > %5$sකළමනාකරණය කරන්න%6$s වෙත ගොස් %7$sවෙනත් උපාංගයක් සමඟ "
+"සමමුහුර්ත කරන්න%8$s තෝරන්න."
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23790,9 +23946,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn On” තෝරන්න "
-"Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන "
-"PDF එකේ QR ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත කරන්න. “Turn "
+"On” තෝරන්න Sync & Backup යටතේ, “තවත් උපාංගයක් සමඟ සමමුහුර්ත කරන්න” තෝරන්න. "
+"නැතහොත් ඔබගේ ප්‍රතිසාධන PDF එකේ QR ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23814,9 +23970,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai සැකසුම් විවෘත "
-"කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් උපාංගයක් සමග සමමුහුර්ත කරන්න” "
-"තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR කේතය ස්කෑන් කරන්න."
+"ඔබගේ අනෙක් බ්‍රවුසරයෙන් හෝ DuckDuckGo යෙදුමෙන් Duck.ai වෙත පිවිස Duck.ai "
+"සැකසුම් විවෘත කරන්න. “ක්‍රියාත්මක කරන්න” තෝරා Sync & Backup යටතේ, “තවත් "
+"උපාංගයක් සමග සමමුහුර්ත කරන්න” තෝරන්න. නැතහොත් ඔබගේ ප්‍රතිසාධන PDF ගොනුවේ QR "
+"කේතය ස්කෑන් කරන්න."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23869,7 +24026,8 @@ msgstr "හඬ කතාබහ අවසන්"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් භාවිතා කරන්නේ නැහැ."
+"හඬ කතාබස් අපි නිර්නාමික කරලා තියෙනවා, AI ආකෘති පුහුණු කිරීමට කිසි විටෙකත් "
+"භාවිතා කරන්නේ නැහැ."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24019,8 +24177,8 @@ msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
 msgstr ""
-"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ "
-"ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
+"YouTube හි පුද්ගලාරෝපිත දැන්වීම් අවහිර කිරීමට සහ යූ ටියුබ් නිර්දේශයන්ට "
+"බලපෑම් කිරීමෙන් ඔබේ නැරඹීමේ ක්රියාකාරකම් වළක්වා ගැනීමට Duck Player හි නරඹන්න."
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -24040,9 +24198,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට ඔබව නිරීක්ෂණය කළ "
-"හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ යුතු වීමයි. DuckDuckGo යනු ස්වාධීන "
-"සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
+"මෙහි වීඩියෝවක් නැරඹීම යන්නෙන් අදහස් කරන්නේ එහි සත්කාරකත්වය දරන වෙබ් අඩවියට "
+"ඔබව නිරීක්ෂණය කළ හැකි බව වන අතර, ඊට හේතුව අප එහි සිට අන්තර්ගතය විකාශය කළ "
+"යුතු වීමයි. DuckDuckGo යනු ස්වාධීන සමාගමක් වන අතර බොහෝ වීඩියෝ දර්ශන "
+"සත්කාරකත්වය සපයන YouTube සමඟ කිසිදු සම්බන්ධයක් නොමැත."
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24054,7 +24213,9 @@ msgstr "අපි නිර්නාමික කරමු"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ හැකිය."
+msgstr ""
+"ඔබට වඩාත් නිවැරදි ප්‍රතිඵල පෙන්වීමට අපට%1$s ඔබේ ස්ථානය%2$s නිර්නාමික කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24066,9 +24227,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර මෙම සංවාදය DuckDuckGo සමඟ බෙදා ගන්න, එවිට අපට ගැටලුව "
+"විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24080,15 +24241,17 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් වාර්තා කිරීමට, "
-"කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට ගැටලුව විමර්ශනය කර විසඳා ගත "
-"හැකිය."
+"අපට පෙනෙන දේ පමණක් නිවැරදි කළ හැකි ය. හානිකර හෝ නීති විරෝධී ප්‍රතිචාරයක් "
+"වාර්තා කිරීමට, කරුණාකර ඔයාගේ ක්ෂණික පණිවිඩය සහ ප්‍රතිචාරය බෙදා ගන්න එවිට අපට "
+"ගැටලුව විමර්ශනය කර විසඳා ගත හැකිය."
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ හැකිය."
+msgstr ""
+"ඔබට ආසන්න ප්‍රතිඵල පෙන්වීම සඳහා අපට ඔබේ නිර්නාමික%1$s පිහිටීම%2$s භාවිතා කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
@@ -24096,7 +24259,8 @@ msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
 msgstr ""
-"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා කියවිය නොහැක."
+"අමුණා ඇති ගොනුවලින් යටත් පිරිසෙයින් එකක් හෝ සංකේතනය කර ඇති නිසා, අපට ඒවා "
+"කියවිය නොහැක."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24112,7 +24276,9 @@ msgstr "අපි පරිශීලක නාම හෝ පුද්ගලි�
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don't store your personal info or track you. Ever."
-msgstr "කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද නැත."
+msgstr ""
+"කවදාවත් අප ඔබගේ පෞද්ගලික දත්ත ගබඩා කරන්නේ හෝ ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේද "
+"නැත."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24124,8 +24290,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට පත් නොකරන්නෙමු. "
-"අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
+"අපි ඔබේ පුද්ගලික තතු ගබඩා කර නොගන්නෙමු. අපි වෙළෙඳ දැන්වීම්වලින් ඔබව කරදරයට "
+"පත් නොකරන්නෙමු. අපි ඔබව නිරික්සන්නේ නැත. කවදත්."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24139,8 +24305,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
 msgstr ""
-"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි පැවසුවහොත් එය "
-"අපට උපකාරී වීමට හැක:"
+"අපි ඔබව අනවසරයෙන් පරීක්ෂා කරන්නේ නැත, ඉතින් අද ඔබව මෙහි ගෙන ආවේ කුමක්ද යැයි "
+"පැවසුවහොත් එය අපට උපකාරී වීමට හැක:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24149,8 +24315,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ අපට පැවසීමට "
-"ඔබගේ උදව් භාවිතා කළ හැකිය:"
+"අපි ඔබව ලුහුබැඳ නොයන්නෙමු, එබැවින් අද අපව අත්හදා බැලීමට ඔබට ඒත්තු ගැන්වූ දේ "
+"අපට පැවසීමට ඔබගේ උදව් භාවිතා කළ හැකිය:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24190,8 +24356,8 @@ msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
 msgstr ""
-"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම වලට විකිණීමට "
-"කිසිවක් නැත."
+"අප ඔබගේ සෙවුම් ඉතිහාසය ගබඩා කරන්නේ නැත. එම නිසා අපට අන්තර්ජාලය හරහා දැන්වීම "
+"වලට විකිණීමට කිසිවක් නැත."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24217,8 +24383,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට අමතරව VPN එකක් "
-"සහ තවත් දේ ලබා ගන්න."
+"අපි දත්ත තැරැව්කාර අඩවිවලින් ඔබේ පුද්ගලික තොරතුරු සොයාගෙන ඉවත් කරන්නෙමු. ඊට "
+"අමතරව VPN එකක් සහ තවත් දේ ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24227,8 +24393,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ ගිවිසුම් ඇති කරගෙන "
-"ඇත්තෙමු."
+"ඔබගේ කතාබස් AI පුහුණු කිරීම සඳහා භාවිතා නොකිරීමට අපි සියලුම AI සපයන්නන් සමඟ "
+"ගිවිසුම් ඇති කරගෙන ඇත්තෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24253,8 +24419,8 @@ msgid ""
 "We make money from %sprivacy-respecting search ads%s, not by exploiting your "
 "data."
 msgstr ""
-"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ දත්ත සූරාකෑමෙන් "
-"නොවේ."
+"අපි %1$sපෞද්ගලිකත්වයට ගරු කරන සෙවුම් දැන්වීම්%2$s මගින් මුදල් උපයන්නෙමු, ඔබේ "
+"දත්ත සූරාකෑමෙන් නොවේ."
 
 # smartling.placeholder_format=C
 #. Message describing how DuckDuckGo users location access anonymously to provide better search results.
@@ -24263,8 +24429,8 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික පිහිටීම භාවිතා "
-"කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
+"අපි ඔබට වඩා ආසන්නයෙන් ඇති, වඩා හොඳ ප්‍රතිඵල ලබා දීම සඳහා පමණක් ඔබේ නිර්නාමික "
+"පිහිටීම භාවිතා කරන්නෙමු. ඔබට ඕනෑම මොහොතක පසුව ඔබේ අදහස වෙනස් කරගත හැක."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24273,15 +24439,16 @@ msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
 msgstr ""
-"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, භාවිතයට පහසු "
-"උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
+"ඔබේ පෞද්ගලික තොරතුරු සඳහා අපි දත්ත තැරැව්කාර අඩවි නිතිපතා ස්කෑන් කරන අතර, "
+"භාවිතයට පහසු උපකරණ පුවරුවකින් අපගේ ප්‍රගතිය ඔබ සමඟ බෙදා ගන්නෙමු."
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
 msgstr ""
-"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත රඳා සිටිමු."
+"අපි DuckDuckGo සෑම කෙනෙකුටම වඩා හොඳ කිරීම සඳහා ඔබේ නිර්නාමික ප්‍රතිචාර මත "
+"රඳා සිටිමු."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24302,13 +24469,15 @@ msgid ""
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
 msgstr ""
-"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි අභිමතය පරිදි "
-"යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
+"DuckDuckGo වැඩි දියුණු කිරීම සඳහා අපි මෙවැනි ප්‍රතිපෝෂණ භාවිතා කරමු. %1$s හි "
+"අභිමතය පරිදි යෝජනා ඇතුළත් කෙරේ. නිවැරදි කිරීම් වහාම ප්‍රතිඵලවල නොපෙන්වයි."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර කරන්නෙමු."
+msgstr ""
+"ඔබ බ්‍රවුස් කරන විට ඔබගේ දත්ත රැස් කිරීමට උත්සාහ කරන ට්‍රැකර් අපි අවහිර "
+"කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24317,8 +24486,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි ස්කෑන් කර, ඔබ ගැන "
-"සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
+"අපි ඔබේ විද්‍යුත් තැපෑල, නම, ලිපිනය සහ තවත් දේ සඳහා දත්ත තැරැව්කාර අඩවි "
+"ස්කෑන් කර, ඔබ ගැන සොයා ගන්නා ඕනෑම දෙයක් ඉවත් කිරීමට කටයුතු කරන්නෙමු."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24327,8 +24496,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට මෙම දෝෂය දිගටම "
-"පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. ඔබට "
+"මෙම දෝෂය දිගටම පෙනේ නම්, කරුණාකර %1$s වෙත සම්බන්ධ වන්න."
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24337,8 +24506,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
 msgstr ""
-"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර විට ඔබගේ "
-"බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
+"අපි මෙම ගැටලුව පිළිබඳව දන්නා අතර දැනට එය විසඳීමට කටයුතු කරමින් සිටිමු. සමහර "
+"විට ඔබගේ බ්‍රවුසරයේ හැඹිලිය හිස් කිරීම උපකාරී විය හැක."
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24353,7 +24522,8 @@ msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
 msgstr ""
-"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි මහන්සි වෙමින් සිටිමු."
+"අප මේ අපහසුතාව ගැන කනගාටුව ප්‍රකාශ කරමු. ඔබේ අත්දැකීම වඩා හොඳ කිරීමට අපි "
+"මහන්සි වෙමින් සිටිමු."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24362,7 +24532,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත පූරණය කළ යුතුය."
+"අපි Duck.ai සේවාව යාවත්කාලීන කළෙමු. වෙනස ක්‍රියාත්මක වීමට, අප පිටුව නැවත "
+"පූරණය කළ යුතුය."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24471,8 +24642,8 @@ msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
 msgstr ""
-"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම කතාබහේ යෙදිය "
-"හැකි ය."
+"සතිපතා පරිශීලන සීමාවට ළඟා වී ඇත. ඔබේ මාසික සීමාව භාවිතා කිරීමෙන් ඔබට දිගටම "
+"කතාබහේ යෙදිය හැකි ය."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24486,8 +24657,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර "
-"ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"Duck.ai වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප "
+"විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24496,8 +24667,9 @@ msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් පුද්ගලිකයි, අප විසින් "
-"නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙහි ඇති ඔබගේ සියලු කතාබස් "
+"පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
+"නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24507,15 +24679,17 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ %1$sගේ %2$s "
-"විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් DuckDuckGo විසින් ගබඩා කර හෝ AI "
-"ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
+"DuckDuckGo AI Chat වෙත සාදරයෙන් පිළිගනිමු! මෙම කතාබස් සැසිය බලගන්වන්නේ "
+"%1$sගේ %2$s විසිනි. මෙහි ඔබගේ සියලු කතාබස් පෞද්ගලික වන අතර, කිසි විටෙකත් "
+"DuckDuckGo විසින් ගබඩා කර හෝ AI ආකෘති පුහුණු කිරීම සඳහා භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න පුළුවන්."
+msgstr ""
+"නව Duck.ai වෙත සාදරයෙන් පිළිගනිමු! දැන් ඔයාට බාගත කරගත් කතාබස් ආයාත කරන්න "
+"පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24583,8 +24757,8 @@ msgid ""
 "We’re really sorry, but it seems there was a problem loading Duck.ai. Try "
 "reloading the page."
 msgstr ""
-"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. පිටුව නැවත "
-"ප්‍රවේශනය කර උත්සාහ කරන්න."
+"අපිට ඇත්තටම කණගාටුයි, නමුත් Duck.ai පූරණය කිරීමේදී ගැටලුවක් ඇතිවූ බව පෙනේ. "
+"පිටුව නැවත ප්‍රවේශනය කර උත්සාහ කරන්න."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to suggest an AI (Artificial Intelligence) model to be added to the product, and this field is optional.
@@ -24599,7 +24773,8 @@ msgid ""
 "What are some arguments, counter-arguments, and rebuttals to the concept of "
 "a plant-based diet?"
 msgstr ""
-"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ ප්‍රතිවිරෝධතා මොනවාද?"
+"ශාක පදනම් කරගත් ආහාරයක් පිළිබඳ සංකල්පයට සමහර තර්ක, ප්‍රති-තර්ක සහ "
+"ප්‍රතිවිරෝධතා මොනවාද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
@@ -24620,8 +24795,8 @@ msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
 msgstr ""
-"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර විකල්ප "
-"මොනවාද."
+"“අපි ඇත්තටම වඩා හොඳ කරන්න ඕන” යන සන්දර්භය තුළ 'වඩා හොඳ' යන වචනය සඳහා සමහර "
+"විකල්ප මොනවාද."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24646,10 +24821,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ ප්‍රතිලාභ මොනවා "
-"ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ කිරීම් සහ රහස්‍යතා ආරක්ෂණ "
-"කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික "
-"අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
+"Duck.ai භාවිතා කිරීමට උනන්දුවක් දක්වන කෙනෙකුට DuckDuckGo බ්‍රව්සරය බාගැනීමේ "
+"ප්‍රතිලාභ මොනවා ද? නිල DuckDuckGo මූලාශ්‍ර පමණක් යොමු කරන්න. Duck.ai ඒකාබද්ධ "
+"කිරීම් සහ රහස්‍යතා ආරක්ෂණ කෙරෙහි අවධානය යොමු කරමින්, ප්‍රතිචාරය මාතෘකා සහිත "
+"පැහැදිලි කොටස්වලට බෙදන්න. AI හෝ තාක්ෂණික අත්දැකීම් ඇති හෝ නැති අයට එය තරමක් "
+"කෙටි, සරල සහ තේරුම් ගැනීමට පහසු වන පරිදි සකසන්න."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24885,7 +25061,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් වන්නේ කෙසේද?"
+"Cloud Save පොත් සලකුණු යනු කුමක්ද සහ එය URL පරාමිති පොත් සලකුණු වලින් වෙනස් "
+"වන්නේ කෙසේද?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -24986,8 +25163,8 @@ msgid ""
 "When buying an electric guitar for a beginner, what are the top product "
 "brands I should consider?"
 msgstr ""
-"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම නිෂ්පාදන වෙළඳ නාම "
-"මොනවාද?"
+"ආරම්භකයෙකු සඳහා විදුලි ගිටාරයක් මිලදී ගැනීමේදී, මා සලකා බැලිය යුතු ඉහළම "
+"නිෂ්පාදන වෙළඳ නාම මොනවාද?"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -25188,8 +25365,9 @@ msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
 msgstr ""
-"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු කිරීමට භාවිත "
-"නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය කරන්න."
+"Duck.ai සමඟින්, ඔබගේ කතාබස් නිර්නාමික කර ඇති අතර ඒවා කිසි විටෙකත් AI පුහුණු "
+"කිරීමට භාවිත නොකෙරේ. '%1$s' මෙනුව තුළ ඕනෑම වේලාවක එය සක්‍රිය හෝ අක්‍රිය "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25198,8 +25376,8 @@ msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
 msgstr ""
-"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස්වලින් %1$sක් දක්වා මෙම "
-"උපාංගයේ සුරැකෙනු ඇත."
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස්වලින් "
+"%1$sක් දක්වා මෙම උපාංගයේ සුරැකෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25207,8 +25385,8 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
 msgstr ""
-"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස් මෙම උපාංගයේ සුරැකෙනු "
-"ඇත."
+"කතාබස් ඉතිහාසය ක්‍රියාත්මක කර ඇති විට, ඔබේ වඩාත්ම මෑත කාලීන කතාබස් මෙම "
+"උපාංගයේ සුරැකෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25223,8 +25401,8 @@ msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
 msgstr ""
-"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් ඉවත් කිරීමට ඔබේ "
-"උපාංගයෙන්ම ක්‍රියා කරයි."
+"ඔබේ විද්‍යුත් තැපැල් ලිපිනය, නම, ලිපිනය සහ තවත් දේ දත්ත තැරැව්කාර අඩවිවලින් "
+"ඉවත් කිරීමට ඔබේ උපාංගයෙන්ම ක්‍රියා කරයි."
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25491,7 +25669,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"ඔබට එය %1$sහි නැරඹිය හැකිය. AI කතාබස් සාවද්ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25500,8 +25680,8 @@ msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
 msgstr ""
-"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර මත කඍජුව %1$s හෝ "
-"සෙවිය හැකිය."
+"ඔබට %2$s සෙවුම් කෙටිමං භාවිත කරමින් DuckDuckGo වෙතින් වෙනත් සෙවුම් යන්ත්‍ර "
+"මත කඍජුව %1$s හෝ සෙවිය හැකිය."
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25515,8 +25695,8 @@ msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s තුළ එය "
-"අක්‍රිය කළ හැකිය."
+"ඔබට %1$s ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ ඕනෑම වේලාවක %2$sසෙවුම් සැකසුම්%3$s "
+"තුළ එය අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25525,21 +25705,22 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් කිරීමට හෝ එය "
-"අක්‍රිය කිරීමට හැකිය."
+"ඔබට %1$sසෙවුම් සැකසීම්%2$s තුළ ඕනෑම වේලාවක Assist ක්‍රියා කරන ආකාරය සකස් "
+"කිරීමට හෝ එය අක්‍රිය කිරීමට හැකිය."
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
 msgstr ""
-"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ හැකිය."
+"ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට ඔබට %1$sDuck.ai%2$s ද භාවිත කළ "
+"හැකිය."
 
 # smartling.placeholder_format=C
 msgid ""
 "You can also use %sDuckDuckGo AI Chat%s to answer questions or summarize "
 "text."
 msgstr ""
-"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s ද භාාවිත "
-"කළ හැකිය."
+"ඔබට ප්‍රශ්නවලට පිළිතුරු දීමට හෝ පෙළ සාරාංශ කිරීමට %1$sDuckDuckGo AI Chat%2$s "
+"ද භාාවිත කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach more text selections than are allowed. Placeholder is the maximum number of text selections. E.g. You can attach up to 5 text selections.
@@ -25553,8 +25734,8 @@ msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
 msgstr ""
-"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, එය "
-"සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
+"ඔබට %1$sසෙවුම් සැකසුම්%2$s තුළ Search Assist දකින වාර ගණන වෙනස් කළ හැකි අතර, "
+"එය සම්පූර්ණයෙන්ම අක්‍රිය කළ හැකිය."
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25575,8 +25756,8 @@ msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
 msgstr ""
-"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස පළමු සමූහය "
-"මකනවා."
+"වෙනස් මුර පදයක් යටතේ ඔබගේ සැකසුම් සුරැකීමෙන් ඔබට මෙය කළ හැකිය, විකල්පයක් ලෙස "
+"පළමු සමූහය මකනවා."
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25669,8 +25850,8 @@ msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
 msgstr ""
-"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම වෙනත් වෙබ් අඩවියක් "
-"අහිතකර කිරීමට අවශ්ය වේ."
+"ඔබට අවහිර කළ හැක්කේ අඩවි %1$s දක්වා පමණි. %2$s අවහිර කිරීමට, ඔබ මුලින්ම "
+"වෙනත් වෙබ් අඩවියක් අහිතකර කිරීමට අවශ්ය වේ."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25734,8 +25915,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් පුළුල් පරිශීලන "
-"සීමාවන් ඇත."
+"ඔබට දැන් %1$s වෙත ප් රවේශය, ඉහළ AI තර්කනය සහ Plus ප්‍රකාරයට වඩා දෙගුණයක් "
+"පුළුල් පරිශීලන සීමාවන් ඇත."
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25744,8 +25925,8 @@ msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
 msgstr ""
-"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ අනෙකුත් "
-"DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
+"ඔබට දැන් උසස් AI ආකෘති වෙත ප්‍රවේශය ඇත. ඔබට DuckDuckGo බ්‍රවුසරයේ VPN සහ "
+"අනෙකුත් DuckDuckGo දායකත්ව ආරක්ෂණ වෙත ප්‍රවේශ විය හැක."
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25767,9 +25948,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් දේශීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25779,9 +25960,9 @@ msgid ""
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
 msgstr ""
-"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි වනු ඇත. අවසාන "
-"කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් සංකේතනය කළ සර්වරයෙන් මකා දමනු "
-"නොලැබේ."
+"මෙම බ්‍රව්සරයෙන් ඔබගේ සුරකින ලද කතාබස් වෙත ප්‍රවේශ වීමට ඔබට තවදුරටත් නොහැකි "
+"වනු ඇත. අවසාන කතාබස් 30 තවමත් ස්ථානීය ගබඩාවේ පවතිනු ඇත. මින් ඔබේ කතාබස් "
+"සංකේතනය කළ සර්වරයෙන් මකා දමනු නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25794,7 +25975,9 @@ msgctxt "Update browser banner"
 msgid ""
 "You'll receive automatic DuckDuckGo app updates once you have the latest "
 "version."
-msgstr "ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන ලැබෙනු ඇත."
+msgstr ""
+"ඔබට නවතම අනුවාදය ලැබුණු පසු ඔබට ස්වයංක්‍රීය DuckDuckGo යෙදුම් යාවත්කාලීන "
+"ලැබෙනු ඇත."
 
 # smartling.placeholder_format=C
 #. Celebration heading shown when the user has completed every step of the onboarding checklist.
@@ -25809,8 +25992,8 @@ msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome වෙනුවට අපගේ යෙදුම භාවිතා "
-"කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chromeහි පුද්ගලිකව සොයමින් සිටී. පුද්ගලිකව පිරික්සීමටත් Chrome "
+"වෙනුවට අපගේ යෙදුම භාවිතා කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25823,8 +26006,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර ගැනීමට ඉඟි ලබා "
-"ගන්න."
+"ඔබ දැන් පෞද්ගලිකත්වයෙන් යුතුව සොයයි. %1$sඔබගේ පා සටහන් තව දුරටත් අවම කර "
+"ගැනීමට ඉඟි ලබා ගන්න."
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25900,8 +26083,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
-"ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට ඇමුණුම් සහිත Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත "
+"කිරීම නැවත ආරම්භ කිරීමට පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25911,8 +26095,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත ආරම්භ කිරීමට "
-"ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු නොලැබේ."
+"ඔබට Duck.ai කතාබස් සඳහා Sync & Backup ඉඩ අවසන් වී ඇත. සමමුහුර්ත කිරීම නැවත "
+"ආරම්භ කිරීමට ඇමුතුම් සමඟ පැරණිතම කතාබස් %1$s මකන්න. ඇමුණූ කතාබස් මකා දමනු "
+"නොලැබේ."
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25926,8 +26111,9 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. ඒ වගේම, "
-"Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා කිරීමකට ලක් වෙන්න පුළුවන්."
+"Youtube (Google සතු) ඔබට නිර්නාමිකව වීඩියෝ දර්ශන නැරඹීමට ඉඩ ලබා දෙන්නේ නැහැ. "
+"ඒ වගේම, Youtube වීඩියෝ නැරඹීමේදී Google/Youtube මගින් අනවසරයෙන් පරීක්ෂා "
+"කිරීමකට ලක් වෙන්න පුළුවන්."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25987,8 +26173,8 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync."
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත."
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත."
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list. The %s is a placeholder for the maximum number of chats stored locally.
@@ -25998,8 +26184,9 @@ msgid ""
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබගේ මෑත කාලීන කතාබස් %1$s මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා "
+"ගත හැකිය:"
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -26009,8 +26196,9 @@ msgid ""
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
 msgstr ""
-"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් විසන්ධි වනු "
-"ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත හැකිය:"
+"ඔබේ උපස්ථය DuckDuckGo සර්වරයෙන් මකා දැමෙනු ඇත. සියලුම උපාංග සමමුහුර්තකරණයෙන් "
+"විසන්ධි වනු ඇත. ඔබේ මෑත කාලීන කතාබස් 100 මෙම බ්‍රව්සර්වල දේශීය ගබඩාවේ ලබා ගත "
+"හැකිය:"
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -26035,8 +26223,8 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත කිසිවිටෙක මෙම දත්ත "
-"වෙත ප්‍රවේශය නොමැත."
+"ඔබගේ බ්‍රවුසරය ඔබ වැඩිපුරම නරඹන අඩවි ලැයිස්තුවක් සපයයි. DuckDuckGo වෙත "
+"කිසිවිටෙක මෙම දත්ත වෙත ප්‍රවේශය නොමැත."
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -26044,8 +26232,8 @@ msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
 msgstr ""
-"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට කවදාවත් අවසරයක් "
-"නැහැ ඒ දත්ත වලට."
+"ඔබගේ බ්‍රව්සරය නිතරම නරඹන අඩවි ලැයිස්තුවක් සපයනවා. නමුත් DuckDuckGo වලට "
+"කවදාවත් අවසරයක් නැහැ ඒ දත්ත වලට."
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26053,7 +26241,9 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය හැකිය."
+msgstr ""
+"%1$s සමඟ ඔයාගේ චැට් පුද්ගලිකයි. AI චැට් සාවද්‍ය හෝ අමනාපකාරී තොරතුරු පෙන්විය "
+"හැකිය."
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -26066,7 +26256,8 @@ msgstr "ඔබගේ කතාබස් දැන් සුරැකෙමින
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ භාවිත නොකෙරේ"
+"ඔබේ කතාබස් පුද්ගලික වන අතර AI ආකෘති පුහුණු කිරීම සඳහා කිසිවිටෙකත් සුරකිනු හෝ "
+"භාවිත නොකෙරේ"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26080,7 +26271,8 @@ msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
@@ -26088,7 +26280,8 @@ msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු කිරීමට භාවිත නොකෙරේ."
+"ඔබගේ කතාබස් පුද්ගලිකයි, අප විසින් නිර්නාමිකෘත කර ඇති අතර AI ආකෘති පුහුණු "
+"කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -26096,8 +26289,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26105,8 +26298,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති පුහුණු කිරීමට භාවිත "
-"නොකෙරේ."
+"ඔබේ කතාබස් පුද්ගලික වන අතර, අප විසින් කිසි විටෙකත් සුරකින අතර AI ආකෘති "
+"පුහුණු කිරීමට භාවිත නොකෙරේ."
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26121,8 +26314,9 @@ msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
 msgstr ""
-"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා කෘත්‍රිම බුද්ධි ආකෘති "
-"පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා ගැනීමට මේ පියවර අනුගමනය කරන්න."
+"ඔබගේ කතාබස් පුද්ගලික වන අතර ඒ්වා අප විසින් නිර්නාමික කර තිබේ. තව ද ඒ්වා "
+"කෘත්‍රිම බුද්ධි ආකෘති පුහුණු කිරීමට යොදා ගනු නොලැබේ. ඔබේ කතාබස් ඉතිහාසය තබා "
+"ගැනීමට මේ පියවර අනුගමනය කරන්න."
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -26162,8 +26356,8 @@ msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
 msgstr ""
-"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ සම්බන්ධ කිරීමක් සිදු නොවේ. "
-"[%2$sඋදාහරණ පණිවිඩය%3$s]"
+"ඔබගේ විද්‍යුත් තැපැල් ලිපිනය බෙදාහැරීමක්, %1$sහෝ නිර්නාමික සෙවුම් සමඟ "
+"සම්බන්ධ කිරීමක් සිදු නොවේ. [%2$sඋදාහරණ පණිවිඩය%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -26206,9 +26400,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ මුරපදය 512-bit "
-"යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත සැකසුම් ගොනුව පමණි. යතුර නම ලෙස "
-"භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
+"%1$sSHA-2%2$s ලෙස හැඳින්වෙන ආරක්ෂිත හැෂ් ඇල්ගොරිතම භාවිතා කිරීමෙන් ඔබගේ "
+"මුරපදය 512-bit යතුරක් ජනනය කරයි.. ඔබගේ බ්‍රව්සරයෙන් පිටවන්නේ යතුර සහ ආශ්‍රිත "
+"සැකසුම් ගොනුව පමණි. යතුර නම ලෙස භාවිතා කර අපි සැකසුම් ගොනුව සුරකිමු. "
+"DuckDuckGo කිසි විටෙකත් ඔබේ මුරපදය දන්නේ නැත."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26223,8 +26418,9 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත හැකි පාර-දත්ත "
-"ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත සම්බන්ධ කළ නොහැක."
+"ඔබගේ විමසීම් DuckDuckGo සර්වර හරහා යවනු ලබන අතර ඒවායෙන් පුද්ගලිකව හඳුනාගත "
+"හැකි පාර-දත්ත ඉවත් කරනු ලැබේ, එබැවින් ආකෘති සපයන්නන්ට ඔබගේ සංවාද ඔබ හා නැවත "
+"සම්බන්ධ කළ නොහැක."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26238,8 +26434,8 @@ msgid ""
 "Your recent chats live here! You can refer to your chats or clear them "
 "anytime."
 msgstr ""
-"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම වේලාවක "
-"ඒවා ඉවත් කළ හැකි ය."
+"ඔබගේ මෑත කාලීන කතාබස් මෙහි ඇත! ඔබට ඔබේ කතාබස් වෙත යොමු විය හැකි ය හෝ ඕනෑම "
+"වේලාවක ඒවා ඉවත් කළ හැකි ය."
 
 # smartling.placeholder_format=C
 #. Message on a feedback form.
@@ -26271,8 +26467,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව සක්‍රීය කරන්න."
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26281,8 +26477,9 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය ස්ථිර කර ගැනීමට "
-"%1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර දැනගන්න%4$s"
+"ඔබේ සැකසුම් සුරැකෙනු ඇත, නමුත් කුකී මකා දැමීමෙන් ඒවා යළි සැකසෙනු ඇත. එය "
+"ස්ථිර කර ගැනීමට %1$sDuckDuckGo No AI%2$s දිගුව ස්ථාපනය කරන්න. %3$sවැඩිදුර "
+"දැනගන්න%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26310,8 +26507,8 @@ msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
 msgstr ""
-"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට අපේ බ්‍රවුසරය "
-"භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
+"දැන් ඔබ Chrome හි පුද්ගලිකව සොයමින් සිටී. වැඩි ආරක්ෂාව සඳහා Chrome වෙනුවට "
+"අපේ බ්‍රවුසරය භාවිත කරන්න. එය දැනටමත් ස්ථාපනය කර ඇති අතර හැකියාව ඇත්තේ:"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26320,7 +26517,8 @@ msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
 msgstr ""
-"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ කරන්න."
+"ඔබ උපරිම පණිවිඩ ප්‍රමාණය ඉක්මවා ඇත. කරුණාකර ඔබගේ පණිවිඩය කෙටි කර නැවත උත්සාහ "
+"කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26329,8 +26527,8 @@ msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
 msgstr ""
-"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button සමඟ "
-"මෙම සංවාදය ඉවත් කරන්න."
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. දිගටම කරගෙන යාම සඳහා Fire Button "
+"සමඟ මෙම සංවාදය ඉවත් කරන්න."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26338,7 +26536,9 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Start a new "
 "chat to continue."
-msgstr "ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ ගන්න."
+msgstr ""
+"ඔබ මෙම සංවාදයේ උපරිම කතාබස් දිගට පැමිණ ඇත. ඉදිරියට යාමට නව කතාබහක් ආරම්භ "
+"ගන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when the user has reached the maximum voice chat duration.
@@ -26353,8 +26553,8 @@ msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
 msgstr ""
-"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් දිගටම කරගෙන "
-"යන්න."
+"ඔබ එක් දිනක් සඳහා උපරිම පණිවිඩ සංඛ්‍යාවට ළඟා වී ඇත. කරුණාකර හෙට මෙම කතාබස් "
+"දිගටම කරගෙන යන්න."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,7 +95,8 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr ""
+"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -106,7 +107,8 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr ""
+"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -230,7 +232,8 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr ""
+"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -312,7 +315,8 @@ msgstr "Rebríček %1$s ešte nie je k dispozícii"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr "%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
+msgstr ""
+"%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -476,7 +480,8 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr ""
+"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -508,13 +513,15 @@ msgstr "%1$sZistiť viac%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr ""
+"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -526,7 +533,8 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr ""
+"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -950,14 +958,16 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr ""
+"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1672,7 +1682,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
+msgstr ""
+"Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2024,7 +2035,8 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr ""
+"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2957,6 +2969,18 @@ msgstr ""
 "metadáta."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3106,7 +3130,8 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr ""
+"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -5343,7 +5368,8 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
+msgstr ""
+"Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5473,7 +5499,8 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr ""
+"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5691,7 +5718,8 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr "Vytvorí kópiu četu, ktorú si môže zobraziť a uložiť každý, kto otvorí odkaz."
+msgstr ""
+"Vytvorí kópiu četu, ktorú si môže zobraziť a uložiť každý, kto otvorí odkaz."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6515,6 +6543,12 @@ msgid "Dislike source"
 msgstr "Nepáči sa mi zdroj"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Skryť"
@@ -6625,6 +6659,12 @@ msgid "Djibouti"
 msgstr "Džibutsko"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6678,7 +6718,8 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr ""
+"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -7042,7 +7083,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr ""
+"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7349,8 +7391,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
-"e-mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
+"mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7358,13 +7400,15 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr ""
+"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7533,7 +7577,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr ""
+"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7752,7 +7797,8 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr ""
+"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8483,6 +8529,12 @@ msgid "Fast"
 msgstr "Rýchle"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8677,7 +8729,8 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr ""
+"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8689,7 +8742,8 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr ""
+"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8813,6 +8867,12 @@ msgstr "Doplňujúca otázka"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Doplňujúce otázky zostávajú súkromné."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9170,7 +9230,8 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr ""
+"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9553,8 +9614,8 @@ msgstr "Získaj aplikáciu"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
-"YouTube.%2$s"
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na YouTube."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9666,7 +9727,8 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr ""
+"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9753,6 +9815,12 @@ msgstr "Dobrý dizajn"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Dobrá politika ochrany osobných údajov"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10494,7 +10562,8 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr ""
+"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10894,6 +10963,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Obrazové príkayy musia byť v súlade s Duck.ai %1$s."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11366,7 +11441,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr ""
+"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11416,7 +11492,8 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr ""
+"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11880,7 +11957,8 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr ""
+"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -11943,8 +12021,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
-"Duck.ai"
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -14449,7 +14527,8 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr ""
+"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14528,7 +14607,8 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr ""
+"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -14679,7 +14759,8 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr ""
+"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15506,7 +15587,8 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr ""
+"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15759,6 +15841,12 @@ msgstr "Poľština"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Zlé formátovanie"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16558,7 +16646,8 @@ msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
+msgstr ""
+"Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17687,7 +17776,8 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr ""
+"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17884,7 +17974,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr ""
+"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18048,7 +18139,8 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr ""
+"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18184,7 +18276,8 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr ""
+"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18234,7 +18327,8 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr ""
+"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18263,9 +18357,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
-"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
-"zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
+"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18469,13 +18562,15 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr ""
+"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr ""
+"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18919,7 +19014,8 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr ""
+"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19227,7 +19323,8 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr ""
+"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19487,7 +19584,8 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19503,12 +19601,14 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr ""
+"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19539,7 +19639,8 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr ""
+"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19549,7 +19650,8 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr ""
+"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19860,7 +19962,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr ""
+"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19894,7 +19997,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr ""
+"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -19948,7 +20052,8 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr ""
+"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20214,7 +20319,8 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr ""
+"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20711,7 +20817,8 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr ""
+"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -21018,7 +21125,8 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr ""
+"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21334,7 +21442,8 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr ""
+"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21453,7 +21562,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr ""
+"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21805,7 +21915,8 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr ""
+"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -21928,8 +22039,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
-"vám.%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
+"%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -21977,8 +22088,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
-"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
+"%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22038,7 +22149,8 @@ msgstr "Prepni na súkromný AI čet alebo ho %1$svypni v nastaveniach%2$s."
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
+msgstr ""
+"Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22099,6 +22211,12 @@ msgstr "Príliš veľa výsledkov z tohto zdroja"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Príliš pomalé"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22521,13 +22639,15 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr ""
+"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr ""
+"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22541,6 +22661,12 @@ msgstr "Skúste experimentovať s každým modelom - poskytnú rôzne reakcie."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Skúste menej kľúčových slov."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22892,7 +23018,8 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr ""
+"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -22915,7 +23042,8 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr ""
+"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23121,13 +23249,14 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
-"https://duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
+"duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr ""
+"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23140,7 +23269,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr ""
+"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23154,7 +23284,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr ""
+"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -24103,7 +24234,8 @@ msgstr "Tapeta"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr "Chceš mať jednoduchý prístup k súkromnému AI četu na stránke novej karty?"
+msgstr ""
+"Chceš mať jednoduchý prístup k súkromnému AI četu na stránke novej karty?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24787,7 +24919,8 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr ""
+"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -25163,7 +25296,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr ""
+"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25181,7 +25315,8 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr ""
+"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25221,7 +25356,8 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr ""
+"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -26140,7 +26276,8 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr "Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
+msgstr ""
+"Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26213,7 +26350,8 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr ""
+"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26262,7 +26400,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr ""
+"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26323,7 +26462,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr ""
+"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26519,7 +26659,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr ""
+"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26863,7 +27004,8 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr ""
+"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sk_SK/LC_MESSAGES/duckduckgo.po
+++ b/locales/sk_SK/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sk_SK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,8 +95,7 @@ msgstr "%1$s a %2$s Modely umelej inteligencie"
 #. Message that appears above the search results encouraging them to filter results by domain. The placeholder string would include a the name of a website. E.g. 'Reddit appears in some of the top results for this search.'
 msgctxt "Site filter message"
 msgid "%s appears in some of the top results for this search."
-msgstr ""
-"%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
+msgstr "%1$s sa vyskytuje v niektorých z najlepších výsledkov pre toto vyhľadávanie."
 
 # smartling.placeholder_format=C
 #. Number of tracking attempts blocked, when there is more than 1. Eg: '2 attempts' or '302 attempts'
@@ -107,8 +106,7 @@ msgstr "Pokusy: %1$s"
 # smartling.placeholder_format=C
 #. A summary description of how many tracking attempts where blocked, when there was more than 1. Eg: '1,028 attempts blocked by DuckDuckGo in the last 24 hours'
 msgid "%s attempts blocked by DuckDuckGo in the last 24 hours"
-msgstr ""
-"DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
+msgstr "DuckDuckGo za posledných 24 hodín zablokoval nasledujúci počet pokusov: %1$s"
 
 # smartling.placeholder_format=C
 #. A label that indicates a specific search result has been blocked by the safe search filter. The placeholder value is the name of the search result that was blocked.
@@ -232,8 +230,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
+msgstr "%1$s je dočasne nedostupný. Prejdite na iný model alebo to skúste neskôr."
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -315,8 +312,7 @@ msgstr "Rebríček %1$s ešte nie je k dispozícii"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits 2-5x faster than other models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s reaches usage limits 2-5x sooner than basic models. %s"
-msgstr ""
-"%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
+msgstr "%1$s dosahuje limity používania 2–5× rýchlejšie ako základné modely. %2$s"
 
 # smartling.placeholder_format=C
 #. Warning text shown when approaching the dictation recording time limit. %s is replaced with the time remaining (e.g. '1:00').
@@ -480,8 +476,7 @@ msgctxt "noresults"
 msgid ""
 "%sClick here%s to try again, if you think there should be results for this "
 "search."
-msgstr ""
-"%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
+msgstr "%1$sSkúste to znova%2$s, ak si myslíte, že sa mali nájsť nejaké výsledky."
 
 # smartling.placeholder_format=C
 #. Header for a page with information about sharing DuckDuckGo.
@@ -513,15 +508,13 @@ msgstr "%1$sZistiť viac%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
+msgstr "%1$sZisti viac%2$s o tom, ako sú čety súkromne uložené na serveri DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
+msgstr "%1$sZisti viac%2$s o tom, ako sú chaty súkromne uložené v tvojom zariadení."
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -533,8 +526,7 @@ msgstr "%1$sDlho stlačte%2$s ikonu aplikácie DuckDuckGo na úvodnej obrazovke"
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
+msgstr "%1$sAch!%2$s%3$sNiečo sa pokazilo. Prosím, %4$sobnov%5$s a skús to znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -958,16 +950,14 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
+msgstr "K dispozícii je nová verzia AI Chat! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
+msgstr "Je k dispozícii nová verzia Duck.ai! Ak chceš pokračovať, obnov túto stránku."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1682,8 +1672,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
+msgstr "Pokročilé modely môžu využiť limity 2-5x rýchlejšie než iné modely. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2035,8 +2024,7 @@ msgstr "Už je to synchronizované."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
+msgstr "Vyhľadávajte súkromne aj vo svojom zariadení iPad alebo iPhone či Androide!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2979,6 +2967,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Pred uložením tohto hlásenia DuckDuckGo odstráni nahrané súbory a "
+"vygenerované obrázky a anonymizuje tvoju konverzáciu odstránením osobných "
+"údajov, ako sú mená, e-mailové adresy a identifikačné metadáta."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3130,8 +3121,7 @@ msgstr "Zablokovať túto stránku vo všetkých výsledkoch"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
+msgstr "Blokujte sledovače a prevezmite späť kontrolu nad svojimi osobnými údajmi"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -5368,8 +5358,7 @@ msgstr "Pokračuj v blokovaní reklám"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
+msgstr "Tu pokračuj v nedávnych četoch. Alebo ich vymaž pomocou tlačidla Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5499,8 +5488,7 @@ msgstr "Kopírovať"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
+msgstr "Skopírujte a prilepte %1$sabout:preferences#search%2$s do panela s adresou."
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5718,8 +5706,7 @@ msgctxt "Share modal info bullet about public access"
 msgid ""
 "Creates a copy of the chat that can be viewed and saved by anyone who opens "
 "the link."
-msgstr ""
-"Vytvorí kópiu četu, ktorú si môže zobraziť a uložiť každý, kto otvorí odkaz."
+msgstr "Vytvorí kópiu četu, ktorú si môže zobraziť a uložiť každý, kto otvorí odkaz."
 
 # smartling.placeholder_format=C
 #. Explains that anyone with the link can view the shared copy.
@@ -6546,7 +6533,7 @@ msgstr "Nepáči sa mi zdroj"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Nepáči sa mi vizuálny štýl"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6662,7 +6649,7 @@ msgstr "Džibutsko"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Nedodržiava pokyny"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6718,8 +6705,7 @@ msgstr "Nevidíte súbor? %1$s%2$s%3$sKliknite sem a stiahnite si ho znova.%4$s
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Don't see the checkbox? %sFollow these steps%s."
-msgstr ""
-"Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
+msgstr "Nevidíte začiarkavacie políčko? %1$sPostupujte podľa týchto krokov%2$s."
 
 # smartling.placeholder_format=C
 #. Setting that hides a user's most visited sites when they open a new browser tab.
@@ -7083,8 +7069,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
+msgstr "Duck.ai je najlepší v našom súkromnom a bezplatnom prehliadači DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7391,8 +7376,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite e-"
-"mailom tento anonymný kód %1$s na adresu %2$s"
+"DuckDuckGo AI Chat je dočasne nedostupný. Ak to bude pretrvávať, pošlite "
+"e-mailom tento anonymný kód %1$s na adresu %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7400,15 +7385,13 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Obnovte stránku a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
+msgstr "DuckDuckGo AI Chat je dočasne nedostupný. Prosím, skúste to neskôr znova."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -7577,8 +7560,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
+msgstr "DuckDuckGo anonymizuje tvoje chaty. Kliknutím na „%1$s“ súhlasíš s %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7797,8 +7779,7 @@ msgstr "Upravujem obrázok..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
+msgstr "Úpravou tvojej správy sa odstráni nižšie uvedená odpoveď, a vytvorí sa nová."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8532,7 +8513,7 @@ msgstr "Rýchle"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Rýchle generovanie obrázka"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8729,8 +8710,7 @@ msgstr "Finančný poradca"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
+msgstr "Nájdite %1$sDuckDuckGo%2$s a kliknite na%3$sNastaviť ako predvolené%4$s."
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8742,8 +8722,7 @@ msgstr "Nájdi <b>%1$s</b> v&nbsp;tvojom priečinku so&nbsp;stiahnutými súborm
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
+msgstr "Nájdite DuckDuckGo v zozname a vyberte %1$sNastaviť ako predvolený%2$s."
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8872,7 +8851,7 @@ msgstr "Doplňujúce otázky zostávajú súkromné."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Dodržané pokyny"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9230,8 +9209,7 @@ msgstr "Všeobecná umelá inteligencia s vysokou mierou moderovania"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
+msgstr "Umelá inteligencia na všeobecné použitie s nízkou vstavanou moderovaním"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
@@ -9614,8 +9592,8 @@ msgstr "Získaj aplikáciu"
 msgctxt "Browser Promo Popover"
 msgid "Get the free DuckDuckGo Browser %sto block ads on YouTube.%s"
 msgstr ""
-"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na YouTube."
-"%2$s"
+"Získaj bezplatný prehliadač DuckDuckGo %1$sna blokovanie reklám na "
+"YouTube.%2$s"
 
 # smartling.placeholder_format=C
 #. Label for links to appropriate local health authorities
@@ -9727,8 +9705,7 @@ msgstr ""
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Go to %sPrivacy & Security > Location Services%s"
-msgstr ""
-"Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
+msgstr "Prejsť na %1$sOchrana osobných údajov a zabezpečenie > Lokalizačné služby%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9820,7 +9797,7 @@ msgstr "Dobrá politika ochrany osobných údajov"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Dobrý vizuálny štýl"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10562,8 +10539,7 @@ msgstr "Otvárací čas chýba"
 #. This is the name of a user setting
 msgctxt "settings"
 msgid "Hover, Module, and Dropdown Background Color"
-msgstr ""
-"Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
+msgstr "Farba pozadia pri ukázaní kurzorom, v moduloch a rozbaľovacích ponukách"
 
 # smartling.placeholder_format=C
 #. Label for a pill-shaped tab below the empty-state Duck.ai chat input. Clicking it opens a panel that explains how Duck.ai protects user privacy.
@@ -10968,7 +10944,7 @@ msgstr "Obrazové príkayy musia byť v súlade s Duck.ai %1$s."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Kvalita obrázku"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11441,8 +11417,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
+msgstr "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11492,8 +11467,7 @@ msgstr "Je to rýchly, bezplatný a poskytuje ti ešte väčšiu ochranu online.
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
+msgstr "Občas (naozaj len občas) sa ma môžete spýtať na môj názor na DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11957,8 +11931,7 @@ msgstr "Viac informácií o tom, ako to funguje"
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
 msgid "Learn why reducing online tracking is important."
-msgstr ""
-"Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
+msgstr "Ďalšie informácie o tom, prečo je dôležité obmedziť sledovanie na internete."
 
 # smartling.placeholder_format=C
 #. A link that takes users to a page where they can learn more about the dangers of online tracking.
@@ -12021,8 +11994,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do Duck."
-"ai"
+"Umožní ti prepínať medzi odosielaním vyhľadávacích dopytov a výziev do "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -14527,8 +14500,7 @@ msgctxt "translations_module"
 msgid ""
 "Oops! An unexpected error occurred while translating this text. Please try "
 "again later."
-msgstr ""
-"Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
+msgstr "Ajaj! Pri preklade tohto textu došlo k neočakávanej chybe. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Title shown in a fatal error modal when Duck.ai fails to load.
@@ -14607,8 +14579,7 @@ msgstr "Otvorte položku Poloha a uistite sa, že je poloha %1$szapnutá%2$s."
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open 'Privacy', then 'Location Services'."
-msgstr ""
-"Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
+msgstr "Otvorte položku „Ochrana osobných údajov“ a potom „Služby určovania polohy“."
 
 # smartling.placeholder_format=C
 #. Indicates a business is open 24 hours a day.
@@ -14759,8 +14730,7 @@ msgstr "Otvoriť panel Ako funguje Duck.ai"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
+msgstr "Otvorte ponuku Safari a vyberte položku %1$sNastavenia pre DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15587,8 +15557,7 @@ msgstr "Popíš, prečo je odpoveď v chate škodlivá alebo nezákonná. (nepov
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
+msgstr "Popíšte, prečo je odpoveď v chate nelegálna alebo škodlivá. (Nepovinné)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15846,7 +15815,7 @@ msgstr "Zlé formátovanie"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Zlá kvalita obrázku"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16646,8 +16615,7 @@ msgstr "Uvažovanie môže poskytnúť lepšie odpovede na zložité otázky."
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
+msgstr "Uvažovanie je dôkladnejšie, ale limity používania dosiahne 2–5× skôr. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17776,8 +17744,7 @@ msgstr "Ulož si až 30 svojich najnovších chatov lokálne do svojho zariad
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
+msgstr "Ulož si svoje čety Duck.ai medzi zariadeniami pomocou end-to-end šifrovania."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17974,8 +17941,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
+msgstr "Prejdite nadol do časti %1$sSlužby%2$s a vyberte %3$sPanel s adresou%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18139,8 +18105,7 @@ msgstr "Viditeľnosť vyhľadávania"
 # smartling.placeholder_format=C
 #. Message prompting users to download the DuckDuckGo app.
 msgid "Search and browse privately with the DuckDuckGo app."
-msgstr ""
-"Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
+msgstr "Vyhľadávajte a prehľadávajte web súkromne pomocou aplikácie DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Category a user can select on a feedback form.
@@ -18276,8 +18241,7 @@ msgstr "Vyhľadávajte cez DuckDuckGo"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
+msgstr "Vyhľadávaj, prehliadaj a chatuj súkromne v našom bezplatnom prehliadači"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18327,8 +18291,7 @@ msgstr "Druhý názor"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
+msgstr "Bezpečne ukladaj a synchronizuj svoje chaty na všetkých svojich zariadeniach."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18357,8 +18320,9 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou end-"
-"to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných zariadení."
+"Bezpečne ukladaj takmer neobmedzený počet četov na našom serveri pomocou "
+"end-to-end šifrovania a pristupuj k nim zo všetkých synchronizovaných "
+"zariadení."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18562,15 +18526,13 @@ msgstr "Vyberte %1$sDuckDuckGo%2$s a potom %3$sPridať ako predvolené%4$s."
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Select %sDuckDuckGo%s in the Default Search Engine drop down"
-msgstr ""
-"V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
+msgstr "V rozbaľovacej ponuke Predvolený vyhľadávač vyberte %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
+msgstr "V zozname vyberte %1$sDuckDuckGo%2$s a %3$spovoľte%4$s prístup k polohe"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -19014,8 +18976,7 @@ msgstr "Zdieľať"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
+msgstr "Zdieľajte DuckDuckGo a pomôžte svojim priateľom získať späť ich súkromie!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19323,8 +19284,7 @@ msgstr "Zobraziť DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
+msgstr "Zobrazovať DuckAssist častejšie. (Môžete ho tiež úplne %1$svypnúť%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19584,8 +19544,7 @@ msgstr "Zobraziť vodorovné čiary medzi stránkami vo výsledkoch vyhľadávan
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows links to instructions for how to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť odkazy na návod, ako pridať DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers more frequently.
@@ -19601,14 +19560,12 @@ msgstr "Zobraziť najnavštevovanejšie odkazy na novej karte"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
+msgstr "Zobraziť občasné pripomenutia na pridanie DuckDuckGo do webového prehliadača"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
+msgstr "Zobraziť občasné pripomenutia na pridanie služby DuckDuckGo do zariadení"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19639,8 +19596,7 @@ msgstr "Zobrazovať návrhy pod vyhľadávacím poľom pri písaní"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
+msgstr "Zobraziť výhody DuckDuckGo v oblasti ochrany súkromia na domovskej stránke"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19650,8 +19606,7 @@ msgstr "Zobraziť pozadie tlačidla Hľadať"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message on top of the search results page"
-msgstr ""
-"Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
+msgstr "Zobraziť uvítaciu správu v hornej časti stránky s výsledkami vyhľadávania"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19962,8 +19917,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
+msgstr "Žiaľ, nahraný obrázok sa nepodarilo spracovať. Skús iný obrázok alebo formát."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19997,8 +19951,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
+msgstr "Ľutujeme, ale nepodarilo sa nám odoslať vašu spätnú väzbu. Skúste to neskôr."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20052,8 +20005,7 @@ msgstr "Zdrojový text bol vymazaný"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
+msgstr "Zdrojový text je príliš dlhý na zhrnutie. Skús to znova s kratším výberom."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20319,8 +20271,7 @@ msgstr "Zablokujte skryté sledovače, ktoré na vás číhajú na iných weboch
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
+msgstr "Zablokujte väčšinu skrytých sledovačov, ktoré na vás číhajú na iných weboch."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20817,8 +20768,7 @@ msgstr "Prepnuté na %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
+msgstr "Prepnutím sa tvoj chat odošle modelu bez nulovej viditeľnosti poskytovateľa."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -21125,8 +21075,7 @@ msgstr "Získajte späť kontrolu nad svojimi osobnými údajmi!"
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
+msgstr "Vyplň tento anonymný prieskum a daj nám vedieť, ako môžeme Duck.ai vylepšiť."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21442,8 +21391,7 @@ msgstr "Uplynul časový limit žiadosti. Skús to znova."
 #. Inform the users that "something" went wrong and we are unable to show any results.
 msgctxt "noresults"
 msgid "The server encountered an error and could not complete your request."
-msgstr ""
-"Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
+msgstr "Na serveri sa vyskytla chyba a server nemohol dokončiť tvoju požiadavku."
 
 # smartling.placeholder_format=C
 #. Title for the theme menu:
@@ -21562,8 +21510,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
+msgstr "Tento model AI už nie je k dispozícii. Skúste začať nový chat iným modelom."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21915,8 +21862,7 @@ msgstr "Tento preklad je nesprávny"
 # smartling.placeholder_format=C
 #. Label indicating that the video can't be played on the current page, and only on the website that owns the vide. The placeholder is the name of the website that owns the video.
 msgid "This video is not yet able to be watched here. You can watch it on %s."
-msgstr ""
-"Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
+msgstr "Toto video tu ešte nie je možné sledovať. Môžete ho sledovať v službe %1$s."
 
 # smartling.placeholder_format=C
 #. Message indicating that a website is not using an encrypted connection and is not secure.
@@ -22039,8 +21985,8 @@ msgstr "Tipy"
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
 msgstr ""
-"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme vám."
-"%2$s"
+"Už vás nebaví, že vás na internete niekto neustále sleduje? %1$sPomôžeme "
+"vám.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22088,8 +22034,8 @@ msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
 msgstr ""
-"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete vytlačiť."
-"%3$sKliknite na ikonu tlače.%4$s"
+"Tlač návodu:%1$sVráťte sa do mapy.%2$sVyberte trasu, ktorú chcete "
+"vytlačiť.%3$sKliknite na ikonu tlače.%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -22149,8 +22095,7 @@ msgstr "Prepni na súkromný AI čet alebo ho %1$svypni v nastaveniach%2$s."
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
-msgstr ""
-"Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
+msgstr "Prepnutím vyskúšaj súkromný AI čet alebo ho %1$svypni v ponuke %2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22216,7 +22161,7 @@ msgstr "Príliš pomalé"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Príliš pomalé generovanie"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22639,15 +22584,13 @@ msgstr "Skúste iné kľúčové slová."
 # smartling.placeholder_format=C
 #. Prompt encouraging the user to turn off their ad blocker to see more results for their query.
 msgid "Try disabling your ad blocker on DuckDuckGo to see more results."
-msgstr ""
-"Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
+msgstr "Skús vypnúť blokovanie reklám na DuckDuckGo, aby si videl/-a viac výsledkov."
 
 # smartling.placeholder_format=C
 #. Prompt to enable location access in order to get search results closer to the user's actual location.
 msgctxt "precise_user_location"
 msgid "Try enabling anonymous location for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
+msgstr "Presnejšie výsledky môžete získať povolením anonymného určovania polohy."
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the screen of the onboarding where the user picks a chat model.
@@ -22666,7 +22609,7 @@ msgstr "Skúste menej kľúčových slov."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Vyskúšaj to zadarmo"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23018,8 +22961,7 @@ msgstr "Vypnúť:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
+msgstr "Ak chcete získať presnejšie výsledky, zapnite možnosť %1$sPresná poloha%2$s"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23042,8 +22984,7 @@ msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Presná 
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
+msgstr "Presnejšie výsledky môžete získať zapnutím nastavenia „Použiť presnú polohu“."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23249,14 +23190,13 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: https://"
-"duckduckgo.com."
+"Pod možnosťou %1$sPri spustení > Domovská stránka%2$s napíšte: "
+"https://duckduckgo.com."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch Settings%s select %sDuckDuckGo%s"
-msgstr ""
-"Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
+msgstr "Pod možnosťou %1$sNastavenia vyhľadávania%2$s vyberte %3$sDuckDuckGo%4$s."
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23269,8 +23209,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch%s section, click %sManage search engines...%s"
-msgstr ""
-"Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
+msgstr "Pod sekciou %1$sVyhľadávanie%2$s vyberte %3$sSpravovať vyhľadávače...%4$s."
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -23284,8 +23223,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
+msgstr "V časti Vyhľadávanie vyberte rozbaľovaciu ponuku a potom %1$sDuckDuckGo%2$s."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -24234,8 +24172,7 @@ msgstr "Tapeta"
 #. Title of the one-time Duck.ai promo card on the Chrome New Tab Page.
 msgctxt "new tab page"
 msgid "Want easy access to private AI chat on the new tab page?"
-msgstr ""
-"Chceš mať jednoduchý prístup k súkromnému AI četu na stránke novej karty?"
+msgstr "Chceš mať jednoduchý prístup k súkromnému AI četu na stránke novej karty?"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -24919,8 +24856,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
+msgstr "Aké sú niektoré možnosti slova „lepší“ v kontexte „Naozaj musíme byť lepší“."
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -25296,8 +25232,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
+msgstr "Ak je toto povolené, Duck.ai bude v chate zobrazovať okamžité odpovede."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25315,8 +25250,7 @@ msgstr "Kde sledovať <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
+msgstr "Pri možnosti Domovská stránka vyberte %1$sNastaviť aktuálnu stránku%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25356,8 +25290,7 @@ msgstr "Kto sme"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
+msgstr "Kto je hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -26276,8 +26209,7 @@ msgstr ""
 msgctxt ""
 "Description shown under the title on the Sync & Backup settings screen"
 msgid "Your Duck.ai chats are being synced with end-to-end encryption."
-msgstr ""
-"Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
+msgstr "Tvoje čety Duck.ai sa synchronizujú pomocou šifrovania typu end-to-end."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -26350,8 +26282,7 @@ msgstr "Podľa vášho prehliadača ste tento odkaz už otvorili."
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid "Your browser provides a list of your most-visited sites."
-msgstr ""
-"Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
+msgstr "Váš prehliadač poskytuje zoznam vašich najčastejšie navštevovaných lokalít."
 
 # smartling.placeholder_format=C
 #. Used as a description in a menu
@@ -26400,8 +26331,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
+msgstr "Tvoje rozhovory sú súkromné a nikdy sa nepoužívajú na trénovanie modelov AI"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26462,8 +26392,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
+msgstr "Tvoje čety boli importované. Pokračuj tam, kde si na Duck.ai skončil/-a."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26659,8 +26588,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
+msgstr "Prekročili ste maximálnu veľkosť správy. Skráťte správu a skúste to znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -27004,8 +26932,7 @@ msgstr "oficiálnej webovej stránky"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
+msgstr "alebo napíšte kód požadovanej farby, napr. %1$s (%2$s je kódovaný znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -528,13 +529,15 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr ""
+"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr ""
+"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -885,7 +888,8 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -965,7 +969,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr ""
+"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1679,7 +1684,8 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
+msgstr ""
+"Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2333,7 +2339,8 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr ""
+"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2702,7 +2709,8 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr ""
+"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2961,6 +2969,18 @@ msgstr ""
 "identifikacijski metapodatki."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3110,7 +3130,8 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr ""
+"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -4006,8 +4027,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
-"%1$shttps://duck.ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
+"ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4669,7 +4690,8 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr ""
+"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4702,7 +4724,8 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr ""
+"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5345,7 +5368,8 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
+msgstr ""
+"Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5475,7 +5499,8 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr ""
+"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5943,7 +5968,8 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6523,6 +6549,12 @@ msgid "Dislike source"
 msgstr "Ne maram vira"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Opusti"
@@ -6631,6 +6663,12 @@ msgstr "Podatki divizije"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Džibuti"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6959,7 +6997,8 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7005,7 +7044,8 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr ""
+"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7051,7 +7091,8 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7187,7 +7228,8 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr ""
+"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7364,7 +7406,8 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr ""
+"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7761,7 +7804,8 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr ""
+"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7822,7 +7866,8 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr ""
+"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8048,7 +8093,8 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8060,7 +8106,8 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr ""
+"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8084,7 +8131,8 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr ""
+"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8190,7 +8238,8 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr ""
+"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8488,6 +8537,12 @@ msgstr "Konec rednega dela"
 msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr "Hitro"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8823,6 +8878,12 @@ msgid "Follow-ups remain private."
 msgstr "Nadaljnja vprašanja ostanejo zasebna."
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8926,7 +8987,8 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr ""
+"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9649,8 +9711,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
-"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
+"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9766,6 +9828,12 @@ msgstr "Oblikovna zasnova mi je všeč"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Dober pravilnik o zasebnosti"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10610,7 +10678,8 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr ""
+"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10915,6 +10984,12 @@ msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Pozivi za slike morajo biti v skladu s %1$s Duck.ai."
 
 # smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
+
+# smartling.placeholder_format=C
 msgctxt "settingsvalue"
 msgid "Image tiles"
 msgstr "Ploščice slik"
@@ -11057,7 +11132,8 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr ""
+"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11383,7 +11459,8 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr ""
+"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11433,7 +11510,8 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr ""
+"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -11957,7 +12035,8 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
+msgstr ""
+"Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12968,7 +13047,8 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13142,7 +13222,8 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr ""
+"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -14517,7 +14598,8 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr ""
+"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15500,7 +15582,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15508,7 +15591,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr ""
+"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15773,6 +15857,12 @@ msgstr "Poljščina"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Slabo oblikovanje"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16580,7 +16670,8 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
+msgstr ""
+"Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16615,7 +16706,8 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr ""
+"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -16948,7 +17040,8 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr ""
+"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17341,7 +17434,8 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr ""
+"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17704,7 +17798,8 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr ""
+"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17746,7 +17841,8 @@ msgstr "Spoznajte Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
+msgstr ""
+"Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17856,7 +17952,8 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr ""
+"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18461,8 +18558,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
-"%3$shttps://duckduckgo.com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
+"com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -19245,7 +19342,8 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr ""
+"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19428,7 +19526,8 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
+msgstr ""
+"Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19530,7 +19629,8 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr ""
+"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19566,7 +19666,8 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr ""
+"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19906,7 +20007,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr ""
+"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20217,7 +20319,8 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr ""
+"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20721,7 +20824,8 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr ""
+"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -21027,8 +21131,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
-"Duck.ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21309,7 +21413,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr ""
+"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21785,7 +21890,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
+msgstr ""
+"Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21939,7 +22045,8 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr ""
+"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22119,6 +22226,12 @@ msgid "Too slow"
 msgstr "Prepočasno"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -22278,7 +22391,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22286,7 +22400,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr ""
+"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22518,7 +22633,8 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr ""
+"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -22550,13 +22666,20 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr ""
+"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Preizkusite manj ključnih besed."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22736,7 +22859,8 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr ""
+"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22841,7 +22965,8 @@ msgstr "Izklopi Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr "Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
+msgstr ""
+"Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -22912,7 +23037,8 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr ""
+"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23081,7 +23207,8 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr ""
+"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23128,12 +23255,14 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr ""
+"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr ""
+"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23280,7 +23409,8 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr ""
+"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23651,7 +23781,8 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr ""
+"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24260,7 +24391,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr ""
+"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24461,7 +24593,8 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr ""
+"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -24525,7 +24658,8 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr ""
+"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24635,7 +24769,8 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr ""
+"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24780,7 +24915,8 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr ""
+"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25189,7 +25325,8 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr ""
+"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25968,7 +26105,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr ""
+"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26072,7 +26210,8 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr ""
+"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26560,13 +26699,15 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr ""
+"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr ""
+"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26649,7 +26790,8 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr ""
+"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26868,7 +27010,8 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr ""
+"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sl_SI/LC_MESSAGES/duckduckgo.po
+++ b/locales/sl_SI/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sl_SI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -529,15 +528,13 @@ msgstr ""
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "%sLong-press%s the DuckDuckGo app icon on the home screen"
-msgstr ""
-"%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
+msgstr "%1$sDolgo pritisnite%2$s ikono aplikacije DuckDuckGo na začetnem zaslonu."
 
 # smartling.placeholder_format=C
 #. A message displayed when there is an error loading content or no results on requery
 msgctxt "Error or no results message"
 msgid "%sOops!%s%sSomething went wrong. Please %srefresh%s and try again."
-msgstr ""
-"%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
+msgstr "%1$sUps!%2$s%3$sNekaj je šlo narobe. %4$sOsvežite%5$s in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Tagline in a popover encouraging the user to download the DuckDuckGo browser
@@ -888,8 +885,7 @@ msgstr "Dosežena je 6-urna omejitev uporabe."
 #. Displayed when the user has reached a fixed 6-hour Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "6-hour usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je 6-urna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable 6-hour Duck.ai usage limit and can opt in to continue using the daily limit.
@@ -969,8 +965,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
+msgstr "Na voljo je nova različica Duck.ai! Če želite nadaljevati, osvežite to stran."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1684,8 +1679,7 @@ msgctxt ""
 "Always-visible warning banner shown above the recommended models in the "
 "model picker dropdown"
 msgid "Advanced models can use limits 2-5x faster than other models. %s"
-msgstr ""
-"Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
+msgstr "Napredni modeli lahko porabijo omejitve 2–5× hitreje kot drugi modeli. %1$s"
 
 # smartling.placeholder_format=C
 #. Link to a page with resources for advertisers who want to place ads on the search results page.
@@ -2339,8 +2333,7 @@ msgstr "Ali ste prepričani, da želite izbrisati ta pogovor in začeti novega?"
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
+msgstr "Ste prepričani, da želite izbrisati ta klepet? Tega ni mogoče razveljaviti."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2709,8 +2702,7 @@ msgstr "Samodejno odgovarjanje"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
+msgstr "Samodejno ustvarjeno na podlagi navedenih virov. Lahko vsebuje netočnosti."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2979,6 +2971,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Preden shrani to poročilo, bo DuckDuckGo odstranil naložene datoteke in "
+"ustvarjene slike ter anonimiziral vaš pogovor z odstranitvijo osebnih "
+"podatkov, kot so imena, e-poštni naslovi in identifikacijski metapodatki."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3130,8 +3125,7 @@ msgstr "Blokiraj to spletno mesto v vseh rezultatih"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
+msgstr "Blokirajte sledilnike in prevzemite nadzor nad svojimi osebnimi podatki"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -4027,8 +4021,8 @@ msgstr ""
 "klepeta z umetno inteligenco tretjih oseb, ki podpirajo modele OpenAI, "
 "Anthropic in druge. Če to nastavitev izklopiš, bodo gumbi in povezave za "
 "klepet v iskalniku DuckDuckGo skriti. Vendar pa lahko še vedno dostopaš do "
-"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš %1$shttps://duck."
-"ai%2$s neposredno."
+"klepeta, ko je ta nastavitev izklopljena tako, da obiščeš "
+"%1$shttps://duck.ai%2$s neposredno."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4690,8 +4684,7 @@ msgstr "Kliknite %1$stukaj%2$s za prenos razširitve DuckDuckGo"
 # smartling.placeholder_format=C
 #. Link to download the DuckDuckGo browser extension.
 msgid "Click %sOpen%s to download and open the DuckDuckGo Safari extension"
-msgstr ""
-"Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
+msgstr "Kliknite %1$sOdpri%2$s za prenos in odprite razširitev DuckDuckGo Safari"
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
@@ -4724,8 +4717,7 @@ msgstr "Kliknite %1$sNastavitve%2$s v spustnem meniju."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
+msgstr "Kliknite %1$sUporabi trenutne strani%2$s, nato %3$skliknite V redu%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -5368,8 +5360,7 @@ msgstr "Nadaljuj blokiranje oglasov"
 #. Description in the first tooltip shown when the user selects the 'Delete a chat' onboarding step. The Fire Button is DuckDuckGo's control for deleting a chat from history.
 msgctxt "Product-tour tooltip description"
 msgid "Continue recent chats here. Or delete them with the fire button."
-msgstr ""
-"Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
+msgstr "Nadaljujte nedavne klepete tukaj. Ali pa jih izbrišite z gumbom Fire Button."
 
 # smartling.placeholder_format=C
 #. In the context of an AI Chat, tooltip text for the button that allows the user to select an existing response from an AI model and continue the conversation with that AI model.
@@ -5499,8 +5490,7 @@ msgstr "Kopiraj"
 # smartling.placeholder_format=C
 #. Instructions on how to change the default search engine
 msgid "Copy &amp; paste %sabout:preferences#search%s into the address bar"
-msgstr ""
-"Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
+msgstr "Kopirajte in prilepite %1$sabout:preferences#search%2$s v naslovno vrstico"
 
 # smartling.placeholder_format=C
 #. Text for a button that copies the content from a block of programming code. Please keep the text as short as possible.
@@ -5968,8 +5958,7 @@ msgstr "Dosežena je dnevna omejitev"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je dnevna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6552,7 +6541,7 @@ msgstr "Ne maram vira"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Vizualni slog mi ni všeč"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6668,7 +6657,7 @@ msgstr "Džibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Ne upošteva navodil"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6997,8 +6986,7 @@ msgstr "Spustite svoje fotografije ali datoteke PDF"
 # smartling.placeholder_format=C
 #. A title explaining what Duck Player (DDG's feature to watch youtube videos more privately) does
 msgid "Duck Player lets you watch YouTube without targeted ads"
-msgstr ""
-"Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
+msgstr "Predvajalnik Duck Player vam omogoča gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. This is the DDG version of "Google it", meaning "search it".
@@ -7044,8 +7032,7 @@ msgstr "pogoji storitve Duck.ai"
 #. The HTML <title> for Duck.ai.
 msgctxt "duckai_seo"
 msgid "Duck.ai by DuckDuckGo. Private AI chat. Free."
-msgstr ""
-"Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
+msgstr "Duck.ai by DuckDuckGo. Zasebni klepet z umetno inteligenco. Brezplačno."
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users Duck.ai can read and analyze PDF files.
@@ -7091,8 +7078,7 @@ msgstr ""
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai is best in our private and free DuckDuckGo browser!"
-msgstr ""
-"Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v našem zasebnem in brezplačnem brskalniku DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Introductory paragraph in the About & Legal section of the Duck.ai settings page, describing DuckDuckGo as the independent company behind Duck.ai.
@@ -7228,8 +7214,7 @@ msgstr "Duck.ai je nadgrajen!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
+msgstr "Duck.ai najbolje deluje v naši zasebni in brezplačni aplikaciji DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7406,8 +7391,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
+msgstr "DuckDuckGo AI Chat trenutno ni na voljo. Osvežite stran in poskusite znova."
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7804,8 +7788,7 @@ msgstr "Urejanje slike ..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
+msgstr "Z urejanjem sporočila boste odstranili spodnji odgovor in ustvarili novega."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -7866,8 +7849,7 @@ msgstr "Omogoči funkcije UI"
 #. Text explaining how to enable the cloud save feature.
 msgctxt "cloudsave"
 msgid "Enable Cloud Save by entering your existing passphrase."
-msgstr ""
-"Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
+msgstr "Omogočite storitev Cloud Save z vnosom svoje obstoječe varnostne fraze."
 
 # smartling.placeholder_format=C
 #. Primary button text in the dictation privacy consent modal to enable dictation.
@@ -8093,8 +8075,7 @@ msgstr "Prepričajte se, da so »Lokacijske storitve« %1$somogočene%2$s."
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure 'Location' is set to %sallow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
@@ -8106,8 +8087,7 @@ msgstr "Preverite, ali je možnost »Lokacija« nastavljena na %1$sdovoli%2$s."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure Location is set to %sAllow%s"
-msgstr ""
-"Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
+msgstr "Prepričajte se, da je možnost »Lokacija« nastavljena na %1$sDovoli%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8131,8 +8111,7 @@ msgstr "Prepričajte se, da ima brskalnik omogočen %1$sdostop do lokacije%2$s."
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
+msgstr "Preverite, ali ima vaš brskalnik dovoljenje za %1$sdostop do lokacije%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8238,8 +8217,7 @@ msgstr "Ekvatorialna Gvineja"
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Erase your browsing data in a flash with our %sFire Button%s"
-msgstr ""
-"V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
+msgstr "V trenutku izbrišite podatke o brskanju z našim gumbom %1$sFire Button%2$s"
 
 # smartling.placeholder_format=C
 msgid "Eritrea"
@@ -8542,7 +8520,7 @@ msgstr "Hitro"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Hitro ustvarjanje slik"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8881,7 +8859,7 @@ msgstr "Nadaljnja vprašanja ostanejo zasebna."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Upoštevana navodila"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8987,8 +8965,7 @@ msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
+msgstr "Brezplačni in zasebni klepeti, ki jih anonimiziramo. Račun ni potreben."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9711,8 +9688,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve Duck."
-"ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
+"V drugem brskalniku ali aplikaciji DuckDuckGo pojdite v %1$snastavitve "
+"Duck.ai%2$s in nato v %3$sKlepeti › Sync & Backup › Sinhroniziraj z drugo "
 "napravo%4$s ter optično preberite to kodo:"
 
 # smartling.placeholder_format=C
@@ -9833,7 +9810,7 @@ msgstr "Dober pravilnik o zasebnosti"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Dober vizualni slog"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10678,8 +10655,7 @@ msgstr ""
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
+msgstr "Delež vaših dnevnih in tedenskih omejitev, ki ste jih doslej uporabili."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10987,7 +10963,7 @@ msgstr "Pozivi za slike morajo biti v skladu s %1$s Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Kakovost slike"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11132,8 +11108,7 @@ msgstr "V zgornjem meniju izberite %1$sOrodja%2$s > %3$sNastavitve%4$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "In the popup, check %sMake this my default search provider%s"
-msgstr ""
-"V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
+msgstr "V pojavnem oknu potrdite %1$sTo naj bo moj privzeti ponudnik iskanja%2$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -11459,8 +11434,7 @@ msgctxt "Page suggestion prompt"
 msgid ""
 "Is this place any good? Summarize its reputation based on reviews and "
 "ratings."
-msgstr ""
-"Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
+msgstr "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj."
 
 # smartling.placeholder_format=C
 #. Question on a feedback form.
@@ -11510,8 +11484,7 @@ msgstr "Je hiter, brezplačen in zagotavlja še večjo spletno zaščito."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
+msgstr "Dovolim, da me (zelo redko) vprašate o mojih izkušnjah z uporabo DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12035,8 +12008,7 @@ msgstr "Omogoča anonimno iskanje z DuckDuckGo"
 msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
-msgstr ""
-"Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
+msgstr "Omogoča preklapljanje med pošiljanjem iskalnih poizvedb in pozivov v Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -13047,8 +13019,7 @@ msgstr "Dosežena je mesečna omejitev"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je mesečna omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13222,8 +13193,7 @@ msgstr "Več statističnih podatkov o medaljah je na voljo na %1$s"
 msgctxt ""
 "Note on the Olympics module as to where they can find more information"
 msgid "More medal stats on %solympics.com%s"
-msgstr ""
-"Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
+msgstr "Več statističnih podatkov o medaljah je na voljo na %1$solympics.com%2$s"
 
 # smartling.placeholder_format=C
 #. A link to more information on a topic. The placeholder is the name of a website. For example 'More on Wikipedia'.
@@ -14598,8 +14568,7 @@ msgstr "Odpri spletno mesto %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
+msgstr "Odprite %1$sLokacija%2$s in se prepričajte, da je lokacija %3$somogočena%4$s."
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -15582,8 +15551,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je ta poziv ustvaril človek."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15591,8 +15559,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
+msgstr "Rešite naslednji izziv in s tem potrdite, da je to iskanje opravil človek."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15862,7 +15829,7 @@ msgstr "Slabo oblikovanje"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Slaba kakovost slike"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16670,8 +16637,7 @@ msgstr ""
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but uses limits 2-5x faster. %s"
-msgstr ""
-"Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
+msgstr "Razmišljanje je temeljitejše, vendar porabi omejitve 2–5-krat hitreje. %1$s"
 
 # smartling.placeholder_format=C
 #. Accessibility label for the dropdown that allows users to select reasoning mode (Reasoning, Fast, Auto) for AI models that support it.
@@ -16706,8 +16672,7 @@ msgstr "Nedavni zavihki"
 #. Text explaining that this feature can be adjusted in the settings. Placeholder is for adding a link to 'Settings'. Example: 'Recent chat storage can be adjusted in Settings.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "Recent chat storage can be adjusted in %s."
-msgstr ""
-"Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
+msgstr "Nastavitve shranjevanja nedavnih klepetov je mogoče prilagoditi v %1$s."
 
 # smartling.placeholder_format=C
 #. Title of the first tooltip shown when the user selects the 'Delete a chat' onboarding step.
@@ -17040,8 +17005,7 @@ msgstr "Zapomni si mojo izbiro"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
+msgstr "Zapomni si mojo odločitev (to lahko spremenite v %1$s%2$s%3$sNastavitvah%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17434,8 +17398,7 @@ msgstr "Rezultati ne vključujejo informacij z blokiranih spletnih mest."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
+msgstr "Rezultati ne vključujejo blokiranih strani, ki jih lahko upravljate v: %1$s."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17798,8 +17761,7 @@ msgstr "Shrani do 30 vaših najnovejših klepetov lokalno v vaši napravi."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
+msgstr "Shranite svoje klepete Duck.ai med napravami z uporabo celovitega šifriranja."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17841,8 +17803,7 @@ msgstr "Spoznajte Duck.ai"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
+msgstr "Spoznajte Duck.ai, brezplačen in zaseben klepet z UI ponudnika DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17952,8 +17913,7 @@ msgstr "Pomaknite navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s"
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down and click %sView advanced settings%s."
-msgstr ""
-"Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
+msgstr "Pomaknite stran navzdol in kliknite %1$sPrikaži napredne nastavitve%2$s."
 
 #  Edge Legacy default search engine instruction, obsolete?
 # smartling.placeholder_format=C
@@ -18558,8 +18518,8 @@ msgstr "V meniju Safari izberite %1$s»Nastavitev za to spletno mesto ...«%2$s.
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"Izberite %1$sPo meri%2$s in v vnosno polje vnesite %3$shttps://duckduckgo."
-"com%4$s"
+"Izberite %1$sPo meri%2$s in v vnosno polje vnesite "
+"%3$shttps://duckduckgo.com%4$s"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -19342,8 +19302,7 @@ msgstr "Pokaži DuckAssist <sup>BETA</sup>"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
+msgstr "Pogosteje prikažite DuckAssist. (Lahko ga tudi popolnoma %1$sizklopite%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19526,8 +19485,7 @@ msgstr "Prikaži stransko vrstico"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
+msgstr "Prikažite nasvete po korakih, da lahko kar najbolje izkoristite Duck.ai."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19629,8 +19587,7 @@ msgstr "Prikaže občasne opomnike, da dodate DuckDuckGo v svoje naprave"
 msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
+msgstr "Prikaže občasne opomnike, da se prijavite na glasila o zasebnosti DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19666,8 +19623,7 @@ msgstr "Prikaže pozdravno sporočilo na vrhu strani z rezultati iskanja"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
+msgstr "Prikaže pozdravno sporočilo uporabnikom v meniju z nastavitvami za EU Android"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -20007,8 +19963,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
+msgstr "Žal nismo mogli poslati vaših povratnih informacij. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20319,8 +20274,7 @@ msgstr "Ustavi ustvarjanje"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop hidden trackers lurking on other websites."
-msgstr ""
-"Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
+msgstr "Onemogočite skrite sledilnike, ki se skrivajo v drugih spletnih mestih."
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -20824,8 +20778,7 @@ msgstr "Preklopljeno na model %1$s"
 msgctxt "AI Chat warning when switching from an encrypted model"
 msgid ""
 "Switching will send your chat to a model without zero provider visibility"
-msgstr ""
-"S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
+msgstr "S preklopom bo vaš klepet poslan modelu, ki nima nobene vidnosti ponudnika."
 
 # smartling.placeholder_format=C
 msgid "Switzerland"
@@ -21131,8 +21084,8 @@ msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
 msgstr ""
-"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo Duck."
-"ai."
+"Sodelujte v tej anonimni anketi in nam sporočite, kako lahko izboljšamo "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21413,8 +21366,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
+msgstr "Ponudnik modela izbriše vse podatke, povezane s tem klepetom, v 30 dneh."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21890,8 +21842,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
+msgstr "Tega deljenega klepeta ni bilo mogoče odpreti. Povezava je morda nepopolna."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -22045,8 +21996,7 @@ msgstr "Nasveti"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
+msgstr "Utrujeni od tega, da vam sledijo na spletu? %1$sMi vam lahko pomagamo.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22229,7 +22179,7 @@ msgstr "Prepočasno"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Prepočasno ustvarjanje"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22391,8 +22341,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta angleški stavek v francoščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22400,8 +22349,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
+msgstr "Prevedi ta slovenski stavek v angleščino: »Kako pridem do najbližjega kina?«"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22633,8 +22581,7 @@ msgstr "Poskusi dodati mesto, državo ali poštno številko"
 #. Message to display during errors for users who have AI enabled to encourage them to use that feature while the site is having issues. Example: 'Try asking Duck.ai, our private AI chat service:'
 msgctxt "noresults"
 msgid "Try asking %s, our private AI chat service:"
-msgstr ""
-"Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
+msgstr "Poskusite vprašati %1$s, našo zasebno storitev klepeta z umetno inteligenco:"
 
 # smartling.placeholder_format=C
 #. A message suggesting that the user clears their filters and tries their search again when they get no results
@@ -22666,8 +22613,7 @@ msgstr "Preizkusite omogočiti anonimno lokacijo za natančnejše rezultate."
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
+msgstr "Poskusite eksperimentirati z vsakim modelom – dobili boste različne odzive."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22679,7 +22625,7 @@ msgstr "Preizkusite manj ključnih besed."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Preizkusite brezplačno"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22859,8 +22805,7 @@ msgstr "Preizkusite nedavno dodana odprtokodna modela Llama 3.1 in Mixtral"
 #. Message displayed to suggest the user to try the provided prompts or enter their own.
 msgctxt "Prompt suggestion message"
 msgid "Try these prompts to get started or enter your own prompt below"
-msgstr ""
-"Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
+msgstr "Če želite začeti, poskusite uporabiti te pozive ali spodaj vnesite svoj poziv"
 
 # smartling.placeholder_format=C
 #. Description for the empty state displayed when searching recent chats in Duck.ai returns no results, suggesting the user rephrase their search query.
@@ -22965,8 +22910,7 @@ msgstr "Izklopi Sync & Backup"
 #. Asks the user to confirm wiping the server-side backup and disconnecting all devices.
 msgctxt "Title for the destructive Delete Server Data confirmation modal"
 msgid "Turn Off Sync & Backup and Delete Server Data?"
-msgstr ""
-"Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
+msgstr "Želite izklopiti funkcijo Sync & Backup in izbrisati podatke iz strežnika?"
 
 # smartling.placeholder_format=C
 #. Asks the user to confirm disconnecting this device from Sync & Backup.
@@ -23037,8 +22981,7 @@ msgstr "Za natančnejše rezultate vklopite %1$sNatančno lokacijo%2$s."
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
+msgstr "Vklopite predvajalnik Duck Player za gledanje YouTuba brez ciljanih oglasov"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23207,8 +23150,7 @@ msgstr "Povratnih informacij ni mogoče poslati"
 #. Message shown to the user when the voice chat failed to establish a connection, and they should try again later.
 msgctxt "voice chat"
 msgid "Unable to connect to voice chat, please try again later."
-msgstr ""
-"Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
+msgstr "Povezave z glasovnim klepetom ni mogoče vzpostaviti. Poskusi znova pozneje."
 
 # smartling.placeholder_format=C
 #. Message shown to the user when there was an issue connecting to their microphone.
@@ -23255,14 +23197,12 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
+msgstr "Za nastavitev %1$sOdpri z%2$s izberite %3$sDoločena stran ali strani%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
+msgstr "Za nastavitev %1$sZAGON > Domača stran%2$s vnesite: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23409,8 +23349,7 @@ msgstr "Odklenite napredne modele umetne inteligence z naročnino %1$s"
 #. Tooltip text shown when the user hovers over the free badge telling the user that they can unlock advanced AI (Artificial Intelligence) models with a DuckDuckGo subscription.
 msgctxt "Tooltip for the free badge"
 msgid "Unlock advanced AI models with a DuckDuckGo subscription"
-msgstr ""
-"Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
+msgstr "Odklenite napredne modele umetne inteligence z naročnino na DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. A link to a blog post explaining the new AI benefits to a subscription. Please keep translations to 50 characters or less.
@@ -23781,8 +23720,7 @@ msgstr "Uporabite DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
+msgstr "Uporabite zasebno iskanje DuckDuckGo na svojem iPadu, iPhonu ali Androidu!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24391,8 +24329,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
+msgstr "Priloženih datotek ne moremo prebrati, ker je vsaj ena od njih šifrirana."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24593,8 +24530,7 @@ msgstr ""
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
+msgstr "Uporabljamo takšne povratne informacije kot so te, za izboljšanje DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -24658,8 +24594,7 @@ msgctxt "duckai_migration"
 msgid ""
 "We're sorry for this inconvenience. We’re working hard to make your "
 "experience better."
-msgstr ""
-"Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
+msgstr "Žal nam je za to nevšečnost. Prizadevamo si, da bi bila vaša izkušnja boljša."
 
 # smartling.placeholder_format=C
 #. Body text explaining the service update requires a page reload.
@@ -24769,8 +24704,7 @@ msgstr "Dosežena je tedenska omejitev uporabe"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Weekly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
+msgstr "Dosežena je tedenska omejitev uporabe. Ta klepet lahko nadaljujete po %1$s."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable weekly Duck.ai usage limit and can opt in to continue using the monthly limit.
@@ -24915,8 +24849,7 @@ msgstr ""
 #. Text for a prompt suggestion for considering factors when purchasing a computer monitor.
 msgctxt "Full sentence for preparing for a purchase"
 msgid "What are some factors to consider when purchasing a computer monitor?"
-msgstr ""
-"Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
+msgstr "Katere dejavnike je treba upoštevati pri nakupu računalniškega zaslona?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
@@ -25325,8 +25258,7 @@ msgstr "Kje gledati: <strong>%1$s</strong>"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
+msgstr "Pri nastavitvi Domača Stran kliknite %1$sNastavi na trenutno stran%2$s."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -26105,8 +26037,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
+msgstr "Tega sporočila ne boste več videli, razen če počistite podatke brskalnika."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26210,8 +26141,7 @@ msgstr "Dosegli ste najdaljše trajanje glasovnega klepeta za eno sejo."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
+msgstr "Dosegli ste omejitev glasovnega klepeta za danes. Poskusite znova jutri."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26699,15 +26629,13 @@ msgctxt "Error message for user limit"
 msgid ""
 "You’ve reached the maximum number of messages for one day. Please continue "
 "this chat tomorrow."
-msgstr ""
-"Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
+msgstr "Dosegli ste največje število sporočil za en dan. Nadaljujte ta klepet jutri."
 
 # smartling.placeholder_format=C
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
+msgstr "Dosegli ste trenutno omejitev glasovnega klepeta. Poskusite znova pozneje."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26790,8 +26718,7 @@ msgstr "od %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
+msgstr "omogoča DuckDuckGo – spletna zaščita, ki ji vsak dan zaupajo milijoni ljudi."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -27010,8 +26937,7 @@ msgstr "uradno spletno stran"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
+msgstr "ali pa vpišite kodo želene barve, npr. %1$s (%2$s je kodiran znak %3$s)."
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sq_AL/LC_MESSAGES/duckduckgo.po
+++ b/locales/sq_AL/LC_MESSAGES/duckduckgo.po
@@ -2387,6 +2387,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5287,6 +5298,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Hidhe tej"
@@ -5376,6 +5392,11 @@ msgid "Division Record"
 msgstr "Rekord Divizioni"
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6865,6 +6886,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7125,6 +7151,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7877,6 +7908,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8816,6 +8852,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12797,6 +12838,11 @@ msgstr "Polonisht"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17919,6 +17965,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18281,6 +18332,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Provoni më pak fjalëkyçe."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/sr_RS/LC_MESSAGES/duckduckgo.po
+++ b/locales/sr_RS/LC_MESSAGES/duckduckgo.po
@@ -2384,6 +2384,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5252,6 +5263,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Затвори"
@@ -5341,6 +5357,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6815,6 +6836,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7072,6 +7098,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7822,6 +7853,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8758,6 +8794,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12722,6 +12763,11 @@ msgstr "Пољски"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17799,6 +17845,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18158,6 +18209,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Покушајте са мање кључних речи."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,7 +22,8 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr ""
+"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -384,7 +385,8 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
+msgstr ""
+"%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -448,7 +450,8 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr ""
+"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1388,7 +1391,8 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr ""
+"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1712,7 +1716,8 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr ""
+"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1975,7 +1980,8 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr ""
+"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2315,19 +2321,22 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr ""
+"Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr ""
+"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2546,11 +2555,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
-"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
-"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
-"för att generera ett kort svar baserat på relevant information som hittats. "
-"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
+"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
+"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
+"att generera ett kort svar baserat på relevant information som hittats. Det "
+"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2652,7 +2661,8 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr ""
+"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2693,7 +2703,8 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr ""
+"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2950,6 +2961,18 @@ msgstr ""
 "Innan denna rapport lagras kommer DuckDuckGo att anonymisera din "
 "konversation genom att ta bort personuppgifter som namn, e-postadresser och "
 "identifierande metadata."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3341,8 +3364,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett "
-"%1$s%2$s-tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
+"tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -3990,12 +4013,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
-"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
-"Anthropic och fler. Om du stänger av den här inställningen döljs "
-"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
-"åt chatten när den här inställningen är avstängd genom att gå till "
-"%1$shttps://duck.ai%2$s direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
+"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
+"och fler. Om du stänger av den här inställningen döljs chattknappar och "
+"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
+"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
+"direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4257,7 +4280,8 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr ""
+"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4690,7 +4714,8 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr ""
+"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -6361,7 +6386,8 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr ""
+"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6510,6 +6536,12 @@ msgid "Dislike source"
 msgstr "Ogilla källan"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Avvisa"
@@ -6620,6 +6652,12 @@ msgid "Djibouti"
 msgstr "Djibouti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6667,7 +6705,8 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr ""
+"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6715,8 +6754,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
-"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
+"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7103,8 +7142,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
-"%1$sduck.ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
+"ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7184,9 +7223,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
-"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
-"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
+"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
+"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7355,7 +7394,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr ""
+"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8280,7 +8320,8 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr ""
+"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8474,6 +8515,12 @@ msgid "Fast"
 msgstr "Snabb"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8517,7 +8564,8 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr ""
+"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8676,7 +8724,8 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr ""
+"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8713,7 +8762,8 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr ""
+"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8796,6 +8846,12 @@ msgstr "Följdfråga"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Följdfrågor förblir privata."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8901,7 +8957,8 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr ""
+"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9309,7 +9366,8 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+msgstr ""
+"Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9428,9 +9486,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
-"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
-"för integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
+"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
+"integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9741,6 +9799,12 @@ msgid "Good privacy policy"
 msgstr "Bra integritetspolicy"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
 msgctxt "shortbelieve"
 msgid "Goodies"
@@ -9928,7 +9992,8 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr ""
+"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10821,7 +10886,8 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr ""
+"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10879,6 +10945,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Bildpromptar måste följa %1$s för Duck.ai."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11401,7 +11473,8 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr ""
+"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12037,7 +12110,8 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr ""
+"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12148,7 +12222,8 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr ""
+"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13485,11 +13560,10 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en "
-"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
-"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
-"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
-"inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
+"server efter att de har skickats, så att du kan återställa chatten om din "
+"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
+"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -15419,7 +15493,8 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
+msgstr ""
+"Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15460,7 +15535,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15468,7 +15544,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr ""
+"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15735,6 +15812,12 @@ msgstr "Polska"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Dålig formatering"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16251,7 +16334,8 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr ""
+"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16590,8 +16674,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16600,8 +16684,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på "
-"DuckDuckGo-servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
+"servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17664,7 +17748,8 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr ""
+"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17853,13 +17938,15 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr ""
+"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr ""
+"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18209,7 +18296,8 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr ""
+"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18218,8 +18306,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18228,8 +18316,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18248,8 +18336,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med "
-"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
+"kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18812,7 +18900,8 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr ""
+"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19469,12 +19558,14 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr ""
+"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19492,7 +19583,8 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr ""
+"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19518,7 +19610,8 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr ""
+"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -20347,7 +20440,8 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr ""
+"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21355,7 +21449,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr ""
+"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21680,8 +21775,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
-"Duck.ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
+"ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21731,7 +21826,8 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr "Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
+msgstr ""
+"Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21766,7 +21862,8 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr ""
+"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21951,8 +22048,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera "
-"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
+"webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21990,8 +22087,8 @@ msgstr "Växla till privat AI-chatt eller %1$sinaktivera i inställningarna%2$s.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
-"%2$s.%3$s"
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn %2$s."
+"%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22052,6 +22149,12 @@ msgstr "För många resultat från denna källa"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "För långsam"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22496,6 +22599,12 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Försök att använda färre sökord."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23062,13 +23171,14 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
-"https://duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
+"duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr ""
+"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23095,7 +23205,8 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr ""
+"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23202,8 +23313,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en "
-"DuckDuckGo-prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
+"prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23585,7 +23696,8 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr ""
+"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -23903,10 +24015,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
-"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
-"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
-"återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
+"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
+"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23959,8 +24070,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna "
-"AI-modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
+"modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24146,7 +24257,8 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr ""
+"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24180,14 +24292,16 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr ""
+"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr ""
+"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24198,7 +24312,8 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr ""
+"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24229,7 +24344,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr ""
+"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24401,7 +24517,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr ""
+"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24612,7 +24729,8 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr ""
+"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24707,7 +24825,8 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr ""
+"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24807,7 +24926,8 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr ""
+"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -24832,7 +24952,8 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr ""
+"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25059,7 +25180,8 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr ""
+"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25091,7 +25213,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr ""
+"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25149,7 +25272,8 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr ""
+"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25305,7 +25429,8 @@ msgstr ""
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr "När chatthistoriken är på sparas dina senaste chattar på den här enheten."
+msgstr ""
+"När chatthistoriken är på sparas dina senaste chattar på den här enheten."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25569,7 +25694,8 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr ""
+"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25588,7 +25714,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr ""
+"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25774,7 +25901,8 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr ""
+"Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -26034,8 +26162,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
-"YouTube-videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
+"videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26180,8 +26308,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna "
-"AI-modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
+"modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26324,10 +26452,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
-"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
-"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
-"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
+"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
+"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
+"DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26568,7 +26696,8 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr ""
+"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26788,8 +26917,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
-"%3$s-tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
+"tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/sv_SE/LC_MESSAGES/duckduckgo.po
+++ b/locales/sv_SE/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: sv_SE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -22,8 +22,7 @@ msgstr "!Bang-sökgenvägar"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
+msgstr "”%1$s” kommer inte längre att få tillgång till dina synkroniserade data."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -385,8 +384,7 @@ msgstr "%1$s använt"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
+msgstr "%1$s förbrukar gränserna upp till 2–5 gånger snabbare än basmodellerna %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -450,8 +448,7 @@ msgstr "%1$s ord"
 #. Instructions on which buttons and options the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
+msgstr "%1$sKlicka på %2$sLägg till%3$sMarkera %4$sTillåt%5$s och sedan på %6$sOK%7$s"
 
 # Firefox, obsolete
 # smartling.placeholder_format=C
@@ -1391,8 +1388,7 @@ msgstr "Installera tillägget DuckDuckGo"
 # smartling.placeholder_format=C
 msgid ""
 "Add DuckDuckGo Privacy Essentials to your browser for free with one download:"
-msgstr ""
-"Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
+msgstr "Ladda ner DuckDuckGo Privacy Essentials utan kostnad för din webbläsare:"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -1716,8 +1712,7 @@ msgstr "Afrikaans"
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid "After it downloads and opens, click %sInstall%s"
-msgstr ""
-"Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
+msgstr "Efter att ha laddat ner och öppnat den klickar du på %1$sInstallera%2$s"
 
 # smartling.placeholder_format=C
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
@@ -1980,8 +1975,7 @@ msgstr "Vill du tillåta anonym filgranskning för den här chatten?"
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
+msgstr "Tillåt annonser som respekterar integritet på DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2321,22 +2315,19 @@ msgstr "Är du fortfarande där?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
+msgstr "Är du säker på att du vill rensa alla dina chattar? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Är du säker på att du vill rensa den här konversationen och starta en ny?"
+msgstr "Är du säker på att du vill rensa den här konversationen och starta en ny?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
 msgctxt "Body text for delete chat confirmation modal"
 msgid "Are you sure you want to delete this chat? This cannot be undone."
-msgstr ""
-"Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
+msgstr "Är du säker på att du vill ta bort den här chatten? Detta kan inte ångras."
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable chat history, with a warning that it will also delete currently saved chats including pinned chats.
@@ -2555,11 +2546,11 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist är en valbar funktion i våra sökresultat som anonymt kan generera AI-"
-"assisterade svar på sökfrågor. För att göra detta skannar den webben efter "
-"relevant innehåll och använder sedan AI-driven naturlig språkteknologi för "
-"att generera ett kort svar baserat på relevant information som hittats. Det "
-"är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
+"Assist är en valbar funktion i våra sökresultat som anonymt kan generera "
+"AI-assisterade svar på sökfrågor. För att göra detta skannar den webben "
+"efter relevant innehåll och använder sedan AI-driven naturlig språkteknologi "
+"för att generera ett kort svar baserat på relevant information som hittats. "
+"Det är viktigt att komma ihåg att svaren genereras automatiskt från citerade "
 "källor och baseras på %1$sgenomsökning av webben%2$s."
 
 # smartling.placeholder_format=C
@@ -2661,8 +2652,7 @@ msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten avslutats."
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat is transcribed."
-msgstr ""
-"Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
+msgstr "Ljud lagras inte av oss eller av OpenAI efter att chatten har transkriberats."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when MediaRecorder API is unavailable.
@@ -2703,8 +2693,7 @@ msgstr "Autosvar"
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
 msgid "Auto-generated based on listed sources. May contain inaccuracies."
-msgstr ""
-"Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
+msgstr "Automatiskt genererad baserat på angivna källor. Kan innehålla felaktigheter."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -2973,6 +2962,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Innan denna rapport lagras kommer DuckDuckGo att ta bort uppladdade filer "
+"och genererade bilder, och anonymisera din konversation genom att ta bort "
+"personuppgifter som namn, e-postadresser och identifierande metadata."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3364,8 +3356,8 @@ msgid ""
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
 "Surfa som vanligt medan vi ger dig integritetsskydd. Vi har förenat vår "
-"sökmotor, spårningsblockerare och tvingande kryptering i ett %1$s%2$s-"
-"tillägg%3$s."
+"sökmotor, spårningsblockerare och tvingande kryptering i ett "
+"%1$s%2$s-tillägg%3$s."
 
 # smartling.placeholder_format=C
 msgid ""
@@ -4013,12 +4005,12 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med AI-"
-"chattmodeller från tredje part med stöd för modeller från OpenAI, Anthropic "
-"och fler. Om du stänger av den här inställningen döljs chattknappar och "
-"länkar på DuckDuckGo Search. Du kan dock fortfarande komma åt chatten när "
-"den här inställningen är avstängd genom att gå till %1$shttps://duck.ai%2$s "
-"direkt."
+"Med chatten (via vår tjänst Duck.ai) kan du ha anonyma konversationer med "
+"AI-chattmodeller från tredje part med stöd för modeller från OpenAI, "
+"Anthropic och fler. Om du stänger av den här inställningen döljs "
+"chattknappar och länkar på DuckDuckGo Search. Du kan dock fortfarande komma "
+"åt chatten när den här inställningen är avstängd genom att gå till "
+"%1$shttps://duck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4280,8 +4272,7 @@ msgstr "Kontrollera stavningen"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
+msgstr "Kolla DuckDuckGos subreddit för att se uppdateringar om det här avbrottet."
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4714,8 +4705,7 @@ msgstr "Klicka på %1$sInställningar%2$s i rullgardinsmenyn."
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
+msgstr "Klicka på %1$sAnvänd aktuella sidor%2$s och sedan på %3$sKlicka på OK%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -6386,8 +6376,7 @@ msgstr "Diktering i Duck.ai"
 # smartling.placeholder_format=C
 #. Description for the privacy highlight in the dictation consent modal.
 msgid "Dictation is anonymized by us, and never used to train AI models."
-msgstr ""
-"Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
+msgstr "Diktering anonymiseras av oss och används aldrig för att träna AI-modeller."
 
 # smartling.placeholder_format=C
 #. Tooltip for the disabled microphone button in the duck.ai chat input when the voice budget is exhausted.
@@ -6539,7 +6528,7 @@ msgstr "Ogilla källan"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Ogilla visuell stil"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6655,7 +6644,7 @@ msgstr "Djibouti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Följer inte instruktionerna"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6705,8 +6694,7 @@ msgstr "Ser du inte DuckDuckGo i listan?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
+msgstr "Hittar du inte filen? %1$s%2$s%3$sKlicka här för att ladda ner den igen%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -6754,8 +6742,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan AI-"
-"funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
+"Vill du inte ha AI? Besök %1$snoai.duckduckgo.com%2$s för att söka utan "
+"AI-funktioner och med AI-bilder bortfiltrerade. %3$sLäs mer%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -7142,8 +7130,8 @@ msgid ""
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
 "Duck.ai låter dig chatta privat med populära AI-modeller. Att inaktivera det "
-"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka %1$sduck."
-"ai%2$s direkt."
+"döljer Duck.ai-knappar och länkar, men du kan fortfarande besöka "
+"%1$sduck.ai%2$s direkt."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7223,9 +7211,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym AI-"
-"chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, AI-"
-"modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
+"Duck.ai, DuckDuckGo AI, privat AI-chattbot, gratis AI-chatt, anonym "
+"AI-chatt, AI-chatt utan registrering, OpenAI, Anthropic, Llama, Mistral, "
+"AI-modeller med öppen källkod, integritetsfokuserad AI, AI-chatt utan konto"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7394,8 +7382,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "DuckDuckGo AI Chat is temporarily unavailable. Please try again later."
-msgstr ""
-"DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
+msgstr "DuckDuckGo AI Chat är inte tillgänglig för tillfället. Försök igen senare."
 
 # smartling.placeholder_format=C
 #. Used in the desktop electron app instead of 'DuckDuckGo Subscription' since purchases happen on duckduckgo.com, not in the app.
@@ -8320,8 +8307,7 @@ msgstr "Förklara det accepterade svaret med enkla ord."
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
+msgstr "Förklara de grundläggande begreppen för svarta hål för mig på gymnasienivå."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8518,7 +8504,7 @@ msgstr "Snabb"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Snabb bildgenerering"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8564,8 +8550,7 @@ msgstr "Feedback har skickats"
 msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and improvements."
-msgstr ""
-"Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
+msgstr "Din feedback påverkar direkt våra produktuppdateringar och förbättringar."
 
 # smartling.placeholder_format=C
 #. Message that appears after submitting a feedback form.
@@ -8724,8 +8709,7 @@ msgstr "Hitta <b>%1$s</b> i din nedladdningsmapp"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
+msgstr "Hitta DuckDuckGo i listan som visas och klicka på %1$sAnvänd som standard%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8762,8 +8746,7 @@ msgstr "Hitta sökresultat närmare dig."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
+msgstr "Hitta resultat nära dig. %1$sDin plats förblir privat, säker och anonym."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8851,7 +8834,7 @@ msgstr "Följdfrågor förblir privata."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Följde instruktionerna"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8957,8 +8940,7 @@ msgstr "Kostnadsfria och privata chattar, anonymiserade av oss"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
+msgstr "Kostnadsfria och privata chattar, anonymiserade av oss. Inget konto behövs."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9366,8 +9348,7 @@ msgstr ""
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Get DuckDuckGo VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
+msgstr "Skaffa DuckDuckGo VPN, avancerade Duck.ai och Identity Theft Restoration."
 
 # smartling.placeholder_format=C
 #. Sentence shown when hovering the Dax-in-sunglasses logo (desktop, where the whole sentence is the link) or tapping it (mobile, where it is a heading above a short button). It must read as a call to action on its own, since on desktop there is no separate link text. Points at /collaborations, the DuckDuckGo branded merchandise line. Names sunglasses specifically, so it belongs to that logo only -- another merch logo needs its own.
@@ -9486,9 +9467,9 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"Få tillgång till avancerade AI-modeller i Duck.ai med ett DuckDuckGo-"
-"abonnemang, som även inkluderar vårt VPN och andra premiumskydd för "
-"integritet."
+"Få tillgång till avancerade AI-modeller i Duck.ai med ett "
+"DuckDuckGo-abonnemang, som även inkluderar vårt VPN och andra premiumskydd "
+"för integritet."
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9802,7 +9783,7 @@ msgstr "Bra integritetspolicy"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Bra visuell stil"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -9992,8 +9973,7 @@ msgstr "Guatemala"
 #. Text for a prompt suggestion for guiding through the basic steps of replacing a window wiper.
 msgctxt "Full sentence for learning a new skill"
 msgid "Guide me through the basic steps of replacing a window wiper."
-msgstr ""
-"Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
+msgstr "Guida mig genom de grundläggande stegen för att byta ut en fönstertorkare."
 
 # smartling.placeholder_format=C
 msgid "Guinea"
@@ -10886,8 +10866,7 @@ msgstr ""
 #. http://i.imgur.com/ReKkJtU.png
 msgctxt "settings"
 msgid "If you still want to support us, %shelp spread DuckDuckGo%s"
-msgstr ""
-"Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
+msgstr "Om du fortfarande vill stödja oss, %1$shjälp till sprida DuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. From <a href="https://duckduckgo.com/settings.html">settings page</a>.
@@ -10950,7 +10929,7 @@ msgstr "Bildpromptar måste följa %1$s för Duck.ai."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Bildkvalitet"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11473,8 +11452,7 @@ msgstr "Det är snabbt, gratis och ger dig ännu mer skydd online."
 msgctxt "settings"
 msgid ""
 "It's okay to (very infrequently) ask me about my experience using DuckDuckGo"
-msgstr ""
-"Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
+msgstr "Det är okej att fråga mig om min upplevelse med DuckDuckGo (inte så ofta)"
 
 # smartling.placeholder_format=C
 #. The name of the Italian language
@@ -12110,8 +12088,7 @@ msgstr "Länkar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
+msgstr "Lista verktygen, materialen eller förutsättningarna jag behöver för detta."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12222,8 +12199,7 @@ msgstr "Läser in fler sökresultat med bilder när du skrollar"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more results in Images, Videos, and Shopping when scrolling"
-msgstr ""
-"Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
+msgstr "Läser in fler sökresultat med bilder, videor och shopping när du skrollar"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/WTkvs9I.png
@@ -13560,10 +13536,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"Nya promptar och svar krypteras och lagras tillfälligt på en DuckDuckGo-"
-"server efter att de har skickats, så att du kan återställa chatten om din "
-"internetanslutning bryts. Om du inaktiverar chatthistoriken raderas fästa "
-"chattar och tillfällig lagring av nya promptar och svar inaktiveras."
+"Nya promptar och svar krypteras och lagras tillfälligt på en "
+"DuckDuckGo-server efter att de har skickats, så att du kan återställa "
+"chatten om din internetanslutning bryts. Om du inaktiverar chatthistoriken "
+"raderas fästa chattar och tillfällig lagring av nya promptar och svar "
+"inaktiveras."
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -15493,8 +15470,7 @@ msgstr "Fäst"
 #. Second, dimmer line of the highlight tooltip shown under the 'Pin a chat' item title when the user activates that onboarding step.
 msgctxt "Product-tour tooltip description"
 msgid "Pinned chats will appear at the top of your recent chats."
-msgstr ""
-"Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
+msgstr "Fastnålade chattar kommer att visas högst upp bland dina senaste chattar."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings"
@@ -15535,8 +15511,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att prompten görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att prompten görs av en människa."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15544,8 +15519,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Lös följande utmaning för att bekräfta att sökningen görs av en människa."
+msgstr "Lös följande utmaning för att bekräfta att sökningen görs av en människa."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15817,7 +15791,7 @@ msgstr "Dålig formatering"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Dålig bildkvalitet"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16334,8 +16308,7 @@ msgstr "Fråga mig"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Be mig använda min ungefärliga plats för att få sökresultat i närheten."
+msgstr "Be mig använda min ungefärliga plats för att få sökresultat i närheten."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16674,8 +16647,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16684,8 +16657,8 @@ msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
 msgstr ""
-"De senaste chattarna lagras lokalt på din enhet istället för på DuckDuckGo-"
-"servrar eller andra fjärrservrar."
+"De senaste chattarna lagras lokalt på din enhet istället för på "
+"DuckDuckGo-servrar eller andra fjärrservrar."
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -17748,8 +17721,7 @@ msgstr "Spara upp till 30 av dina senaste chattar lokalt på din enhet."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
+msgstr "Spara dina Duck.ai-chattar mellan dina enheter med end-to-end-kryptering."
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17938,15 +17910,13 @@ msgstr "Skrolla nedåt och leta reda på %1$sdin webbläsare%2$s i listan."
 #. Tells users which setting to change to enable location service.
 msgctxt "precise_user_location"
 msgid "Scroll down to %sDuckDuckGo%s and allow it to use your location."
-msgstr ""
-"Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
+msgstr "Skrolla ner till %1$sDuckDuckGo%2$s och ge tillåtelse att använda din plats."
 
 #  Edge default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
+msgstr "Skrolla ner till avsnittet %1$sTjänster%2$s och klicka på %3$sAdressfält%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18296,8 +18266,7 @@ msgstr "En andra åsikt"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
+msgstr "Spara och synkronisera dina chattar på ett säkert sätt på alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18306,8 +18275,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -18316,8 +18285,8 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
 msgstr ""
-"Lagra säkert nästan obegränsat antal chattar på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra säkert nästan obegränsat antal chattar på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18336,8 +18305,8 @@ msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
 msgstr ""
-"Lagra dina chattar på ett säkert sätt på vår server med end-to-end-"
-"kryptering och få åtkomst till dem från alla dina enheter."
+"Lagra dina chattar på ett säkert sätt på vår server med "
+"end-to-end-kryptering och få åtkomst till dem från alla dina enheter."
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18900,8 +18869,7 @@ msgstr ""
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
+msgstr "Ställ in din plats manuellt eller se till att platstjänster är aktiverade."
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19558,14 +19526,12 @@ msgstr "Visar mest besökta länkar i ny flik"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i din webbläsare"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
+msgstr "Visar påminnelser då och då om att lägga till DuckDuckGo i dina enheter"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19583,8 +19549,7 @@ msgstr "Visar sidnummer där sidan med sökresultat bryts"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows sign-up form for the DuckDuckGo privacy newsletters"
-msgstr ""
-"Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
+msgstr "Visar registreringsformuläret för nyhetsbrevet om integritet från DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/94erFcS.png
@@ -19610,8 +19575,7 @@ msgstr "Visar välkomstmeddelande högst upp på sidan med sökresultat"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
+msgstr "Visar välkomstmeddelande till användare av inställningsmeny för Android i EU"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -20440,8 +20404,7 @@ msgstr "Förslag på rubrik för ett blogginlägg"
 #. Prompt sent to the AI when the user taps the "Suggest related articles to explore" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Suggest related articles or topics worth exploring next."
-msgstr ""
-"Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
+msgstr "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Suggest related articles to explore", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21449,8 +21412,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Error message for explore more questions when a retryable error occurs (timeout, network)
 msgid "There's been an issue loading this answer. Please try again."
-msgstr ""
-"Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
+msgstr "Det uppstod ett problem när det här svaret skulle läsas in. Försök igen."
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -21775,8 +21737,8 @@ msgstr "Denna sida kräver javascript för att fungera."
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
 msgstr ""
-"Innehållet på den här sidan kommer att skickas med ditt meddelande till Duck."
-"ai"
+"Innehållet på den här sidan kommer att skickas med ditt meddelande till "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21826,8 +21788,7 @@ msgstr ""
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
 msgctxt "Toast when share decryption fails"
 msgid "This shared chat could not be opened. The link may be incomplete."
-msgstr ""
-"Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
+msgstr "Den här delade chatten kunde inte öppnas. Länken kan vara ofullständig."
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because it was deleted or expired.
@@ -21862,8 +21823,7 @@ msgstr "Denna video kan ännu inte visas här. Du kan titta på den på %1$s."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
+msgstr "Den här webbplats använder inte en säker, krypterad anslutning (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22048,8 +22008,8 @@ msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
 msgstr ""
-"För att överföra din chatthistorik till Duck.ai, uppdatera DuckDuckGo-"
-"webbläsaren till den senaste versionen och försök igen."
+"För att överföra din chatthistorik till Duck.ai, uppdatera "
+"DuckDuckGo-webbläsaren till den senaste versionen och försök igen."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -22087,8 +22047,8 @@ msgstr "Växla till privat AI-chatt eller %1$sinaktivera i inställningarna%2$s.
 msgctxt "new tab page"
 msgid "Toggle to try private AI chat or %sdisable it in the %s menu.%s"
 msgstr ""
-"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn %2$s."
-"%3$s"
+"Växla för att prova privat AI-chatt eller %1$sinaktivera den i menyn "
+"%2$s.%3$s"
 
 # smartling.placeholder_format=C
 msgid "Togo"
@@ -22154,7 +22114,7 @@ msgstr "För långsam"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "För långsam för att generera"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22604,7 +22564,7 @@ msgstr "Försök att använda färre sökord."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Prova gratis"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23171,14 +23131,13 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: https://"
-"duckduckgo.com"
+"Under %1$sVid uppstart%2$s, välj %3$sStartsida%4$s och skriv: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sOpen with%s select %sA specific page or pages%s"
-msgstr ""
-"Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
+msgstr "Under %1$sÖppna med%2$s, välj %3$sEn särskild sida eller grupp av sidor%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23205,8 +23164,7 @@ msgstr "Under sektionen %1$sSök%2$s, klicka på %3$sHantera sökmotorer...%4$s"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under On startup select %sOpen a specific page or set of pages%s"
-msgstr ""
-"Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
+msgstr "Under Vid start, välj %1$sÖppna en särskild sida eller grupp av sidor%2$s"
 
 #  Opera default search engine instruction
 # smartling.placeholder_format=C
@@ -23313,8 +23271,8 @@ msgctxt "voice chat limit modal"
 msgid ""
 "Unlock advanced AI models and higher limits with a DuckDuckGo Subscription"
 msgstr ""
-"Lås upp avancerade AI-modeller och högre gränser med en DuckDuckGo-"
-"prenumeration"
+"Lås upp avancerade AI-modeller och högre gränser med en "
+"DuckDuckGo-prenumeration"
 
 # smartling.placeholder_format=C
 #. Text informing the user that advanced AI models can be unlocked with a subscription. The variable is used to insert a link that opens the subscription modal. Example: Unlock advanced AI models with a DuckDuckGo subscription.
@@ -23696,8 +23654,7 @@ msgstr "Använd DuckDuckGo Private Search"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
+msgstr "Använd privat sökning från DuckDuckGo på din iPad, iPhone eller Android!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24015,9 +23972,10 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna Duck."
-"ai-inställningarna. Välj Aktivera under Sync & Backup och välj Synkronisera "
-"med en annan enhet. Eller skanna QR-koden på din återställnings-PDF."
+"Gå till Duck.ai i din andra webbläsare eller DuckDuckGo-appen och öppna "
+"Duck.ai-inställningarna. Välj Aktivera under Sync & Backup och välj "
+"Synkronisera med en annan enhet. Eller skanna QR-koden på din "
+"återställnings-PDF."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24070,8 +24028,8 @@ msgstr "Röstchatt avslutad"
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
 msgstr ""
-"Röstchatt är anonymiserad av oss och används aldrig för att träna AI-"
-"modeller."
+"Röstchatt är anonymiserad av oss och används aldrig för att träna "
+"AI-modeller."
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24257,8 +24215,7 @@ msgstr "Vi anonymiserar"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
+msgstr "Vi kan anonymisera %1$sdin plats%2$s för att visa dig mer exakta resultat."
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24292,16 +24249,14 @@ msgstr ""
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can use your anonymous%s location%s to show you nearby results."
-msgstr ""
-"Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
+msgstr "Vi kan använda din %1$splats%2$s anonymt för att visa resultat i närheten."
 
 # smartling.placeholder_format=C
 #. Error message displayed when one or more attached files are encrypted and cannot be read.
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
+msgstr "Vi kan inte läsa de bifogade filerna eftersom minst en av dem är krypterad."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24312,8 +24267,7 @@ msgstr "Vi förföljer dig inte med annonser."
 #. Text explaining how the cloud save feature works.
 msgctxt "cloudsave"
 msgid "We don't store usernames or any personally identifiable information."
-msgstr ""
-"Vi lagrar inte användarnamn eller annan personligt identifierbar information."
+msgstr "Vi lagrar inte användarnamn eller annan personligt identifierbar information."
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -24344,8 +24298,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
+msgstr "Vi spårar dig inte, och vi vill gärna veta varför du kom tillbaka idag:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24517,8 +24470,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
+msgstr "Vi blockerar spårare som försöker samla in dina uppgifter medan du surfar."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24729,8 +24681,7 @@ msgstr ""
 #. Intro message on import screen.
 msgctxt "duckai_migration"
 msgid "Welcome to new Duck.ai! You can now import your downloaded chats."
-msgstr ""
-"Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
+msgstr "Välkommen till nya Duck.ai! Du kan nu importera dina nedladdade chattar."
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24825,8 +24776,7 @@ msgstr "Kan du ge några faktorer man ska tänka på när man köper en datorsk�
 #. Text for a prompt suggestion for asking about must-see attractions in Paris for a first-time visitor.
 msgctxt "Full sentence for planning a trip"
 msgid "What are some must-see attractions in Paris for a first-time visitor?"
-msgstr ""
-"Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
+msgstr "Vilka är några sevärdheter man måste se första gången man besöker i Paris?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for finding options for the word 'better' in a specific context.
@@ -24926,8 +24876,7 @@ msgstr "Vilka är de viktigaste lärdomarna?"
 #. Prompt sent to the AI when the user taps the "What will I learn?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "What are the key things I will learn from this course?"
-msgstr ""
-"Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
+msgstr "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the counterarguments?" page-suggestion chip.
@@ -24952,8 +24901,7 @@ msgstr "Vilka är de mest rekommenderade rätterna här?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
+msgstr "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25180,8 +25128,7 @@ msgstr "Vad vill du ge feedback om?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
+msgstr "Det du tittar på i DuckDuckGo påverkar inte dina rekommendationer på YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -25213,8 +25160,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "When enabled, Duck.ai will show instant answers in the chat."
-msgstr ""
-"När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
+msgstr "När det är aktiverat kommer Duck.ai att visa omedelbara svar i chatten."
 
 # smartling.placeholder_format=C
 #. Text of a button that performs a search for the available streaming services that show a particular movie or tv show
@@ -25272,8 +25218,7 @@ msgstr "Vilka är vi"
 #. Prompt sent to the AI when the user taps the "Cast & Crew" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "Who are the main cast and crew, and what else are they known for?"
-msgstr ""
-"Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
+msgstr "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Who is this person?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25429,8 +25374,7 @@ msgstr ""
 msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, your most recent chats will be saved on this device."
-msgstr ""
-"När chatthistoriken är på sparas dina senaste chattar på den här enheten."
+msgstr "När chatthistoriken är på sparas dina senaste chattar på den här enheten."
 
 # smartling.placeholder_format=C
 #. Section header in the model switch dropdown, shown above the list of models that do NOT run in a Trusted Execution Environment (i.e. the model provider can access user data). It is paired with a 'Zero provider visibility' section that lists the encrypted models. Please keep the wording consistent with the 'Zero provider visibility' label.
@@ -25694,8 +25638,7 @@ msgstr "Ja, ny användare!"
 msgctxt "cloudsave"
 msgid ""
 "Yes, we throw away data when you’re done with it, and it cannot be recovered."
-msgstr ""
-"Ja, vi slänger data när du är klar med dem och de kan inte återställas."
+msgstr "Ja, vi slänger data när du är klar med dem och de kan inte återställas."
 
 # smartling.placeholder_format=C
 #. Option for the filter-by-date search.
@@ -25714,8 +25657,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "You are chatting with %s. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
+msgstr "Du chattar med %1$s. AI-chattar kan visa felaktig eller stötande information."
 
 # smartling.placeholder_format=C
 #. Provide users with the ability to retry their search on a different search engine. First placeholder will be a link with the text "try your search again" OR "try your search later". Second is a URL to the !bangs page: https://duckduckgo.com/bangs.
@@ -25901,8 +25843,7 @@ msgstr ""
 #. Text explaining the benefits of the cloud save feature.
 msgctxt "cloudsave"
 msgid "You can restore your settings after deleting cookies."
-msgstr ""
-"Du kan återställa dina inställningar efter att du har tagit bort kakor."
+msgstr "Du kan återställa dina inställningar efter att du har tagit bort kakor."
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -26162,8 +26103,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. YouTube-"
-"videor som visas här spåras därför av YouTube/Google."
+"YouTube (som ägs av Google) låter dig inte titta på videor anonymt. "
+"YouTube-videor som visas här spåras därför av YouTube/Google."
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -26308,8 +26249,8 @@ msgstr "Dina chattar sparas nu."
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never saved or used to train AI models"
 msgstr ""
-"Dina chattar är privata, sparas aldrig och används inte för att träna AI-"
-"modeller"
+"Dina chattar är privata, sparas aldrig och används inte för att träna "
+"AI-modeller"
 
 # smartling.placeholder_format=C
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
@@ -26452,10 +26393,10 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure Hash-"
-"algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande inställningsfil "
-"lämnar din webbläsare. Vi sparar inställningsfilen med nyckeln som namn. "
-"DuckDuckGo känner aldrig till ditt lösenord."
+"Ditt lösenord genererar en 512-bitars nyckel med hjälp av Secure "
+"Hash-algoritmen %1$sSHA-2%2$s. Endast nyckeln och tillhörande "
+"inställningsfil lämnar din webbläsare. Vi sparar inställningsfilen med "
+"nyckeln som namn. DuckDuckGo känner aldrig till ditt lösenord."
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -26696,8 +26637,7 @@ msgstr "av %1$s"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
+msgstr "av DuckDuckGo — onlineskydd som miljontals människor litar på varje dag."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"
@@ -26917,8 +26857,8 @@ msgstr "den officiella webbplatsen"
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
 msgstr ""
-"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat %3$s-"
-"tecken)"
+"eller skriv koden för färgen du vill ha, t.ex. %1$s (%2$s är ett kodat "
+"%3$s-tecken)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/ta_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/ta_IN/LC_MESSAGES/duckduckgo.po
@@ -2382,6 +2382,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5249,6 +5260,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "நிராகரி"
@@ -5339,6 +5355,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6822,6 +6843,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7077,6 +7103,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7825,6 +7856,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8759,6 +8795,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12723,6 +12764,11 @@ msgstr "போலிஷ்"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17811,6 +17857,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18170,6 +18221,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "குறைவான முக்கிய வார்த்தைகளை முயற்சிக்கவும்."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/te_IN/LC_MESSAGES/duckduckgo.po
+++ b/locales/te_IN/LC_MESSAGES/duckduckgo.po
@@ -2373,6 +2373,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5215,6 +5226,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5304,6 +5320,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6761,6 +6782,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7014,6 +7040,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7761,6 +7792,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8682,6 +8718,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12618,6 +12659,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17659,6 +17705,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18017,6 +18068,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,8 +191,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -203,8 +202,7 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
-"Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -221,8 +219,7 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -230,9 +227,7 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr ""
-"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -336,7 +331,6 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
-""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -424,8 +418,7 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -435,9 +428,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
-"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -457,8 +448,7 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
-"จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -510,16 +500,13 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s "
-"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -1003,9 +990,8 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
-"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1068,8 +1054,7 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
-"และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1266,8 +1251,7 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
-"หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1302,9 +1286,7 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1312,8 +1294,7 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1711,9 +1692,7 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
-"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1850,8 +1829,7 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
-"หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1904,8 +1882,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
-"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
+"AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1976,10 +1954,8 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
-"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
-"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2124,8 +2100,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2134,8 +2109,7 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
-"%4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2149,8 +2123,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
-"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
+"หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2197,8 +2171,7 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
-"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2325,8 +2298,7 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
-"รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2335,8 +2307,7 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
-"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2374,8 +2345,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
-"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
+"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2518,16 +2489,12 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
-"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
-"(ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
+"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2539,14 +2506,9 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-""
-"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
-"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ "
-""
+"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2574,8 +2536,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN "
-"จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP ของคุณเมื่อใช้ Wi‑Fi"
+"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP "
+"ของคุณเมื่อใช้ Wi‑Fi"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2722,8 +2684,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2733,8 +2695,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
-"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2940,8 +2902,20 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
-"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
+"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3332,17 +3306,15 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
-"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3351,9 +3323,8 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
-"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
-"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
+"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3460,11 +3431,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น "
-"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
-"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3473,9 +3442,8 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
-"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
-"%1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3484,8 +3452,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
-"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
+"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3986,8 +3954,7 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
-"%1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4130,9 +4097,8 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"การแชทจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"ด้วยการเข้ารหัสแบบครบวงจร ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ "
-"แม้แต่เรา"
+"การแชทจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo ด้วยการเข้ารหัสแบบครบวงจร "
+"ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ แม้แต่เรา"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4141,8 +4107,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4155,11 +4121,9 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4182,8 +4146,7 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
-"Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -4244,9 +4207,7 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr ""
-"ตรวจสอบ subreddit ของ DuckDuckGo "
-"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4349,8 +4310,7 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 "
-"แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
+"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4549,9 +4509,8 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-""
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
-"AI Chat เป็นเวลา 7 วันขึ้นไป"
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
+"Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4562,8 +4521,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
-"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
+"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4572,8 +4531,7 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
-"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4582,8 +4540,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
-"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
+"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4625,8 +4583,7 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
-"Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4657,8 +4614,7 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
-"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4750,8 +4706,7 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
-"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4832,8 +4787,7 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
-"%3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5041,8 +4995,7 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save "
-"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5497,8 +5450,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup "
-"› Sync With Another Device%2$s แล้วลองอีกครั้ง"
+"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup › Sync "
+"With Another Device%2$s แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6480,6 +6433,12 @@ msgid "Dislike source"
 msgstr "ไม่ชอบแหล่งที่มา"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "ปิด"
@@ -6590,6 +6549,12 @@ msgid "Djibouti"
 msgstr "จิบูตี"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6675,8 +6640,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
-"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
+"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6685,8 +6650,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
-"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
+"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6970,8 +6935,7 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
-"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -7022,8 +6986,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
-"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
+"duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7038,8 +7002,7 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7060,9 +7023,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
-"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
-"%1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
+"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7073,10 +7035,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
-"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
-"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
+"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
+"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
+"duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7137,9 +7099,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
-"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
-"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
+"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
+"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7168,12 +7130,10 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
-"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
-"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
+"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
+"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7182,9 +7142,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
-"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
-"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
+"และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7193,9 +7153,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
-"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
+"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
+"Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7208,10 +7168,8 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
-""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
-"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -7229,16 +7187,11 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
-""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
-"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
-"โดยอ้างอิงแหล่งที่มาของคำตอบ "
-""
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
+"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
-""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -7248,8 +7201,7 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist "
-"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7257,9 +7209,7 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr ""
-"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
-"โปรดแชทต่อในวันพรุ่งนี้"
+msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7268,8 +7218,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7278,8 +7228,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
-"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
+"%2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7296,8 +7246,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
-"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
+"%1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7305,9 +7255,7 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
-"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7463,8 +7411,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
-"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
+"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7472,8 +7420,7 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
-"ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7482,8 +7429,7 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
-"%2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7492,9 +7438,8 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
-"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
-"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
+"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7506,11 +7451,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
-"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
-"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7532,9 +7475,8 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
-"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
+"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7626,9 +7568,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
-"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
-"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
+"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7842,9 +7783,7 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr ""
-"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
-"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -8064,8 +8003,7 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
-"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8091,8 +8029,7 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
-"นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8432,6 +8369,12 @@ msgid "Fast"
 msgstr "เร็ว"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8492,9 +8435,7 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr ""
-"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
-"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8588,9 +8529,7 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr ""
-"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
-"%1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8753,6 +8692,12 @@ msgid "Follow-ups remain private."
 msgstr "ข้อความเพิ่มเติมยังคงเป็นส่วนตัว"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8868,7 +8813,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8968,8 +8913,7 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
-"<strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9255,8 +9199,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity "
-"Theft Restoration"
+"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity Theft "
+"Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9327,9 +9271,7 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr ""
-"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
-"เพียงครั้งเดียว"
+msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9350,8 +9292,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), "
-"บริการ Personal Info Removal และ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), บริการ Personal "
+"Info Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9360,8 +9302,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI "
-"ขั้นสูงที่เป็นตัวเลือกเสริม และบริการ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI ขั้นสูงที่เป็นตัวเลือกเสริม "
+"และบริการ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9370,8 +9312,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9382,8 +9324,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
-"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
+"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9427,9 +9369,8 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล "
-"AI ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ "
-"อีกมากมาย"
+"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล AI "
+"ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9438,8 +9379,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal "
-"Information Removal และ Identity Theft Restoration"
+"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal Information Removal "
+"และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9447,8 +9388,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft "
-"Restoration ของเรา"
+"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft Restoration "
+"ของเรา"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9548,9 +9489,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
-"Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9559,8 +9499,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9570,9 +9510,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9582,9 +9521,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
-"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
+"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9593,8 +9532,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
-"Another Device%4$s."
+"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With Another "
+"Device%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9610,8 +9549,7 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
-"เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9620,8 +9558,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
+"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9688,6 +9626,12 @@ msgstr "การออกแบบที่ดี"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "นโยบายความเป็นส่วนตัวที่ดี"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10309,9 +10253,7 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr ""
-"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
-"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10404,8 +10346,7 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
-"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10553,7 +10494,6 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
-""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10676,9 +10616,7 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr ""
-"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
-"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10713,8 +10651,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
-"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
+"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10724,9 +10662,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
-"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
-"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
+"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
+"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10761,8 +10699,7 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10779,8 +10716,7 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
-"%2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10788,8 +10724,7 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
-"(เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10827,6 +10762,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "ข้อความแจ้งภาพต้องสอดคล้องกับ %1$s ของ Duck.ai"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10931,7 +10872,6 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
-""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -11367,11 +11307,9 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
-""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page "
-"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
-"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
+"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11380,8 +11318,7 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
-"และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11454,8 +11391,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 "
-"เครื่องพร้อมกัน"
+"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 เครื่องพร้อมกัน"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -13431,11 +13367,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
-"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14270,8 +14204,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
-"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
+"> การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14280,8 +14214,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
-"› Sync With Another Device%4$s"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14290,8 +14224,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
-"› Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14300,8 +14234,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
-"› Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
+"With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14329,8 +14263,7 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
-"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14356,9 +14289,7 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr ""
-"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
-"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14703,8 +14634,7 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ "
-"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -14720,8 +14650,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "VPN แบบไม่บันทึกกิจกรรมที่รวดเร็วของเรามาพร้อมกับการแชท AI "
-"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ "
-"อีกมากมาย การสมัครสมาชิกแบบครบวงจรในที่เดียว"
+"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย "
+"การสมัครสมาชิกแบบครบวงจรในที่เดียว"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14729,8 +14659,7 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
-"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14738,9 +14667,8 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
-"พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14993,8 +14921,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
-"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
+"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15150,8 +15078,7 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal "
-"ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
+"Personal Information Removal ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
 "จากนั้นเราดำเนินการเพื่อให้ข้อมูลนั้นถูกลบออกแทนคุณ"
 
 # smartling.placeholder_format=C
@@ -15223,10 +15150,9 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15236,9 +15162,8 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
-"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
-"DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
+"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15249,8 +15174,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
-"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
+"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15298,9 +15223,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
-"DuckDuckGo"
+msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15669,6 +15592,12 @@ msgstr "โปแลนด์"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "การจัดรูปแบบที่ไม่ดี"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16231,9 +16160,7 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr ""
-"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
-"[แทรกข้อความของคุณเองที่นี่]"
+msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16540,9 +16467,8 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
-"DuckDuckGo หลังจากที่ส่งไปแล้ว "
-"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16824,8 +16750,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
-"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
+"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16933,8 +16859,7 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16943,8 +16868,7 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก "
-"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -17009,9 +16933,8 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
-"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
-"%1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
+"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17019,8 +16942,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
+"ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -17029,9 +16952,8 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo "
-"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
-"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
+"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17123,9 +17045,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -17135,9 +17056,8 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -17148,11 +17068,10 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
-"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
-"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
-"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
+"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
+"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17751,8 +17670,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
-"(หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17761,8 +17679,7 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
-"%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17849,11 +17766,10 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
-"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
-"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
-"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
-"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
+"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
+"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17861,8 +17777,7 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
-"ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17871,9 +17786,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
-"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
-"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
+"ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17994,8 +17909,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
-"โดยตรงบน Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
+"Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -18015,8 +17930,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
-"%1$sduckduckgo.com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
+"com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -18035,10 +17950,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
-""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -18160,7 +18073,6 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
-""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -18339,8 +18251,7 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
-"ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18405,8 +18316,7 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18414,8 +18324,7 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
-"Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18479,9 +18388,7 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr ""
-"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
-"ตามต้องการ)"
+msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18603,8 +18510,7 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI "
-"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -18728,16 +18634,13 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup "
-"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr ""
-"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
-"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19404,8 +19307,7 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
-"DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19767,9 +19669,7 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr ""
-"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
-"เพื่อลองอีกครั้ง"
+msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -20248,9 +20148,7 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr ""
-"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
-"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20648,9 +20546,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup "
-"จะบันทึกการแชทของคุณมากขึ้นและซิงค์การแชทเหล่านั้นในทุกอุปกรณ์ของคุณ"
+msgstr "Sync & Backup จะบันทึกการแชทของคุณมากขึ้นและซิงค์การแชทเหล่านั้นในทุกอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20699,9 +20595,8 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
-"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
-"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
+"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -20711,11 +20606,9 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
-"here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
-"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -20855,8 +20748,7 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"พก Duck.ai ไปกับคุณได้ทุกที่ "
-"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณได้ทุกที่ รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20866,8 +20758,7 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"พก Duck.ai ไปกับคุณทุกที่ "
-"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณทุกที่ รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20891,9 +20782,7 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr ""
-"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
-"ดีขึ้นได้อย่างไรบ้าง"
+msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21114,7 +21003,6 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
-""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -21135,8 +21023,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"ปุ่มสลับ Duck.ai ช่วยให้คุณสลับระหว่างการค้นหาแบบส่วนตัวและแชท AI "
-"ได้อย่างรวดเร็ว โดยไม่ระบุตัวตนด้วย DuckDuckGo"
+"ปุ่มสลับ Duck.ai ช่วยให้คุณสลับระหว่างการค้นหาแบบส่วนตัวและแชท AI ได้อย่างรวดเร็ว "
+"โดยไม่ระบุตัวตนด้วย DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21166,7 +21054,6 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
-""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -21189,9 +21076,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr ""
-"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
-"บนเซิร์ฟเวอร์ของเขา"
+msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21284,7 +21169,6 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
-""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -21332,9 +21216,7 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr ""
-"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
-"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21405,9 +21287,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
-"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
-"สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
+"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21424,8 +21305,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท "
-"%1$s ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
+"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท %1$s "
+"ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21531,8 +21412,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
-"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก ปักหมุด "
+"เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21561,8 +21442,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
-"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
+"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21571,8 +21452,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
-"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
+"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21609,7 +21490,6 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
-""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -21620,9 +21500,8 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21632,9 +21511,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
-"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
-"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
+"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -21686,9 +21564,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
-"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
-"ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
+"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21697,8 +21574,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
-"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
+"การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21716,9 +21593,7 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
-"ดำเนินการต่อหรือไม่"
+msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21837,7 +21712,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr ""
+"วิธีการพิมพ์เส้นทาง:"
+"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21847,8 +21724,7 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
-"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -21955,6 +21831,12 @@ msgstr "มีผลลัพธ์มากเกินไปจากแหล
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "ช้าเกินไป"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22116,9 +21998,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22126,9 +22006,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
-"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22397,6 +22275,12 @@ msgid "Try fewer keywords."
 msgstr "ลองใช้คีย์เวิร์ดน้อยลง"
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22606,8 +22490,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22616,8 +22500,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
-"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
+"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22949,8 +22833,7 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
-"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22958,8 +22841,7 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
-"https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -23075,8 +22957,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
-"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
+"โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23234,8 +23116,7 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
-"และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23463,9 +23344,8 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
-"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
-"ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
+"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23519,9 +23399,7 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr ""
-"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
-"เก็บรักษาไว้ให้ปลอดภัย"
+msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23720,9 +23598,7 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า Assist%2$s "
-"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23730,9 +23606,7 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr ""
-"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
-"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23755,9 +23629,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
-"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
-"Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
+"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23767,9 +23640,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
+"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23779,9 +23651,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
-"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
-"จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
+"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
+"With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23791,9 +23663,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
-"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
-"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
+"การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23845,10 +23717,7 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr ""
-""
-"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
-"AI"
+msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -24019,10 +23888,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
-"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
-"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
-"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
+"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -24034,9 +23901,7 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr ""
-"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
-"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -24048,9 +23913,8 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
-"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -24062,8 +23926,7 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
-"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -24077,9 +23940,7 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
-"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24107,8 +23968,7 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
-"เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24121,9 +23981,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -24132,8 +23990,7 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ "
-"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24200,8 +24057,7 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ "
-"VPN และอื่นๆ"
+"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ VPN และอื่นๆ"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24210,8 +24066,7 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI "
-"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24246,7 +24101,6 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
-""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -24264,9 +24118,7 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr ""
-"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
-"ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24302,8 +24154,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ "
-"ของคุณ และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
+"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ ของคุณ "
+"และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24312,8 +24164,7 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
-"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24346,8 +24197,7 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
-"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24455,9 +24305,7 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr ""
-"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
-"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24471,8 +24319,7 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
-"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24493,8 +24340,7 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
-"หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24601,9 +24447,7 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr ""
-"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
-"\"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24628,11 +24472,10 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
-"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
-"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
-"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
-"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
+"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
+"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
+"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25179,9 +25022,7 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr ""
-"เมื่อเปิดใช้งานประวัติการแชท จะสามารถบันทึกแชทล่าสุดได้สูงสุด %1$s "
-"รายการบนอุปกรณ์นี้"
+msgstr "เมื่อเปิดใช้งานประวัติการแชท จะสามารถบันทึกแชทล่าสุดได้สูงสุด %1$s รายการบนอุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25494,9 +25335,7 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
-"%2$sการตั้งค่าการค้นหา%3$s"
+msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25505,8 +25344,7 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
-"%1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -25645,9 +25483,7 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr ""
-"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
-"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25711,8 +25547,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
-"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
+"เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25787,8 +25623,7 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
-"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25801,8 +25636,7 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
-"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25878,8 +25712,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
-"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
+"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25889,9 +25723,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
-"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
-"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
+"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25905,8 +25738,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
-"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
+"ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25928,8 +25761,7 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
-"การแชทล่าสุด %1$s "
-"รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
+"การแชทล่าสุด %1$s รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26018,17 +25850,14 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
-"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
-"ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -26076,8 +25905,7 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -26085,8 +25913,7 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
-"เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26186,8 +26013,7 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
-"%1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -26204,8 +26030,7 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
-"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -26251,8 +26076,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
-"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น เปิดใช้งานส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26261,10 +26086,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
-"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
-"%3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26641,9 +26464,7 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr ""
-"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
-"ตัวที่เข้ารหัสแล้ว)"
+msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/th_TH/LC_MESSAGES/duckduckgo.po
+++ b/locales/th_TH/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -191,7 +191,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -202,7 +203,8 @@ msgid ""
 "browser again to continue the chat, or switch to a Plus or free model."
 msgstr ""
 "%1$s ใช้ได้กับ Pro เท่านั้น อัปเกรดการสมัครสมาชิก DuckDuckGo "
-"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล Plus หรือฟรี"
+"ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดล "
+"Plus หรือฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -219,7 +221,8 @@ msgid ""
 "model."
 msgstr ""
 "%1$s สามารถใช้ได้เฉพาะกับการสมัครใช้งาน DuckDuckGo เท่านั้น "
-"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งานการสมัครของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -227,7 +230,9 @@ msgctxt "Error message for model unavailability"
 msgid ""
 "%s is temporarily unavailable. Please switch to a different model or try "
 "again later."
-msgstr "%1$s ไม่สามารถใช้งานได้ชั่วคราว โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
+msgstr ""
+"%1$s ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดเปลี่ยนไปใช้รุ่นอื่นหรือลองอีกครั้งในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Reddit's "fake internet points". https://support.reddithelp.com/hc/en-us/articles/204511829-What-is-karma
@@ -331,6 +336,7 @@ msgid ""
 "their servers."
 msgstr ""
 "%1$s ทํางานในสภาพแวดล้อมการดําเนินการที่เชื่อถือได้ "
+""
 "นี่หมายความว่าแม้แต่ผู้ให้บริการโมเดลก็ไม่สามารถดูคำแนะนำของคุณหรือการตอบสนองของโมเดล "
 "หรือบันทึกการแชทนี้บนเซิร์ฟเวอร์ของพวกเขา"
 
@@ -418,7 +424,8 @@ msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
 msgstr ""
-"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+"%1$s จะออกจาก Duck.ai ใน %2$s วัน (%3$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -428,7 +435,9 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
+msgstr ""
+"%1$s จะออกจาก Duck.ai ใน 1 วัน (%2$s) หลังจากนั้น "
+"คุณสามารถเปลี่ยนรุ่นเพื่อแชทต่อ"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -448,7 +457,8 @@ msgstr "%1$sคลิก%2$sเพิ่ม%3$sเลือก%4$sอนุญ�
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
 msgstr ""
-"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s จากนั้นคลิก%8$sตกลง%9$s"
+"%1$sคลิก%2$sอนุญาต%3$sคลิก%4$sเพิ่ม%5$sเลือก%6$sอนุญาต%7$s "
+"จากนั้นคลิก%8$sตกลง%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -500,13 +510,16 @@ msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
 msgstr ""
-"%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนเซิร์ฟเวอร์ของ DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
 msgctxt "Information about adjusting recent chat storage settings"
 msgid "%sLearn more%s about how chats are stored privately on your device."
-msgstr "%1$sเรียนรู้เพิ่มเติม%2$s เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
+msgstr ""
+"%1$sเรียนรู้เพิ่มเติม%2$s "
+"เกี่ยวกับวิธีการจัดเก็บแชทอย่างเป็นส่วนตัวบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Tells the user to press and hold the DuckDuckGo app icon. Part of a list of instructions on how to enable location service.
@@ -990,8 +1003,9 @@ msgid ""
 "aichat%s."
 msgstr ""
 "AI Chat ช่วยให้คุณสนทนาแบบไม่ต้องระบุชื่อด้วยโมเดลแชท AI ของบริษัทอื่น "
-"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search คุณยังคงสามารถเข้าถึง AI Chat "
-"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$sduckduckgo.com/aichat%2$s"
+"การปิดฟีเจอร์นี้จะซ่อนฟีเจอร์ AI Chat ใน DuckDuckGo Search "
+"คุณยังคงสามารถเข้าถึง AI Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$sduckduckgo.com/aichat%2$s"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1054,7 +1068,8 @@ msgid ""
 msgstr ""
 "คำตอบที่ได้รับความช่วยเหลือจาก AI ขณะนี้ยังไม่รองรับคำถามที่ถามต่อโดยตรง "
 "แต่เรามีและมักจะเชื่อมโยงไปยัง %1$sDuck.ai%2$s สำหรับคำถามที่ถามต่อ "
-"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic และอีกมากมาย"
+"ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลแชทจาก OpenAI, Anthropic "
+"และอีกมากมาย"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1251,7 +1266,8 @@ msgid ""
 "Activate your %s in this browser again to continue the chat, or switch to a "
 "free model."
 msgstr ""
-"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ หรือเปลี่ยนไปใช้โมเดลฟรี"
+"เปิดใช้งาน %1$s ของคุณในเบราว์เซอร์นี้อีกครั้งเพื่อดำเนินการแชทต่อ "
+"หรือเปลี่ยนไปใช้โมเดลฟรี"
 
 # smartling.placeholder_format=C
 #. Label indicating that the user has an active DuckDuckGo subscription.
@@ -1286,7 +1302,9 @@ msgstr "โฆษณา"
 #. An item in the ads tooltip that explains that ad clicks are managed by the ad network and are not used to profile you. The placeholder is the name of the ad network. For example: Microsoft
 msgid ""
 "Ad clicks are managed by %s’s ad network and are not used to profile you."
-msgstr "การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+msgstr ""
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ %1$s "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Information that ad clicks are managed by Microsoft.
@@ -1294,7 +1312,8 @@ msgid ""
 "Ad clicks are managed by Microsoft’s ad network and are not used to profile "
 "you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Microsoft "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. An item in the ads tooltip that explains that ad clicks aren’t used to profile you.
@@ -1692,7 +1711,9 @@ msgstr "หลังจากดาวน์โหลดและเปิด �
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
+msgstr ""
+"หลังจากที่ดาวน์โหลดเสร็จเรียบร้อย "
+"ให้ค้นหาไฟล์ส่วนขยายแล้วดับเบิลคลิกเพื่อติดตั้ง"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -1829,7 +1850,8 @@ msgid ""
 "to train chat models by DuckDuckGo or the model providers"
 msgstr ""
 "การแชททั้งหมดจะถูกทำให้ไม่ระบุชื่อโดย DuckDuckGo "
-"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo หรือผู้ให้บริการโมเดล"
+"และการสนทนาของคุณจะไม่ถูกใช้ในการฝึกโมเดลการแชทโดย DuckDuckGo "
+"หรือผู้ให้บริการโมเดล"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1882,8 +1904,8 @@ msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
 msgstr ""
-"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ "
-"AI"
+"ข้อมูลเมตาส่วนบุคคลทั้งหมด (เช่น ที่อยู่ IP ของคุณ) "
+"จะถูกลบออกก่อนที่จะส่งการแชทไปยังผู้ให้บริการ AI"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1954,8 +1976,10 @@ msgid ""
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
 "อนุญาตให้ %1$s ค้นหาเว็บเพื่อปรับปรุงการตอบสนองต่อข้อความแจ้งที่เกี่ยวข้อง "
-"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
-"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี %3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
+"ส่งเฉพาะข้อความค้นหาที่สร้างโดย AI "
+"ไปยังเครื่องมือค้นหาที่มีการเก็บรักษาข้อมูลที่จํากัด "
+"คำแนะนำและการตอบสนองที่มี %2$s ยังคงมี "
+"%3$sการมองเห็นผู้ให้บริการเป็นศูนย์%4$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2100,7 +2124,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Text with information about Duck.ai and supported AI models, the placeholders list AI models. Example: 'Anonymous access to popular AI models, including GPT, Claude, and open-source Llama and Mistral.'
@@ -2109,7 +2134,8 @@ msgid ""
 "Anonymous access to popular AI models, including %s, %s, and open-source %s "
 "and %s."
 msgstr ""
-"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ %4$sโอเพ่นซอร์ส"
+"การเข้าถึงโมเดล AI ยอดนิยมแบบไม่ระบุชื่อ รวมถึง %1$s, %2$sและ %3$s และ "
+"%4$sโอเพ่นซอร์ส"
 
 # smartling.placeholder_format=C
 #. Confirmation message after location service is enabled.
@@ -2123,8 +2149,8 @@ msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
 msgstr ""
-"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ เลือกความถี่ที่คุณต้องการให้แสดง "
-"หรือปิดการใช้งานโดยสมบูรณ์"
+"สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุตัวตนโดยอิงจากเนื้อหาบนเว็บ "
+"เลือกความถี่ที่คุณต้องการให้แสดง หรือปิดการใช้งานโดยสมบูรณ์"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2171,7 +2197,8 @@ msgid ""
 "Any additional instructions you want Duck.ai to follow. e.g. Always tell me "
 "facts about ducks"
 msgstr ""
-"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
+"คำแนะนำเพิ่มเติมที่เธอต้องการให้ Duck.ai ปฏิบัติตาม เช่น "
+"บอกข้อเท็จจริงเกี่ยวกับเป็ดให้ฉันรู้เสมอ"
 
 # smartling.placeholder_format=C
 #. Shown in video filtering. https://duckduckgo.com/?q=videos+of+cats&iax=videos&ia=videos
@@ -2298,7 +2325,8 @@ msgid ""
 "Are you sure you want to disable history? This will delete all chats, "
 "including pinned chats."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด รวมถึงแชทที่ปักหมุดไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานประวัติ การกระทำนี้จะลบแชททั้งหมด "
+"รวมถึงแชทที่ปักหมุดไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to disable recent chats, with a warning that it will also delete currently saved chats.
@@ -2307,7 +2335,8 @@ msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
+"คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งานแชทล่าสุด "
+"การดำเนินการนี้จะลบแชทล่าสุดที่มีการบันทึกไว้ด้วย"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2345,8 +2374,8 @@ msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
 msgstr ""
-"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ ด้วยตนเอง "
-"การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
+"ตามนโยบายความเป็นส่วนตัวของเรา เราจะไม่เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลใดๆ "
+"ด้วยตนเอง การปกป้องความเป็นส่วนตัวทั้งหมดนี้เกิดขึ้นบนอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2489,12 +2518,16 @@ msgid ""
 "answers are only available in the U.S. (English) region."
 msgstr ""
 "Assist สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
+""
 "โดยไม่ระบุตัวตนให้กับการค้นหาบางรายการโดยอิงจากการสรุปเนื้อหาเว็บที่เกี่ยวข้อง "
-"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ Assist UI "
-"ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อคุณคลิกปุ่ม Assist), บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
-"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ Assist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"Assist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI เมื่อคุณคลิกปุ่ม Assist), "
+"บางครั้ง (แสดงเฉพาะคำตอบที่ได้รับความช่วยเหลือจาก AI "
+"เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้างกว่า) สำหรับตอนนี้ "
+"คำตอบที่ได้รับความช่วยเหลือจาก AI มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา "
+"(ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2506,9 +2539,14 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก AI "
-"สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
-"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ "
+"Assist "
+""
+"เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบที่ได้รับความช่วยเหลือจาก "
+"AI สำหรับคำค้นหาโดยไม่ระบุชื่อได้ ในการดำเนินการนี้ "
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -2536,8 +2574,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP "
-"ของคุณเมื่อใช้ Wi‑Fi"
+"ที่คาเฟ่ สนามบิน หรือโรงแรม DuckDuckGo VPN "
+"จะเข้ารหัสการเชื่อมต่อของคุณและซ่อนที่อยู่ IP ของคุณเมื่อใช้ Wi‑Fi"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2684,8 +2722,8 @@ msgid ""
 "Assist is only available in English regions."
 msgstr ""
 "แสดง Assist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง Assist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ Assist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"Assist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2695,8 +2733,8 @@ msgid ""
 "For now, DuckAssist is only available in English regions."
 msgstr ""
 "แสดง DuckAssist โดยอัตโนมัติสำหรับการค้นหาที่เกี่ยวข้อง DuckAssist "
-"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ DuckAssist "
-"มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง สำหรับตอนนี้ "
+"DuckAssist มีให้บริการเฉพาะในภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2902,8 +2940,8 @@ msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
-"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ "
-"ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ "
+"PII เช่น ชื่อ ที่อยู่อีเมล และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2916,6 +2954,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"ก่อนจัดเก็บรายงานนี้ DuckDuckGo จะลบไฟล์ที่อัปโหลดและรูปภาพที่สร้างขึ้น "
+"และจะทำให้การสนทนาของคุณไม่ระบุตัวตนโดยการลบ PII เช่น ชื่อ ที่อยู่อีเมล "
+"และเมตาดาต้าที่ระบุตัวตนz"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3306,15 +3347,17 @@ msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ เรารวมเครื่องมือค้นหา "
-"เครื่องมือบล็อกตัวติดตาม และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
+"เรียกดูตามปกติขณะที่เราเพิ่มการปกป้องความเป็นส่วนตัวให้คุณ "
+"เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง เรารวมเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม "
 "และเครื่องมือบังคับใช้การเข้ารหัสไว้ด้วยกันใน%1$s%2$sส่วนขยาย%3$sเดียว"
 
 # smartling.placeholder_format=C
@@ -3323,8 +3366,9 @@ msgid ""
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
 msgstr ""
-"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private "
-"Search, การบล็อกตัวติดตาม และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
+"เรียกดูตามปกติ แล้วเราจะดูแลส่วนที่เหลือให้เอง "
+"ดาวน์โหลดเพียงครั้งเดียวแล้วใช้งานได้ทั้ง Private Search, การบล็อกตัวติดตาม "
+"และการเข้ารหัสเว็บไซต์สำหรับ%1$sเบราว์เซอร์หลักๆ%2$s"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3431,9 +3475,11 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"ตามค่าเริ่มต้น การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
+"ตามค่าเริ่มต้น "
+"การตั้งค่าจะได้รับการจัดเก็บอยู่ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคล "
 "(ในเบราว์เซอร์ของคุณ) คุณสามารถใช้ Cloud Save "
-"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ (บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
+"แบบไม่ระบุตัวตนเพื่อจัดเก็บข้อมูลการตั้งค่าอย่างถาวรยิ่งขึ้นได้ "
+"(บนเซิร์ฟเวอร์ระยะไกลในระบบคลาวด์) "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวตนได้บนระบบคลาวด์และรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
 
 # smartling.placeholder_format=C
@@ -3442,8 +3488,9 @@ msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการป้อนข้อความด้วยเสียง "
+"คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู "
+"%1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3452,8 +3499,8 @@ msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
 msgstr ""
-"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง OpenAI "
-"เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
+"โดยการเปิดใช้งานการแชทด้วยเสียง คุณยินยอมให้ข้อมูลเสียงของคุณถูกส่งไปยัง "
+"OpenAI เพื่อใช้งานคุณลักษณะนี้ ดู %1$s ของเราก่อนเริ่มต้น"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3954,7 +4001,8 @@ msgstr ""
 "Chat (ผ่านบริการ Duck.ai ของเรา) ให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI "
 "ของบุคคลที่สาม ซึ่งรองรับโมเดลจาก OpenAI, Anthropic และอีกมากมาย "
 "การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม "
-"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
+"คุณยังสามารถเข้าถึง Chat ได้เมื่อปิดการตั้งค่านี้โดยไปที่ "
+"%1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4097,8 +4145,9 @@ msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
 msgstr ""
-"การแชทจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo ด้วยการเข้ารหัสแบบครบวงจร "
-"ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ แม้แต่เรา"
+"การแชทจะถูกจัดเก็บอย่างปลอดภัยบนเซิร์ฟเวอร์ของ DuckDuckGo "
+"ด้วยการเข้ารหัสแบบครบวงจร ไม่มีใครนอกจากคุณที่สามารถเห็นข้อมูลของคุณ "
+"แม้แต่เรา"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4107,8 +4156,8 @@ msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
 msgstr ""
-"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo หรือเซิร์ฟเวอร์ระยะไกล "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
+"แชทจะถูกเก็บไว้ในอุปกรณ์ของคุณแทนที่จะอยู่บนเซิร์ฟเวอร์ของ DuckDuckGo "
+"หรือเซิร์ฟเวอร์ระยะไกล การปิดประวัติการแชทจะลบแชทที่ปักหมุด"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4121,9 +4170,11 @@ msgid ""
 "prompts and responses."
 msgstr ""
 "แชทจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4146,7 +4197,8 @@ msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
 msgstr ""
-"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน Duck.ai "
+"การแชทกับ %1$s จะไม่มีการมองเห็นจากผู้ให้บริการ แต่ไฟล์ทั้งหมดที่อัปโหลดใน "
+"Duck.ai "
 "จะได้รับการตรวจสอบโดยไม่ระบุชื่อโดยผู้ให้บริการกลั่นกรองเนื้อหาสำหรับ %2$s"
 
 # smartling.placeholder_format=C
@@ -4207,7 +4259,9 @@ msgstr "ตรวจสอบการสะกดคำ"
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the DuckDuckGo subreddit for updates on this outage."
-msgstr "ตรวจสอบ subreddit ของ DuckDuckGo เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
+msgstr ""
+"ตรวจสอบ subreddit ของ DuckDuckGo "
+"เพื่อรับข้อมูลอัปเดตเกี่ยวกับการหยุดให้บริการครั้งนี้"
 
 # smartling.placeholder_format=C
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
@@ -4310,7 +4364,8 @@ msgid ""
 "Choose from 40+ server locations worldwide to help block harmful sites and "
 "scams."
 msgstr ""
-"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
+"เลือกจากตำแหน่งเซิร์ฟเวอร์กว่า 40 "
+"แห่งทั่วโลกเพื่อช่วยบล็อกเว็บไซต์ที่เป็นอันตรายและการหลอกลวง"
 
 # smartling.placeholder_format=C
 #. The title of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -4509,8 +4564,9 @@ msgid ""
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชท "
-"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน AI "
-"Chat เป็นเวลา 7 วันขึ้นไป"
+""
+"เบราว์เซอร์บางตัวอาจเก็บแชทล่าสุดไว้อย่างไม่มีกำหนดหรืออาจลบอัตโนมัติหลังจากไม่ได้ใช้งาน "
+"AI Chat เป็นเวลา 7 วันขึ้นไป"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4521,8 +4577,8 @@ msgid ""
 "on your browser."
 msgstr ""
 "การล้างข้อมูลเบราว์เซอร์จะลบแชทล่าสุด "
-"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 วันหากไม่ได้ใช้ Duck.ai "
-"ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
+"แชทล่าสุดอาจถูกบันทึกไว้อย่างไม่มีกำหนดหรือลบอัตโนมัติหลังจาก 7 "
+"วันหากไม่ได้ใช้ Duck.ai ขึ้นอยู่กับเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4531,7 +4587,8 @@ msgid ""
 "Clearing browser data will reset your blocked sites. Save your block list "
 "permanently in"
 msgstr ""
-"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
+"การล้างข้อมูลเบราว์เซอร์จะรีเซ็ตไซต์ที่ถูกบล็อกของคุณ "
+"บันทึกรายการที่บล็อกของคุณอย่างถาวรใน"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -4540,8 +4597,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s บริการแชท AI "
-"ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
+"คลิก \"เพิ่มเติม\" เพื่อเจาะลึกหัวข้อ และถามคำถามติดตามผ่าน %1$sDuck.ai%2$s "
+"บริการแชท AI ส่วนตัวของเราที่รองรับโมเดลแชทจาก OpenAI, Anthropic และอื่น ๆ"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4583,7 +4640,8 @@ msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
 msgstr ""
-"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน Mac)"
+"คลิก%1$sแก้ไข > ค่ากำหนด%2$s (บน Windows) %3$sSeaMonkey > ค่ากำหนด%4$s (บน "
+"Mac)"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4614,7 +4672,8 @@ msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
 msgstr ""
-"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
+"คลิก %1$sSafari%2$s ในเมนูด้านบน (บน Windows "
+"ให้คลิก%3$sไอคอนเฟือง%4$sที่ด้านขวาบน)"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4706,7 +4765,8 @@ msgid ""
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
 msgstr ""
 "คลิกหรือแตะ %1$sลบข้อมูลของฉัน%2$s การดำเนินการนี้จะลบข้อมูลออกจากระบบคลาวด์ "
-"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ %3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
+"แต่จะยังคงอยู่ในเบราว์เซอร์จนกว่าคุณจะคลิก/แตะ "
+"%3$sรีเซ็ตการตั้งค่าการค้นหาทั้งหมด%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4787,7 +4847,8 @@ msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
 msgstr ""
-"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก %3$sDuckDuckGo%4$s"
+"คลิกเมนูดรอปดาวน์ข้าง%1$sเครื่องมือค้นหาที่ใช้ในแถบที่อยู่%2$s และเลือก "
+"%3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -4995,7 +5056,8 @@ msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
 msgstr ""
-"Cloud Save ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
+"Cloud Save "
+"ช่วยให้คุณบันทึกการตั้งค่าของคุณอย่างถาวรยิ่งขึ้นได้โดยการป้อนรหัสผ่าน "
 "ซึ่งเป็นการดำเนินการที่ไม่บังคับ"
 
 # smartling.placeholder_format=C
@@ -5450,8 +5512,8 @@ msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
 msgstr ""
-"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup › Sync "
-"With Another Device%2$s แล้วลองอีกครั้ง"
+"คัดลอกรหัสจากอุปกรณ์อื่น ไปที่ %1$sDuck.ai Settings › Chats › Sync & Backup "
+"› Sync With Another Device%2$s แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6436,7 +6498,7 @@ msgstr "ไม่ชอบแหล่งที่มา"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "ไม่ชอบรูปแบบภาพ"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6552,7 +6614,7 @@ msgstr "จิบูตี"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "ไม่ทำตามคำแนะนำ"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6640,8 +6702,8 @@ msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ AI "
-"ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม %1$snoai.duckduckgo.com%2$s ไม่มีฟีเจอร์ AI และกรองภาพ "
+"AI ออกแล้ว %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6650,8 +6712,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s เพื่อค้นหาโดยไม่มีฟีเจอร์ AI "
-"และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
+"ไม่ต้องการ AI ใช่ไหม ไปที่ %1$snoai.duckduckgo.com%2$s "
+"เพื่อค้นหาโดยไม่มีฟีเจอร์ AI และกรองภาพ AI ออก %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6935,7 +6997,8 @@ msgid ""
 "pages automatically in Settings."
 msgstr ""
 "ตอนนี้ Duck.ai สามารถช่วยตอบคําถามเกี่ยวกับหน้าเว็บที่คุณกำลังดูอยู่ได้แล้ว "
-"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
+"เนื้อหาในหน้าจะถูกรวมเข้าไปเมื่อคุณแนบมัน "
+"ยกเว้นว่าคุณเลือกที่จะแนบหน้าโดยอัตโนมัติในการตั้งค่า"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6986,8 +7049,8 @@ msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
 msgstr ""
-"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://"
-"duck.ai"
+"Duck.ai ยังคงเป็นผลิตภัณฑ์ของ DuckDuckGo "
+"แต่ตอนนี้จะมีที่อยู่บนเว็บที่จดจำง่ายขึ้น: https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -7002,7 +7065,8 @@ msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
 msgstr ""
-"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
+"Duck.ai ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7023,8 +7087,9 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai "
-"แต่คุณยังสามารถไปที่ %1$sduck.ai%2$s โดยตรง"
+"Duck.ai ให้คุณแชทแบบส่วนตัวกับโมเดล AI ยอดนิยม "
+"การปิดใช้งานจะซ่อนปุ่มและลิงก์ของ Duck.ai แต่คุณยังสามารถไปที่ "
+"%1$sduck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7035,10 +7100,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม รวมถึงโมเดลจาก "
-"OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat และลิงก์บน DuckDuckGo "
-"Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://"
-"duck.ai%2$s โดยตรง"
+"Duck.ai ช่วยให้คุณสนทนาแบบไม่ระบุตัวตนกับโมเดลแชท AI ของบุคคลที่สาม "
+"รวมถึงโมเดลจาก OpenAI, Anthropic และอื่นๆ การปิดการตั้งค่านี้จะซ่อนปุ่ม Chat "
+"และลิงก์บน DuckDuckGo Search อย่างไรก็ตาม คุณยังสามารถเข้าถึง Duck.ai "
+"ได้เมื่อปิดการตั้งค่านี้โดยไปที่ %1$shttps://duck.ai%2$s โดยตรง"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7099,9 +7164,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI แบบไม่ระบุตัวตน, แชท "
-"AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, โมเดล AI โอเพนซอร์ส, AI "
-"ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
+"Duck.ai, DuckDuckGo AI, แชทบอท AI ส่วนตัว, แชท AI ฟรี, แชท AI "
+"แบบไม่ระบุตัวตน, แชท AI ไม่ต้องสมัคร, OpenAI, Anthropic, Llama, Mistral, "
+"โมเดล AI โอเพนซอร์ส, AI ที่เน้นความเป็นส่วนตัว, แชท AI ไม่ต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7130,10 +7195,12 @@ msgid ""
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
 "DuckAssist สามารถค้นหาและสรุปข้อมูลโดยไม่ระบุตัวตนตามการค้นหาบางอย่าง "
-"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ DuckAssist "
-"UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ (แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
-"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) "
-"สำหรับตอนนี้ DuckAssist มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
+"คุณสามารถเลือกได้ว่าต้องการให้ DuckAssist ปรากฏบ่อยเพียงใด: ไม่แสดงเลย (ลบ "
+"DuckAssist UI ออกจากผลการค้นหาทั้งหมด), ตามต้องการ "
+"(แสดงเฉพาะเมื่อคุณคลิกปุ่ม Assist), บางครั้ง "
+"(แสดงเฉพาะเมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(แสดงบ่อยขึ้นในการค้นหาที่มีช่วงกว้าง) สำหรับตอนนี้ DuckAssist "
+"มีให้บริการเฉพาะในภูมิภาคสหรัฐอเมริกา (ภาษาอังกฤษ) เท่านั้น"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7142,9 +7209,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo AI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก OpenAI, Anthropic "
-"และอื่นๆ อีกมากมาย"
+"DuckAssist ไม่สามารถตอบคำถามที่ตามมาได้ อย่างไรก็ตาม เรายังมี %1$sDuckDuckGo "
+"AI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ใช้ AI และรองรับโมเดลการแชทจาก "
+"OpenAI, Anthropic และอื่นๆ อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7153,9 +7220,9 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo %1$sAI "
-"Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ที่รองรับโมเดลการแชทจาก OpenAI และ "
-"Anthropic"
+"DuckAssist ไม่สามารถตอบคำถามที่ถามต่อได้ อย่างไรก็ตาม เรายังมี DuckDuckGo "
+"%1$sAI Chat%2$s ซึ่งเป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ที่รองรับโมเดลการแชทจาก OpenAI และ Anthropic"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7168,8 +7235,10 @@ msgid ""
 "checked for accuracy."
 msgstr ""
 "DuckAssist "
+""
 "เป็นคุณลักษณะใหม่ในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"ในการดำเนินการนี้ ระบบจะสแกน Wikipedia "
+"และเว็บไซต์ที่เกี่ยวข้องเพื่อหาเนื้อหาที่เกี่ยวข้อง "
 "จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ขับเคลื่อนด้วย AI เพื่อสร้างข้อมูลสรุป "
 "โปรดทราบว่าขณะนี้คำตอบนั้นอิงจาก Wikipedia และเนื้อหาที่เกี่ยวข้อง "
 "และไม่ได้มีการตรวจสอบความถูกต้อง"
@@ -7187,11 +7256,16 @@ msgid ""
 "sources and based on %scrawling the web%s."
 msgstr ""
 "DuckAssist "
+""
 "เป็นฟีเจอร์เสริมในผลการค้นหาของเราที่สามารถสร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อได้ "
-"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ "
-"AI เพื่อสร้างคำตอบสั้นๆ ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
-"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ โดยอ้างอิงแหล่งที่มาของคำตอบ "
+"ในการดำเนินการนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง "
+"จากนั้นใช้เทคโนโลยีภาษาธรรมชาติที่ใช้ AI เพื่อสร้างคำตอบสั้นๆ "
+"ตามข้อมูลที่เกี่ยวข้องที่พบ คำตอบของ DuckAssist "
+"จะเชื่อมโยงโดยตรงกับแหล่งข้อมูลหนึ่งหรือสองแหล่งเสมอ "
+"โดยอ้างอิงแหล่งที่มาของคำตอบ "
+""
 "เพื่อให้คุณสามารถไปยังแหล่งข้อมูลเพื่อดูข้อมูลโดยละเอียดเพิ่มเติมได้อย่างง่ายดาย "
+""
 "สิ่งสำคัญคือต้องจำไว้ว่าคำตอบนั้นถูกสร้างขึ้นโดยอัตโนมัติจากแหล่งข้อมูลที่ใช้อ้างอิง "
 "และขึ้นอยู่กับ%1$sการรวบรวมข้อมูลเว็บ%2$s"
 
@@ -7201,7 +7275,8 @@ msgid ""
 "DuckAssist responses are auto-generated based on listed sources and not "
 "checked for accuracy."
 msgstr ""
-"คำตอบ DuckAssist สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
+"คำตอบ DuckAssist "
+"สร้างขึ้นโดยอัตโนมัติตามแหล่งที่มาที่ระบุไว้และไม่ได้ตรวจสอบความถูกต้อง"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -7209,7 +7284,9 @@ msgctxt "Error message for service limit"
 msgid ""
 "DuckDuckGo AI Chat has reached the maximum number of messages for one day. "
 "Please continue this chat tomorrow."
-msgstr "DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว โปรดแชทต่อในวันพรุ่งนี้"
+msgstr ""
+"DuckDuckGo AI Chat ถึงจำนวนข้อความสูงสุดในหนึ่งวันแล้ว "
+"โปรดแชทต่อในวันพรุ่งนี้"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the AI chat service and supported AI models. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7218,8 +7295,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7228,8 +7305,8 @@ msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
 msgstr ""
-"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI ซึ่งปัจจุบันรองรับโมเดลการแชท "
-"%2$s ของ %1$s และ %4$s ของ %3$s"
+"DuckDuckGo AI Chat เป็นบริการแชทส่วนตัวที่ขับเคลื่อนด้วย AI "
+"ซึ่งปัจจุบันรองรับโมเดลการแชท %2$s ของ %1$s และ %4$s ของ %3$s"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7246,8 +7323,8 @@ msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
 msgstr ""
-"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ "
-"%1$s ไปที่ %2$s"
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว หากยังคงอยู่ "
+"โปรดส่งอีเมลรหัสที่ไม่ระบุชื่อนี้ %1$s ไปที่ %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7255,7 +7332,9 @@ msgctxt "Error message for VQD error"
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. Please refresh the page and "
 "try again."
-msgstr "DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
+msgstr ""
+"DuckDuckGo AI Chat ไม่สามารถใช้งานได้ชั่วคราว "
+"โปรดรีเฟรชหน้านี้แล้วลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Displayed when the AI chat service is temporarily unavailable.
@@ -7411,8 +7490,8 @@ msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
 msgstr ""
-"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น ชื่อ ที่อยู่อีเมล "
-"หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
+"DuckDuckGo ทำให้รายงานเหล่านี้ไม่ระบุตัวตนโดยการลบ PII โดยอัตโนมัติ เช่น "
+"ชื่อ ที่อยู่อีเมล หมายเลขโทรศัพท์ และเมตาดาต้าที่ระบุตัวตน"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
@@ -7420,7 +7499,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s ของ Duck.ai"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' คุณยอมรับ %2$s "
+"ของ Duck.ai"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7429,7 +7509,8 @@ msgctxt ""
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
 msgstr ""
-"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ %2$s ของเรา"
+"DuckDuckGo ทําให้แชทของคุณไม่เปิดเผยตัวตน เมื่อคลิก '%1$s' แสดงว่าคุณยอมรับ "
+"%2$s ของเรา"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7438,8 +7519,9 @@ msgid ""
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
 msgstr ""
-"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google "
-"และ Facebook ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
+"DuckDuckGo จะบล็อกตัวติดตามบนเว็บไซต์ที่คุณเยี่ยมชม "
+"รวมถึงตัวติดตามจากบริษัทต่างๆ เช่น Google และ Facebook "
+"ซึ่งมักจะพยายามติดตามคุณบนเว็บไซต์อื่นๆ"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7451,9 +7533,11 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
+"DuckDuckGo ให้ความสำคัญกับความเป็นส่วนตัวตั้งแต่ขั้นตอนการออกแบบ "
+"เมื่อคุณเปิดใช้งานตำแหน่งที่ตั้ง "
 "ข้อมูลดังกล่าวจะได้รับการจัดเก็บไว้บนอุปกรณ์ของคุณเท่านั้น เมื่อคุณค้นหา "
-"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
+"อุปกรณ์ของคุณจึงจะส่งข้อมูลตำแหน่งที่ตั้งมาให้เรา "
+"ซึ่งเราจะใช้เพื่อปรับปรุงผลการค้นหาดังกล่าว "
 "จากนั้นเราจะทิ้งข้อมูลดังกล่าวในทันทีเพื่อให้ไม่มีการระบุตัวตนของคุณได้ "
 "%1$sดูข้อมูลเพิ่มเติมเกี่ยวกับวิธีที่เราออกแบบเทคโนโลยีนี้เพื่อปกป้องความเป็นส่วนตัวของคุณ%2$s"
 
@@ -7475,8 +7559,9 @@ msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
 msgstr ""
-"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น "
-"และใกล้คุณมากขึ้น %1$sดูข้อมูลเพิ่มเติม%2$s"
+"DuckDuckGo ใช้เฉพาะตำแหน่งที่ตั้งโดยประมาณของคุณ "
+"ซึ่งเราต้องการเพียงเพื่อให้ได้ผลลัพธ์ที่ดีขึ้น และใกล้คุณมากขึ้น "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7568,8 +7653,9 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo "
-"จากนั้นเราจะสุ่มคำ 4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
+"ทุกครั้งที่คุณขอให้แนะนำรหัสผ่าน "
+"เราจะได้รับรายการคำสุ่มหลายคำจากเซิร์ฟเวอร์ของ DuckDuckGo จากนั้นเราจะสุ่มคำ "
+"4 - 5 คำจากรายการดังกล่าวในเบราว์เซอร์ "
 "เพื่อให้มั่นใจว่ารหัสผ่านมีความยาวอักขระอย่างน้อย 18-20 ตัว"
 
 # smartling.placeholder_format=C
@@ -7783,7 +7869,9 @@ msgstr "เปิดใช้งานการค้นหาเว็บ"
 msgid ""
 "Enable anonymous location for more accurate results. You can always change "
 "your mind later."
-msgstr "เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น คุณสามารถเปลี่ยนใจได้ในภายหลัง"
+msgstr ""
+"เปิดใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนเพื่อผลลัพธ์ที่แม่นยำยิ่งขึ้น "
+"คุณสามารถเปลี่ยนใจได้ในภายหลัง"
 
 # smartling.placeholder_format=C
 #. Title of the dictation privacy consent modal shown on first use.
@@ -8003,7 +8091,8 @@ msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
 msgstr ""
-"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
+"ป้อนรหัสผ่านใหม่แล้วคลิก/แตะ%1$sบันทึกการตั้งค่า%2$s "
+"การดำเนินการนี้จะบันทึกข้อมูลในรหัสผ่านใหม่"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -8029,7 +8118,8 @@ msgstr "ป้อนข้อความ"
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
 msgstr ""
-"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s นามแฝง%6$s: d%7$s"
+"ป้อนรายละเอียดต่อไปนี้: %1$sชื่อ%2$s: DuckDuckGo%3$s URL%4$s: %5$s "
+"นามแฝง%6$s: d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8372,7 +8462,7 @@ msgstr "เร็ว"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "การสร้างภาพรวดเร็ว"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8435,7 +8525,9 @@ msgstr ""
 msgid ""
 "Feel free to adjust the settings below. Then, just copy and paste the code "
 "into your website."
-msgstr "โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
+msgstr ""
+"โปรดปรับเปลี่ยนการตั้งค่าด้านล่าง "
+"จากนั้นเพียงแค่คัดลอกและวางโค้ดลงในเว็บไซต์ของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Fiji"
@@ -8529,7 +8621,9 @@ msgstr "กรองภาพที่สร้างโดย AI จากผ�
 msgctxt "settings"
 msgid ""
 "Filters out known AI spam sites from image search results. %sLearn More%s"
-msgstr "กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ %1$sดูข้อมูลเพิ่มเติม%2$s"
+msgstr ""
+"กรองเว็บไซต์สแปม AI ที่รู้จักออกจากผลลัพธ์การค้นหารูปภาพ "
+"%1$sดูข้อมูลเพิ่มเติม%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the final score of a sporting event.
@@ -8695,7 +8789,7 @@ msgstr "ข้อความเพิ่มเติมยังคงเป็
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "ทำตามคำแนะนำ"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8813,7 +8907,7 @@ msgstr "แก้ไข แชร์ และใช้ได้อย่าง�
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์"
+msgstr "แก้ไข แชร์ และใช้ในเชิงพาณิชย์ ได้อย่างอิสระ"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -8913,7 +9007,8 @@ msgid ""
 "strong>."
 msgstr ""
 "จากแถบเมนูแอปบน Mac ให้เลือก <strong>DuckDuckGo</strong> &gt; "
-"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก <strong>ติดตั้งการอัปเดต</strong>"
+"<strong>ตรวจสอบการอัปเดต...</strong> จากนั้นเลือก "
+"<strong>ติดตั้งการอัปเดต</strong>"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9199,8 +9294,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity Theft "
-"Restoration"
+"รับ DuckDuckGo VPN, Duck.ai ขั้นสูง, บริการลบข้อมูลส่วนบุคคล และ Identity "
+"Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9271,7 +9366,9 @@ msgstr "เริ่ม"
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the Privacy Pro subscription.
 msgctxt "SERP footer content"
 msgid "Get a VPN + two more protections in one easy subscription."
-msgstr "รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ เพียงครั้งเดียว"
+msgstr ""
+"รับ VPN + การป้องกันเพิ่มเติมอีกสองรายการในการสมัครสมาชิกง่ายๆ "
+"เพียงครั้งเดียว"
 
 # smartling.placeholder_format=C
 #. Promotional message explaining that a VPN and two additional privacy protections are included in the DuckDuckGo subscription, for which a free trial is available.
@@ -9292,8 +9389,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), บริการ Personal "
-"Info Removal และ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน, แชท AI ขั้นสูง (ทางเลือก), "
+"บริการ Personal Info Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9302,8 +9399,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
 msgstr ""
-"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI ขั้นสูงที่เป็นตัวเลือกเสริม "
-"และบริการ Identity Theft Restoration"
+"รับ VPN ที่รวดเร็วและไม่บันทึกข้อมูลการใช้งาน (no-log), แชท AI "
+"ขั้นสูงที่เป็นตัวเลือกเสริม และบริการ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9312,8 +9409,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ได้โดยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9324,8 +9421,8 @@ msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
 msgstr ""
-"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo ซึ่งยังรวมถึง VPN "
-"และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
+"เข้าถึงโมเดล AI ขั้นสูงใน Duck.ai ด้วยการสมัครสมาชิก DuckDuckGo "
+"ซึ่งยังรวมถึง VPN และการปกป้องความเป็นส่วนตัวระดับพรีเมียมอื่นๆ ของเรา"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9369,8 +9466,9 @@ msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
 msgstr ""
-"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล AI "
-"ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย"
+"รับ VPN ที่รวดเร็ว ไม่เก็บบันทึกการใช้งานของเรา, ตัวเลือกในการเข้าถึงโมเดล "
+"AI ขั้นสูงพร้อมขีดจำกัดการแชทที่สูงขึ้น และการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9379,8 +9477,8 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal Information Removal "
-"และ Identity Theft Restoration"
+"รับ VPN ที่ปลอดภัยและไม่เก็บบันทึกของเรา, Duck.ai ขั้นสูง, Personal "
+"Information Removal และ Identity Theft Restoration"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9388,8 +9486,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
 msgstr ""
-"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft Restoration "
-"ของเรา"
+"รับ VPN แบบไม่บันทึกกิจกรรมที่ปลอดภัย, Duck.ai ขั้นสูง และ Identity Theft "
+"Restoration ของเรา"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9489,8 +9587,9 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device › Copy Text Code%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device › Copy Text "
+"Code%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9499,8 +9598,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9510,8 +9609,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9521,9 +9621,9 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo แล้วไปที่ "
-"%3$sChats › Sync & Backup › Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ %1$sDuck.ai Settings%2$s ในเบราว์เซอร์อื่นของคุณ หรือแอป DuckDuckGo "
+"แล้วไปที่ %3$sChats › Sync & Backup › Sync With Another Device%4$s "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9532,8 +9632,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
 msgstr ""
-"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With Another "
-"Device%4$s."
+"ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync With "
+"Another Device%4$s."
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9549,7 +9649,8 @@ msgid ""
 "“Location Services” is turned on."
 msgstr ""
 "ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
-"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" เปิดอยู่"
+"บริการหาตําแหน่งที่ตั้ง%2$sและตรวจสอบให้แน่ใจว่า \"บริการหาตําแหน่งที่ตั้ง\" "
+"เปิดอยู่"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9558,8 +9659,8 @@ msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
 msgstr ""
-"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการหาตําแหน่งที่ตั้ง%2$s "
-"แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
+"ไปที่ %1$sการตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > "
+"บริการหาตําแหน่งที่ตั้ง%2$s แล้วเลื่อนลงไปที่ %3$sDuckDuckGo%4$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9631,7 +9732,7 @@ msgstr "นโยบายความเป็นส่วนตัวที่
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "สไตล์ภาพที่ดี"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10253,7 +10354,9 @@ msgctxt "settings"
 msgid ""
 "Highlights key facts in Search Assist answers to help you find important "
 "information faster."
-msgstr "เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
+msgstr ""
+"เน้นข้อเท็จจริงสำคัญในคำตอบของ Search Assist "
+"เพื่อช่วยให้คุณค้นหาข้อมูลสำคัญได้เร็วขึ้น"
 
 # smartling.placeholder_format=C
 #. The name of the Hindi language
@@ -10346,7 +10449,8 @@ msgid ""
 "Hotel ad clicks are managed by Tripadvisor’s ad network and are not used to "
 "profile you."
 msgstr ""
-"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
+"การคลิกโฆษณาจัดการโดยเครือข่ายโฆษณาของ Tripadvisor "
+"และไม่ได้ใช้ในการสร้างโปรไฟล์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Refers to hours of operation for a business.
@@ -10494,6 +10598,7 @@ msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
 msgstr ""
+""
 "ฉันจะบอกเพื่อนร่วมงานอย่างมีไหวพริบเกี่ยวกับการเคาะดินสออย่างต่อเนื่องได้อย่างไร "
 "และฉันควรจะพูดว่าอะไร"
 
@@ -10616,7 +10721,9 @@ msgctxt "Full sentence for recommending a book"
 msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
-msgstr "ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ ที่คล้ายกันหรือไม่และเพราะเหตุใด"
+msgstr ""
+"ฉันชอบหนังสือชื่อ Name of the Wind มีหนังสือ/ซีรีส์ดีๆ "
+"ที่คล้ายกันหรือไม่และเพราะเหตุใด"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
@@ -10651,8 +10758,8 @@ msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > ทั่วไป > รีเซ็ต > "
-"\"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน ให้ไปที่%1$sการตั้งค่า > "
+"ทั่วไป > รีเซ็ต > \"รีเซ็ตตำแหน่งที่ตั้งและความเป็นส่วนตัว\"%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10662,9 +10769,9 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ ให้ไปที่ %1$s⋮ > เมนู > "
-"การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s และตรวจสอบว่า DuckDuckGo "
-"ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
+"หากตำแหน่งที่ตั้งของเบราว์เซอร์ยังไม่พร้อมใช้งาน จากเบราว์เซอร์ของคุณ "
+"ให้ไปที่ %1$s⋮ > เมนู > การตั้งค่า > การตั้งค่าเว็บไซต์ > ตำแหน่งที่ตั้ง%2$s "
+"และตรวจสอบว่า DuckDuckGo ได้รับอนุญาตให้เข้าถึงตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10699,7 +10806,8 @@ msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
 msgstr ""
-"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
+"หากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"คุณจะต้องใช้รหัสนี้เพื่อกู้คืนแชทที่บันทึกไว้ "
 "คุณสามารถบันทึกโค้ดนี้ลงในอุปกรณ์ของคุณเป็นไฟล์ข้อความได้"
 
 # smartling.placeholder_format=C
@@ -10716,7 +10824,8 @@ msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
 msgstr ""
-"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ %2$s ของเรา"
+"หากคุณต้องการใช้ DuckDuckGo แบบไม่มี JavaScript โปรดใช้เวอร์ชัน %1$s หรือ "
+"%2$s ของเรา"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10724,7 +10833,8 @@ msgstr ""
 msgid ""
 "If you want, select Home Page next to New windows and New tabs (open with)."
 msgstr ""
-"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" (เปิดด้วย)"
+"หากคุณต้องการ ให้เลือก \"หน้าแรก\" ถัดจาก \"หน้าต่างใหม่\" และ \"แท็บใหม่\" "
+"(เปิดด้วย)"
 
 # smartling.placeholder_format=C
 #. Text of menu item in attach dropdown that adds an image to the AI chat message being composed.
@@ -10767,7 +10877,7 @@ msgstr "ข้อความแจ้งภาพต้องสอดคล้
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "คุณภาพของภาพ"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10872,6 +10982,7 @@ msgid ""
 "server to prevent search leakage. %sLearn more%s."
 msgstr ""
 "ในเบราว์เซอร์เก่ากว่าบางรายการ "
+""
 "เราจำเป็นต้องเปลี่ยนเส้นทางการคลิกของคุณผ่านเซิร์ฟเวอร์ของเราเพื่อป้องกันการรั่วไหลของข้อมูลการค้นหา "
 "%1$sดูข้อมูลเพิ่มเติม%2$s"
 
@@ -11307,9 +11418,11 @@ msgid ""
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
 "รายการต่างๆ "
+""
 "ได้รับการจัดลำดับตามความเกี่ยวข้องกับข้อความค้นหาของคุณและจัดส่งผ่านเครือข่ายโฆษณาของ "
-"Microsoft การคลิกนำไปสู่หน้า Landing Page ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา "
-"DuckDuckGo ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
+"Microsoft การคลิกนำไปสู่หน้า Landing Page "
+"ของผู้ค้าโดยตรงและไม่เหมือนกับโฆษณา DuckDuckGo "
+"ไม่ได้รับการชดเชยสำหรับผลลัพธ์เหล่านี้"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11318,7 +11431,8 @@ msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
 msgstr ""
-"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว และมีความปลอดภัยมากกว่า"
+"การจดจำคำ 4 - 5 คำจะง่ายกว่าการจำตัวอักษรและตัวเลขแบบสุ่ม 10 ตัว "
+"และมีความปลอดภัยมากกว่า"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -11391,7 +11505,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Keep all your apps and online activity private on up to 5 devices at once."
 msgstr ""
-"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 เครื่องพร้อมกัน"
+"รักษาความเป็นส่วนตัวของแอปและกิจกรรมออนไลน์ทั้งหมดของคุณบนอุปกรณ์สูงสุด 5 "
+"เครื่องพร้อมกัน"
 
 # smartling.placeholder_format=C
 #. An instruction to state that a list of companies/trackers will be updated with continued use
@@ -13367,9 +13482,11 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
-"การปิดประวัติการแชทจะลบแชทที่ปักหมุด และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต "
+"การปิดประวัติการแชทจะลบแชทที่ปักหมุด "
+"และปิดใช้งานการเก็บคำแนะนำและการตอบสนองใหม่ชั่วคราว"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14204,8 +14321,8 @@ msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
 msgstr ""
-"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows %3$sให้คลิกไอคอน %4$s "
-"> การตั้งค่า%5$s"
+"สำหรับ Mac %1$sให้คลิก Maxthon > ค่ากำหนด%2$s สำหรับ Windows "
+"%3$sให้คลิกไอคอน %4$s > การตั้งค่า%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14214,8 +14331,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14224,8 +14341,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s แล้วสแกนรหัสนี้:"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s แล้วสแกนรหัสนี้:"
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14234,8 +14351,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup › Sync "
-"With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ในอุปกรณ์อื่น ให้ไปที่ %1$sDuck.ai Settings%2$s › %3$sChats › Sync & Backup "
+"› Sync With Another Device%4$s หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14263,7 +14380,8 @@ msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
 msgstr ""
-"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
+"ไฟล์ที่แนบมาไฟล์ใดไฟล์หนึ่งมีหน้าเว็บมากกว่าที่เรารองรับ "
+"โปรดอัปโหลดไฟล์ที่มี %1$s หน้าหรือน้อยกว่า"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14289,7 +14407,9 @@ msgctxt "cloudsave"
 msgid ""
 "Only the settings that you have changed. They are detailed on the %sURL "
 "Parameters%s page."
-msgstr "เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
+msgstr ""
+"เฉพาะการตั้งค่าที่คุณเปลี่ยนแปลงเท่านั้น "
+"มีรายละเอียดอยู่ในหน้า%1$sพารามิเตอร์ URL%2$s"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers only when the user clicks the Assist button.
@@ -14634,7 +14754,8 @@ msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
 msgstr ""
-"เครื่องมือค้นหาอื่นๆ จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
+"เครื่องมือค้นหาอื่นๆ "
+"จะติดตามการค้นหาของคุณแม้ว่าคุณจะอยู่ในโหมดการท่องเว็บแบบส่วนตัว "
 "แต่เราไม่ติดตามคุณอย่างแน่นอน"
 
 # smartling.placeholder_format=C
@@ -14650,8 +14771,8 @@ msgid ""
 "more premium protections. All in one subscription."
 msgstr ""
 "VPN แบบไม่บันทึกกิจกรรมที่รวดเร็วของเรามาพร้อมกับการแชท AI "
-"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ อีกมากมาย "
-"การสมัครสมาชิกแบบครบวงจรในที่เดียว"
+"ที่ชาญฉลาดยิ่งขึ้นพร้อมขีดจำกัดที่สูงขึ้น รวมถึงการป้องกันระดับพรีเมียมอื่นๆ "
+"อีกมากมาย การสมัครสมาชิกแบบครบวงจรในที่เดียว"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14659,7 +14780,8 @@ msgid ""
 "Our privacy policy is simple: we don’t collect or share any of your personal "
 "information."
 msgstr ""
-"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
+"นโยบายความเป็นส่วนตัวของเราเป็นเรื่องง่าย: "
+"เราไม่ได้เก็บรวบรวมหรือแชร์ข้อมูลส่วนบุคคลของคุณ"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -14667,8 +14789,9 @@ msgid ""
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
 msgstr ""
-"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา เครื่องมือบล็อกตัวติดตาม "
-"เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย พร้อมใช้งานบน %1$siOS และ Android%2$s"
+"เบราว์เซอร์ส่วนตัวสำหรับอุปกรณ์มือถือของเรานั้นมาพร้อมกับเครื่องมือค้นหา "
+"เครื่องมือบล็อกตัวติดตาม เครื่องมือบังคับใช้การเข้ารหัส และอื่นๆ อีกมากมาย "
+"พร้อมใช้งานบน %1$siOS และ Android%2$s"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14921,8 +15044,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, ลายนิ้วมือจากเบราว์เซอร์ "
-"หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
+"ไม่สามารถกู้คืนรหัสผ่านได้เนื่องจากเราไม่ได้เชื่อมโยงที่อยู่ IP, "
+"ลายนิ้วมือจากเบราว์เซอร์ หรือข้อมูลอื่นใดเกี่ยวกับไฟล์"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15078,7 +15201,8 @@ msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
 msgstr ""
-"Personal Information Removal ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
+"Personal Information Removal "
+"ค้นหาข้อมูลของคุณบนเว็บไซต์นายหน้าข้อมูลที่ขายข้อมูลนั้น "
 "จากนั้นเราดำเนินการเพื่อให้ข้อมูลนั้นถูกลบออกแทนคุณ"
 
 # smartling.placeholder_format=C
@@ -15150,9 +15274,10 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
+""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้คำตอบที่ได้รับความช่วยเหลือจาก "
-"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
+"AI มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist ให้ไปที่ %1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15162,8 +15287,9 @@ msgid ""
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด "
-"ให้ไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นและมักจะให้คำตอบที่ดีกว่า "
+"หากต้องการปรับวิธีการทํางานของคุณลักษณะนี้หรือปิด ให้ไปที่%1$sการตั้งค่า "
+"DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15174,8 +15300,8 @@ msgid ""
 "Settings%s."
 msgstr ""
 "การเรียงถ้อยคำในการค้นหาให้เป็นคำถามและเป็นประโยคสมบูรณ์ทำให้ DuckAssist "
-"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า หากต้องการปิดและซ่อนปุ่ม Assist "
-"โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
+"มีแนวโน้มที่จะปรากฏขึ้นโดยอัตโนมัติและมักจะให้คำตอบได้ดีกว่า "
+"หากต้องการปิดและซ่อนปุ่ม Assist โปรดไปที่%1$sการตั้งค่า DuckAssist%2$s"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15223,7 +15349,9 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ DuckDuckGo"
+msgstr ""
+"เลือกบริการเพื่อนำทางไปยังจุดหมายของคุณ แอปภายนอกจะไม่มีการป้องกันของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15597,7 +15725,7 @@ msgstr "การจัดรูปแบบที่ไม่ดี"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "คุณภาพของภาพไม่ดี"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16160,7 +16288,9 @@ msgctxt "Full sentence for critiquing writing"
 msgid ""
 "Provide a few suggestions to make the following text more concise. [Insert "
 "your own text here.]"
-msgstr "ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น [แทรกข้อความของคุณเองที่นี่]"
+msgstr ""
+"ให้คำแนะนำสองสามข้อเพื่อให้ข้อความต่อไปนี้กระชับมากขึ้น "
+"[แทรกข้อความของคุณเองที่นี่]"
 
 # smartling.placeholder_format=C
 #. In the context of a standings table for NHL (hockey), column title that abbreviates 'Total Points' (the total points of this team)
@@ -16467,8 +16597,9 @@ msgid ""
 "sent, to help recover a chat if you lose your internet connection."
 msgstr ""
 "การแชทล่าสุดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ "
-"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ DuckDuckGo "
-"หลังจากที่ส่งไปแล้ว เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
+"คำแนะนำใหม่และการตอบกลับจะถูกเข้ารหัสและเก็บไว้ชั่วคราวบนเซิร์ฟเวอร์ของ "
+"DuckDuckGo หลังจากที่ส่งไปแล้ว "
+"เพื่อช่วยกู้คืนการแชทหากคุณสูญเสียการเชื่อมต่ออินเทอร์เน็ต"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16750,8 +16881,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ &quot;"
-"รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
+"รีโหลด DuckDuckGo โดยทำตามคำแนะนำ หรือคลิกปุ่ม &quot;รีเฟรช&quot; หรือ "
+"&quot;รีโหลด&quot; ของเบราว์เซอร์ของคุณ"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16859,7 +16990,8 @@ msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"ถาม\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"ถาม\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16868,7 +17000,8 @@ msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
 msgstr ""
-"นำปุ่ม \"สร้าง\" ออก เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
+"นำปุ่ม \"สร้าง\" ออก "
+"เพื่อให้คำตอบปรากฏขึ้นโดยอัตโนมัติตามการค้นหาที่เกี่ยวข้อง "
 "คำตอบที่เก็บไว้จะแสดงโดยอัตโนมัติเสมอ"
 
 # smartling.placeholder_format=C
@@ -16933,8 +17066,9 @@ msgid ""
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
 msgstr ""
-"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo เพื่อช่วยปรับปรุงบริการค้นหาของเรา "
-"ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ %1$s เพื่อช่วยปรับปรุงบริการ"
+"การรายงานจะไม่ระบุชื่อและส่งไปยัง DuckDuckGo "
+"เพื่อช่วยปรับปรุงบริการค้นหาของเรา ข้อเสนอแนะที่ไม่ระบุตัวตนของคุณจะแชร์กับ "
+"%1$s เพื่อช่วยปรับปรุงบริการ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16942,8 +17076,8 @@ msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ "
-"ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo จะไม่ระบุชื่อ "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใดๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16952,8 +17086,9 @@ msgid ""
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
 msgstr ""
-"รายงานที่ส่งไปยัง DuckDuckGo รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ "
-"และจะไม่ระบุตัวตน โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
+"รายงานที่ส่งไปยัง DuckDuckGo "
+"รวมข้อความทั้งหมดที่คุณขอให้เราแปลในระหว่างการโหลดหน้านี้ และจะไม่ระบุตัวตน "
+"โปรดอย่าใส่ข้อมูลส่วนตัวหรือข้อมูลระบุตัวตนใด ๆ ลงในข้อเสนอแนะของคุณ"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -17045,8 +17180,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ คำตอบที่ได้รับความช่วยเหลือจาก AI อยู่ภายใต้ "
 "%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -17056,8 +17192,9 @@ msgid ""
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่นๆ DuckAssist "
 "อยู่ภายใต้%1$sข้อกำหนดในการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
@@ -17068,10 +17205,11 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย "
-"การเงิน การลงทุน หรือคำแนะนำทางวิชาชีพอื่น ๆ "
-"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search Assist อยู่ภายใต้ "
-"%1$sข้อกำหนดการให้บริการ%2$sของเรา"
+"คำตอบเหล่านี้มีวัตถุประสงค์เพื่อการศึกษาเท่านั้น "
+"และไม่มีเจตนาให้เป็นคำแนะนำทางการแพทย์ กฎหมาย การเงิน การลงทุน "
+"หรือคำแนะนำทางวิชาชีพอื่น ๆ "
+"ข้อมูลเหล่านี้ถูกสร้างขึ้นจากเนื้อหาบนเว็บและอาจมีความไม่ถูกต้อง Search "
+"Assist อยู่ภายใต้ %1$sข้อกำหนดการให้บริการ%2$sของเรา"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17670,7 +17808,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ%5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s "
+"(หรือ%5$sเพิ่มใหม่%6$s)"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17679,7 +17818,8 @@ msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
 msgstr ""
-"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ %5$sเพิ่มใหม่%6$s)"
+"เลื่อนลงและมองหา%1$sค้นหาในแถบที่อยู่%2$s คลิกที่%3$sเปลี่ยนแปลง%4$s (หรือ "
+"%5$sเพิ่มใหม่%6$s)"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17766,10 +17906,11 @@ msgid ""
 "subset of English speaking regions."
 msgstr ""
 "Search Assist สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการดำเนินการนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ (เฉพาะเมื่อคลิก "
-"Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง (ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ "
-"Search Assist มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
+"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น "
+"ๆ คุณสามารถเลือกได้ว่าต้องการให้มันปรากฏบ่อยแค่ไหน: ไม่เคย, ตามต้องการ "
+"(เฉพาะเมื่อคลิก Assist), บางครั้ง (เมื่อมีความเกี่ยวข้องสูง) หรือบ่อยครั้ง "
+"(ในการค้นหาที่หลากหลาย) สำหรับตอนนี้ Search Assist "
+"มีให้บริการเฉพาะในบางภูมิภาคที่ใช้ภาษาอังกฤษเท่านั้น"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17777,7 +17918,8 @@ msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
 msgstr ""
-"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ ลองค้นหาอีกครั้ง"
+"Search Assist ไม่พบข้อมูลที่เชื่อถือได้เพียงพอเพื่อสร้างคำตอบสำหรับคำถามนี้ "
+"ลองค้นหาอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17786,9 +17928,9 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ ในการทำเช่นนี้ "
-"ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ AI เพื่อสร้างคำตอบสั้น ๆ "
-"ตามข้อมูลที่พบ"
+"Search Assist เป็นฟีเจอร์เสริมที่สร้างคำตอบสำหรับคำค้นหาโดยไม่ระบุชื่อ "
+"ในการทำเช่นนี้ ระบบจะสแกนเว็บเพื่อหาเนื้อหาที่เกี่ยวข้อง %1$s%2$s จากนั้นใช้ "
+"AI เพื่อสร้างคำตอบสั้น ๆ ตามข้อมูลที่พบ"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17909,8 +18051,8 @@ msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
 msgstr ""
-"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" โดยตรงบน "
-"Wikipedia"
+"ค้นหาเว็บไซต์อื่นด้วยทางลัด %1$s: การค้นหา \"!w ducks\" จะค้นหา \"ducks\" "
+"โดยตรงบน Wikipedia"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17930,8 +18072,8 @@ msgid ""
 "favorite browser, or search directly at %sduckduckgo.com%s."
 msgstr ""
 "ค้นหาอย่างเป็นส่วนตัวด้วยแอปหรือส่วนขยายของเรา "
-"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ %1$sduckduckgo."
-"com%2$s"
+"เพิ่มการค้นหาเว็บแบบส่วนตัวลงในเบราว์เซอร์โปรดของคุณ หรือค้นหาโดยตรงที่ "
+"%1$sduckduckgo.com%2$s"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17950,8 +18092,10 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
+""
 "การตั้งค่าการค้นหาจะถูกเก็บไว้ในคุกกี้เบราว์เซอร์ที่ไม่ใช่ส่วนบุคคลและที่เก็บข้อมูลภายในในเบราว์เซอร์ของคุณ "
 "แต่คุณยังสามารถใช้ Cloud Save "
+""
 "เพื่อจัดเก็บการตั้งค่าของคุณโดยไม่ระบุตัวตนบนเซิร์ฟเวอร์ระยะไกลในคลาวด์ได้อีกด้วย "
 "จะไม่มีการจัดเก็บข้อมูลที่สามารถระบุถึงตัวบุคคลได้บนระบบคลาวด์ "
 "และวลีรหัสผ่านของคุณจะอยู่บนเบราว์เซอร์ของคุณเท่านั้น"
@@ -18073,6 +18217,7 @@ msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
 msgstr ""
+""
 "จัดเก็บแชทได้เกือบไม่จำกัดบนเซิร์ฟเวอร์ของเราอย่างปลอดภัยด้วยการเข้ารหัสแบบครบวงจร "
 "และเข้าถึงได้จากอุปกรณ์ที่ซิงค์ทั้งหมดของคุณ"
 
@@ -18251,7 +18396,8 @@ msgstr "เลือก %1$s\"การตั้งค่าสำหรับ�
 msgid ""
 "Select %sCustom%s and enter %shttps://duckduckgo.com%s in the input field"
 msgstr ""
-"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s ลงในช่องการป้อนข้อมูล"
+"เลือก%1$sกำหนดเอง%2$s และป้อน %3$shttps://duckduckgo.com%4$s "
+"ลงในช่องการป้อนข้อมูล"
 
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
@@ -18316,7 +18462,8 @@ msgstr "เลือก%1$sจัดการส่วนเสริม%2$sจ�
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ%3$sเมนู > การตั้งค่า%4$s (บน "
+"Windows)"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
@@ -18324,7 +18471,8 @@ msgstr ""
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
 msgstr ""
-"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน Windows)"
+"เลือก %1$sOpera > ค่ากำหนด%2$s (บน Mac) หรือ %3$sOpera > ตัวเลือก%4$s (บน "
+"Windows)"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18388,7 +18536,9 @@ msgstr "เลือก%1$sการตั้งค่า%2$s จากนั้
 msgid ""
 "Select %sUse this webpage as your only home page%s (or one of the other "
 "options if you prefer)"
-msgstr "เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ ตามต้องการ)"
+msgstr ""
+"เลือก%1$sใช้หน้าเว็บนี้เป็นหน้าหลักเดียวของคุณ%2$s (หรือหนึ่งในตัวเลือกอื่นๆ "
+"ตามต้องการ)"
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
@@ -18510,7 +18660,8 @@ msgid ""
 "respond. These instructions will apply to all of your conversations going "
 "forward."
 msgstr ""
-"ส่งพรอมต์ไปยังโมเดล AI พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
+"ส่งพรอมต์ไปยังโมเดล AI "
+"พร้อมกับข้อความของคุณและคำแนะนำเกี่ยวกับวิธีการตอบกลับ "
 "คำแนะนำเหล่านี้จะใช้กับการสนทนาทั้งหมดของคุณต่อไป"
 
 # smartling.placeholder_format=C
@@ -18634,13 +18785,16 @@ msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
 msgstr ""
-"ตั้งค่า Sync & Backup หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
+"ตั้งค่า Sync & Backup "
+"หลังจากเปิดประวัติการแชทเพื่อให้การแชทของคุณซิงค์กันระหว่างอุปกรณ์ต่างๆ"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
 msgctxt "precise_user_location"
 msgid "Set your location manually, or ensure Location Services is enabled."
-msgstr "ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
+msgstr ""
+"ตั้งค่าตำแหน่งที่ตั้งของคุณด้วยตนเอง "
+"หรือตรวจสอบให้แน่ใจว่าได้เปิดใช้งานบริการตำแหน่งที่ตั้ง"
 
 # smartling.placeholder_format=C
 #. In the top dropdown menu  ("More" > "Settings")
@@ -19307,7 +19461,8 @@ msgctxt "settings"
 msgid ""
 "Shows occasional reminders to sign up for the DuckDuckGo privacy newsletters"
 msgstr ""
-"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ DuckDuckGo"
+"แสดงการแจ้งเตือนเป็นครั้งคราวให้สมัครรับจดหมายข่าวเกี่ยวกับความเป็นส่วนตัวของ "
+"DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19669,7 +19824,9 @@ msgctxt "noresults"
 msgid ""
 "Sorry, we ran into an error displaying these results. %sClick here%s to try "
 "again."
-msgstr "ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s เพื่อลองอีกครั้ง"
+msgstr ""
+"ขออภัย เราพบข้อผิดพลาดในการแสดงผลลัพธ์เหล่านี้ %1$sคลิกที่นี่%2$s "
+"เพื่อลองอีกครั้ง"
 
 # smartling.placeholder_format=C
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
@@ -20148,7 +20305,9 @@ msgctxt "Full sentence for composing a card"
 msgid ""
 "Suggest a phrase to write on a get-well card for someone recovering from a "
 "surgery?"
-msgstr "เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
+msgstr ""
+"เสนอแนะวลีที่จะเขียนลงในการ์ดอวยพรให้หายไว ๆ "
+"สำหรับผู้ที่ฟื้นตัวจากการผ่าตัดหรือไม่"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for asking for a suggestion of a blog post title.
@@ -20546,7 +20705,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup จะบันทึกการแชทของคุณมากขึ้นและซิงค์การแชทเหล่านั้นในทุกอุปกรณ์ของคุณ"
+msgstr ""
+"Sync & Backup "
+"จะบันทึกการแชทของคุณมากขึ้นและซิงค์การแชทเหล่านั้นในทุกอุปกรณ์ของคุณ"
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -20595,8 +20756,9 @@ msgid ""
 msgstr ""
 "รหัสกู้คืนการซิงค์\n"
 "\n"
-"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท Duck.ai "
-"ของคุณระหว่างอุปกรณ์หลายเครื่อง และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
+"รหัสกู้คืนช่วยให้คุณสามารถซิงค์รหัสผ่าน ข้อมูลการกรอกอัตโนมัติ และการแชท "
+"Duck.ai ของคุณระหว่างอุปกรณ์หลายเครื่อง "
+"และกู้คืนข้อมูลที่ซิงค์ไว้หากคุณสูญเสียการเข้าถึงอุปกรณ์\n"
 "\n"
 "เก็บรักษาข้อมูลนี้ให้ปลอดภัย\n"
 "ทุกคนที่มีสิทธิ์เข้าถึงรหัสนี้สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณ\n"
@@ -20606,9 +20768,11 @@ msgstr ""
 "วิธีการทำงานของโค้ดนี้คืออะไร?\n"
 "1. ไปที่ Duck.ai ในเบราว์เซอร์ของคุณ แล้วเปิดการตั้งค่า Duck.ai\n"
 "2. เลือก \"เปิดใช้งาน Sync & Backup\" จากนั้นเลือก \"Recover Synced Data\"\n"
-"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code here\"\n"
+"3. คัดลอกรหัสการกู้คืนด้านบนและวางลงในช่องที่ระบุว่า \"Paste your code "
+"here\"\n"
 "\n"
-"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
+"หากคุณไม่ได้ใช้เบราว์เซอร์ DuckDuckGo ที่มี Sync & Backup "
+"เปิดใช้งานเป็นเวลาเกิน 18 เดือน "
 "ข้อมูลของคุณจะถูกลบออกจากเซิร์ฟเวอร์และไม่สามารถกู้คืนได้"
 
 # smartling.placeholder_format=C
@@ -20748,7 +20912,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
 msgstr ""
-"พก Duck.ai ไปกับคุณได้ทุกที่ รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณได้ทุกที่ "
+"รับแบบรวมอยู่ในแอปฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20758,7 +20923,8 @@ msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
 msgstr ""
-"พก Duck.ai ไปกับคุณทุกที่ รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
+"พก Duck.ai ไปกับคุณทุกที่ "
+"รับแบบที่รวมอยู่ในเบราว์เซอร์ฟรีของเราเพื่อการเข้าถึงที่รวดเร็วยิ่งขึ้น "
 "ไม่ว่าคุณจะท่องเว็บอยู่ที่ไหน"
 
 # smartling.placeholder_format=C
@@ -20782,7 +20948,9 @@ msgstr "ควบคุมข้อมูลส่วนบุคคลของ
 msgctxt "Feedback section description on the Duck.ai settings page"
 msgid ""
 "Take this anonymous survey to let us know how we can make Duck.ai better."
-msgstr "ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai ดีขึ้นได้อย่างไรบ้าง"
+msgstr ""
+"ทำแบบสำรวจที่ไม่ระบุตัวตนนี้เพื่อบอกให้เรารู้ว่าเราจะทำให้ Duck.ai "
+"ดีขึ้นได้อย่างไรบ้าง"
 
 # smartling.placeholder_format=C
 #. Description text shown below the Reasoning option in the reasoning mode dropdown.
@@ -21003,6 +21171,7 @@ msgid ""
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
 msgstr ""
+""
 "นั่นหมายความว่าข้อมูลที่ส่งระหว่างอุปกรณ์ของคุณกับหน้าเว็บเบื้องหลังลิงก์นี้มีความเสี่ยงมากขึ้นต่อการถูกดักข้อมูลโดยบุคคลที่สาม "
 "ในบางกรณีซึ่งเกิดขึ้นไม่บ่อย ข้อมูลนี้รวมถึงรหัสผ่านหรือรายละเอียดการชำระเงิน"
 
@@ -21023,8 +21192,8 @@ msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
 msgstr ""
-"ปุ่มสลับ Duck.ai ช่วยให้คุณสลับระหว่างการค้นหาแบบส่วนตัวและแชท AI ได้อย่างรวดเร็ว "
-"โดยไม่ระบุตัวตนด้วย DuckDuckGo"
+"ปุ่มสลับ Duck.ai ช่วยให้คุณสลับระหว่างการค้นหาแบบส่วนตัวและแชท AI "
+"ได้อย่างรวดเร็ว โดยไม่ระบุตัวตนด้วย DuckDuckGo"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21054,6 +21223,7 @@ msgid ""
 "The encryption key is only saved in your browser's local storage, and only "
 "you can access it."
 msgstr ""
+""
 "คีย์การเข้ารหัสจะถูกบันทึกไว้เฉพาะในที่เก็บข้อมูลในเครื่องของเบราว์เซอร์ของคุณ "
 "และมีเพียงคุณเท่านั้นที่สามารถเข้าถึงได้"
 
@@ -21076,7 +21246,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider does not save this chat or any associated data on their "
 "servers."
-msgstr "ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ บนเซิร์ฟเวอร์ของเขา"
+msgstr ""
+"ผู้ให้บริการโมเดลไม่บันทึกการแชทนี้หรือข้อมูลที่เกี่ยวข้องใดๆ "
+"บนเซิร์ฟเวอร์ของเขา"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -21169,6 +21341,7 @@ msgid ""
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
 msgstr ""
+""
 "สิทธิ์ของเบราว์เซอร์เหล่านี้ใช้เพื่อเพิ่มการปกป้องความเป็นส่วนตัวบนเว็บไซต์ที่คุณเยี่ยมชมโดยการบล็อกตัวติดตามที่ซ่อนอยู่ "
 "การเข้ารหัสการเชื่อมต่อเมื่อสามารถทำได้ และการตั้งค่าให้ DuckDuckGo "
 "เป็นเครื่องมือค้นหาเริ่มต้นของคุณ"
@@ -21216,7 +21389,9 @@ msgctxt "AI Chat: Error message for when a model is deprecated"
 msgid ""
 "This AI model version is no longer supported. Try starting a new chat with "
 "the latest version of this model."
-msgstr "เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
+msgstr ""
+"เวอร์ชันของโมเดล AI นี้ไม่ได้รับการสนับสนุนอีกต่อไป "
+"ลองเริ่มแชทใหม่ด้วยโมเดลรุ่นล่าสุด"
 
 # smartling.placeholder_format=C
 #. Appears below a type of search results called 'Instant Answers'
@@ -21287,8 +21462,9 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s แชท AI "
-"อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s สำหรับข้อมูลเพิ่มเติม)"
+"การสนทนานี้สร้างขึ้นด้วย DuckDuckGo AI Chat (%1$s) โดยใช้โมเดล %3$s ของ %2$s "
+"แชท AI อาจแสดงข้อมูลที่ไม่ถูกต้องหรือไม่เหมาะสม (ดู %4$s "
+"สำหรับข้อมูลเพิ่มเติม)"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21305,8 +21481,8 @@ msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
 msgstr ""
-"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท %1$s "
-"ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
+"อุปกรณ์นี้จะไม่สามารถเข้าถึงข้อมูลที่ซิงค์ของคุณบนอุปกรณ์อื่นได้อีกต่อไป แชท "
+"%1$s ครั้งสุดท้ายจะยังคงมีอยู่ในที่เก็บข้อมูลท้องถิ่น"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21412,8 +21588,8 @@ msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
 msgstr ""
-"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก ปักหมุด "
-"เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
+"นี่เป็นเพียงตัวอย่างแชทเท่านั้น เปิดเมนูของแชทนี้ (จุดสามจุด) จากนั้นเลือก "
+"ปักหมุด เพื่อให้อยู่ที่ด้านบนสุดของแชท!"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21442,8 +21618,8 @@ msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน ผู้ให้บริการโมเดลอื่นๆ "
-"เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
+"ผู้ให้บริการโมเดลจะลบข้อมูลที่เกี่ยวข้องกับแชทนี้ภายใน 30 วัน "
+"ผู้ให้บริการโมเดลอื่นๆ เป็นไปตามโมเดลการเก็บรักษาข้อมูลเป็นศูนย์"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21452,8 +21628,8 @@ msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
 msgstr ""
-"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ ผู้ให้บริการโมเดลอื่นๆ "
-"ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
+"ผู้ให้บริการโมเดลนี้ไม่ได้เก็บข้อมูลใดๆ ที่เกี่ยวข้องกับการแชทนี้ "
+"ผู้ให้บริการโมเดลอื่นๆ ใช้โมเดลการเก็บรักษาข้อมูลที่จํากัด"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21490,6 +21666,7 @@ msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
 msgstr ""
+""
 "การดำเนินการนี้จะบันทึกการแชทของคุณด้วยการเข้ารหัสแบบครบวงจรบนเซิร์ฟเวอร์ที่ปลอดภัยของ "
 "DuckDuckGo ซึ่งต่อมาสามารถเข้าถึงได้จากเบราว์เซอร์ใดก็ตาม"
 
@@ -21500,8 +21677,9 @@ msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21511,8 +21689,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน "
-"duckduckgo.com คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
+"การตั้งค่านี้ถูกเก็บไว้ในเบราว์เซอร์ของคุณ "
+"ซึ่งหมายความว่าถ้าคุณล้างข้อมูลเบราว์เซอร์บน duckduckgo.com "
+"คุณอาจเห็นคำตอบที่ได้รับความช่วยเหลือจาก AI อีกครั้ง อย่างไรก็ตาม "
 "เรามีหน้าเริ่มต้นที่ไม่แสดงคำตอบที่ได้รับความช่วยเหลือจาก AI ด้วยที่ %1$s"
 
 # smartling.placeholder_format=C
@@ -21564,8 +21743,9 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ Sync & Backup "
-"คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ ที่เชื่อมต่อกับ Sync & Backup"
+"การกระทำนี้จะลบการแชท Duck.ai ทั้งหมดจากเบราว์เซอร์นี้ และตัดการเชื่อมต่อ "
+"Sync & Backup คุณยังสามารถเข้าถึงการแชทของคุณในเบราว์เซอร์อื่นๆ "
+"ที่เชื่อมต่อกับ Sync & Backup"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21574,8 +21754,8 @@ msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
 msgstr ""
-"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ เว้นแต่ว่าจะมีการปักหมุดไว้ "
-"การกระทำนี้ย้อนกลับไม่ได้"
+"การดำเนินการนี้จะลบการแชททั้งหมดของคุณเมื่อเร็วๆ นี้ "
+"เว้นแต่ว่าจะมีการปักหมุดไว้ การกระทำนี้ย้อนกลับไม่ได้"
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21593,7 +21773,9 @@ msgstr "การตั้งค่าทั้งหมดของคุณจ
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น ดำเนินการต่อหรือไม่"
+msgstr ""
+"การดำเนินการนี้จะรีเซ็ตการตั้งค่าที่บันทึกไว้เป็นค่าเริ่มต้น "
+"ดำเนินการต่อหรือไม่"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21712,9 +21894,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"วิธีการพิมพ์เส้นทาง:"
-"%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
+msgstr "วิธีการพิมพ์เส้นทาง:%1$sกลับไปยังแผนที่%2$sเลือกเส้นทางที่ต้องการพิมพ์%3$sเลือกไอคอนเครื่องพิมพ์%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21724,7 +21904,8 @@ msgid ""
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
 msgstr ""
-"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
+"เพื่อกู้คืนข้อมูลที่ซิงค์ของคุณ "
+"คุณจำเป็นต้องมีรหัสกู้คืนที่คุณบันทึกไว้เมื่อคุณตั้งค่า Sync เป็นครั้งแรก "
 "รหัสนี้อาจถูกบันทึกเป็น PDF บนอุปกรณ์ที่คุณใช้ตั้งค่าการซิงค์ในตอนแรก"
 
 # smartling.placeholder_format=C
@@ -21836,7 +22017,7 @@ msgstr "ช้าเกินไป"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "สร้างช้าเกินไป"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21998,7 +22179,9 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาอังกฤษนี้เป็นภาษาฝรั่งเศส: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -22006,7 +22189,9 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: “ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
+msgstr ""
+"แปลประโยคภาษาไทยนี้เป็นภาษาอังกฤษ: "
+"“ฉันจะไปโรงภาพยนตร์ที่ใกล้ที่สุดได้อย่างไร?”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22278,7 +22463,7 @@ msgstr "ลองใช้คีย์เวิร์ดน้อยลง"
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "ลองใช้ฟรี"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22490,8 +22675,8 @@ msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม ติดตั้งส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22500,8 +22685,8 @@ msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
 msgstr ""
-"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา %1$sDuckDuckGo No "
-"AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
+"กำลังพยายามปิดใช้งานฟีเจอร์ AI อยู่ใช่ไหม เปลี่ยนไปใช้ส่วนขยายการค้นหา "
+"%1$sDuckDuckGo No AI%2$s เพื่อจดจำการตั้งค่าของคุณ %3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22833,7 +23018,8 @@ msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้คลิก%3$sเปิดหน้าที่เฉพาะเจาะจง%4$s "
+"จากนั้นคลิก%5$sตั้งค่าหน้า%6$s"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
@@ -22841,7 +23027,8 @@ msgstr ""
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
 msgstr ""
-"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: https://duckduckgo.com"
+"ภายใต้%1$sเมื่อเริ่มต้น%2$s ให้เลือก%3$sหน้าแรก%4$s และป้อน: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22957,8 +23144,8 @@ msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
 msgstr ""
-"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า "
-"โดยการอัปเกรดเป็น Pro"
+"ปลดล็อก %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus "
+"ถึง 2 เท่า โดยการอัปเกรดเป็น Pro"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23116,7 +23303,8 @@ msgid ""
 "Update the DuckDuckGo browser to activate your subscription in Duck.ai and "
 "access advanced models"
 msgstr ""
-"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai และเข้าถึงโมเดลขั้นสูง"
+"อัปเดตเบราว์เซอร์ DuckDuckGo เพื่อเปิดใช้งานการสมัครสมาชิกใน Duck.ai "
+"และเข้าถึงโมเดลขั้นสูง"
 
 # smartling.placeholder_format=C
 #. The placeholder indicates a formatted date (e.g., 'Updated 2 days ago')
@@ -23344,8 +23532,9 @@ msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
 msgstr ""
-"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ นักต้มตุ๋น "
-"และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย ไม่จำเป็นต้องมีบัญชี"
+"ใช้ ChatGPT, Claude และ AI อื่นๆ อย่างเป็นส่วนตัว ปกป้องแชทจากแฮกเกอร์ "
+"นักต้มตุ๋น และบริษัทต่าง ๆ เก็บข้อมูลให้เป็นความลับ ไม่มีค่าใช้จ่าย "
+"ไม่จำเป็นต้องมีบัญชี"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23399,7 +23588,9 @@ msgctxt "Description for the joiner-device success screen"
 msgid ""
 "Use this code to restore your data if you lose access to your devices. Keep "
 "it safe."
-msgstr "ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ เก็บรักษาไว้ให้ปลอดภัย"
+msgstr ""
+"ใช้รหัสนี้เพื่อกู้คืนข้อมูลของคุณหากคุณไม่สามารถเข้าถึงอุปกรณ์ของคุณได้ "
+"เก็บรักษาไว้ให้ปลอดภัย"
 
 # smartling.placeholder_format=C
 #. First sentence of the recovery section. The 18-month inactivity notice is rendered by the component using DUCKCHAT_SYNC_RECOVERY_INACTIVITY_NOTICE so both surfaces stay consistent.
@@ -23598,7 +23789,9 @@ msgstr "หมู่เกาะเวอร์จิน"
 msgctxt "duckassist"
 msgid ""
 "Visit %sAssist Settings%s to adjust how this feature works or turn it off."
-msgstr "ไปที่ %1$sการตั้งค่า Assist%2$s เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า Assist%2$s "
+"เพื่อปรับวิธีการทำงานของคุณลักษณะนี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
@@ -23606,7 +23799,9 @@ msgctxt "duckassist"
 msgid ""
 "Visit %sDuckAssist Settings%s to adjust how this feature works or turn it "
 "off."
-msgstr "ไปที่ %1$sการตั้งค่า DuckAssist%2$s เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
+msgstr ""
+"ไปที่ %1$sการตั้งค่า DuckAssist%2$s "
+"เพื่อปรับวิธีการทำงานของฟีเจอร์นี้หรือปิดการใช้งาน"
 
 # smartling.placeholder_format=C
 #. Prompt to visit DuckDuckGo on another device.
@@ -23629,8 +23824,9 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s > %3$sSync "
-"& Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วไปที่ %1$sDuck.ai Settings%2$s "
+"> %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync With Another "
+"Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23640,8 +23836,9 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก \"เปิด\" ภายใต้ Sync "
-"& Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณ แล้วเปิดการตั้งค่า Duck.ai เลือก "
+"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23651,9 +23848,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ %1$sDuck.ai "
-"Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s จากนั้นเลือก %7$sSync "
-"With Another Device%8$s"
+"เข้าไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วไปที่ "
+"%1$sDuck.ai Settings%2$s > %3$sSync & Backup%4$s > %5$sManage%6$s "
+"จากนั้นเลือก %7$sSync With Another Device%8$s"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23663,9 +23860,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า Duck.ai เลือก "
-"\"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" หรือสแกนคิวอาร์บน PDF "
-"การกู้คืนของคุณ"
+"ไปที่ Duck.ai ในเบราว์เซอร์อื่นของคุณหรือแอป DuckDuckGo แล้วเปิดการตั้งค่า "
+"Duck.ai เลือก \"เปิด\" ภายใต้ Sync & Backup และเลือก \"ซิงค์กับอุปกรณ์อื่น\" "
+"หรือสแกนคิวอาร์บน PDF การกู้คืนของคุณ"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23717,7 +23914,10 @@ msgstr "แชทด้วยเสียงสิ้นสุดลง"
 #. Description in consent disclaimer informing that voice chats with the AI (Artificial Intelligence) are anonymized by us, and are never used to train AI models.
 msgctxt "voice chat"
 msgid "Voice chat is anonymized by us, and never used to train AI models."
-msgstr "เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล AI"
+msgstr ""
+""
+"เราจะทำให้การแชทด้วยเสียงไม่ถูกระบุชื่อและจะไม่มีการใช้การแชทด้วยเสียงเพื่อฝึกโมเดล "
+"AI"
 
 # smartling.placeholder_format=C
 #. Title of the modal shown when the user has reached their daily voice chat limit.
@@ -23888,8 +24088,10 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ เพราะเราต้องสตรีมเนื้อหาจากที่นั่น "
-"DuckDuckGo เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
+"การดูวิดีโอที่นี่หมายความว่าเว็บไซต์ที่โฮสต์นั้นสามารถติดตามคุณได้ "
+"เพราะเราต้องสตรีมเนื้อหาจากที่นั่น DuckDuckGo "
+"เป็นบริษัทอิสระและไม่มีความสัมพันธ์กับ YouTube "
+"ซึ่งวิดีโอส่วนใหญ่โฮสต์อยู่ที่นั่น"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23901,7 +24103,9 @@ msgstr "เราทำให้ไม่ระบุตัวตน"
 #. Explains how location service is used to show users search results near their current location.
 msgctxt "precise_user_location"
 msgid "We can anonymize%s your location%s to show you more accurate results."
-msgstr "เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
+msgstr ""
+"เราสามารถเปิดใช้%1$s ตำแหน่งของคุณ%2$s "
+"แบบไม่ระบุตัวตนเพื่อแสดงผลลัพธ์ที่แม่นยำยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share this conversation before they can submit a Harmful or Illegal feedback report.
@@ -23913,8 +24117,9 @@ msgid ""
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
-"โปรดแชร์การสนทนานี้กับ DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย โปรดแชร์การสนทนานี้กับ "
+"DuckDuckGo เพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23926,7 +24131,8 @@ msgid ""
 "please share your prompt and response so we can investigate and address the "
 "issue."
 msgstr ""
-"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
+"เราสามารถแก้ไขได้เฉพาะสิ่งที่เราเห็นเท่านั้น "
+"เพื่อรายงานการตอบสนองที่เป็นอันตรายหรือผิดกฎหมาย "
 "โปรดแชร์คำแนะนำและการตอบสนองของคุณเพื่อที่เราจะสามารถสอบสวนและแก้ไขปัญหานี้"
 
 # smartling.placeholder_format=C
@@ -23940,7 +24146,9 @@ msgstr "เราสามารถใช้%1$sตำแหน่งที่�
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "เราไม่สามารถอ่านไฟล์ที่แนบมาได้ เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
+msgstr ""
+"เราไม่สามารถอ่านไฟล์ที่แนบมาได้ "
+"เนื่องจากอย่างน้อยหนึ่งในนั้นได้รับการเข้ารหัส"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23968,7 +24176,8 @@ msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
 msgstr ""
-"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ เราไม่ติดตามคุณ อย่างแน่นอน"
+"เราไม่จัดเก็บข้อมูลส่วนบุคคลของคุณ เราจะไม่แสดงโฆษณาแก่คุณในทุกๆ ที่ "
+"เราไม่ติดตามคุณ อย่างแน่นอน"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23981,7 +24190,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
+msgstr ""
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณกลับมาในวันนี้:"
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23990,7 +24201,8 @@ msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
 msgstr ""
-"เนื่องจากเราไม่ได้ติดตามคุณ เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
+"เนื่องจากเราไม่ได้ติดตามคุณ "
+"เราจึงอยากให้คุณช่วยบอกว่าสิ่งใดทำให้คุณสนใจลองใช้บริการเราในวันนี้:"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24057,7 +24269,8 @@ msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
 msgstr ""
-"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ VPN และอื่นๆ"
+"เราค้นหาและลบข้อมูลส่วนตัวของคุณออกจากเว็บไซต์นายหน้าข้อมูล นอกจากนี้ยังรับ "
+"VPN และอื่นๆ"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24066,7 +24279,8 @@ msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
 msgstr ""
-"เรามีข้อตกลงกับผู้ให้บริการ AI ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
+"เรามีข้อตกลงกับผู้ให้บริการ AI "
+"ทุกรายเพื่อให้มั่นใจว่าการแชทของคุณจะไม่ถูกใช้ในการฝึกฝน AI"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24101,6 +24315,7 @@ msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
 msgstr ""
+""
 "เราใช้ตำแหน่งที่ตั้งแบบไม่ระบุตัวตนของคุณเพียงเพื่อให้ได้ผลลัพธ์ที่แม่นยำยิ่งขึ้นและใกล้คุณมากขึ้นเท่านั้น "
 "คุณสามารถเปลี่ยนใจได้เสมอในภายหลัง"
 
@@ -24118,7 +24333,9 @@ msgstr ""
 msgctxt "Feedback prompt"
 msgid ""
 "We rely on your anonymous feedback to make DuckDuckGo better for everyone."
-msgstr "เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo ให้ดียิ่งขึ้นสำหรับทุกคน"
+msgstr ""
+"เราพึ่งพาคำติชมที่ไม่ระบุชื่อของคุณเพื่อปรับปรุง DuckDuckGo "
+"ให้ดียิ่งขึ้นสำหรับทุกคน"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24154,8 +24371,8 @@ msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
 msgstr ""
-"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ ของคุณ "
-"และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
+"เราจะสแกนเว็บไซต์นายหน้าข้อมูลเพื่อค้นหาอีเมล ชื่อ ที่อยู่ และข้อมูลอื่นๆ "
+"ของคุณ และดำเนินการเพื่อให้ทุกสิ่งที่เราพบเกี่ยวกับคุณถูกลบออก"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24164,7 +24381,8 @@ msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
 msgstr ""
-"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
+"เราทราบถึงปัญหานี้แล้วและกำลังดำเนินการแก้ไขอยู่ "
+"ถ้าคุณยังเห็นข้อผิดพลาดนี้อยู่ กรุณาติดต่อ %1$s"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24197,7 +24415,8 @@ msgid ""
 "We've updated the Duck.ai service. For the change to take effect, we need to "
 "reload the page."
 msgstr ""
-"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
+"เราได้อัปเดตบริการ Duck.ai แล้ว เพื่อให้การเปลี่ยนแปลงมีผล "
+"เราจำเป็นต้องโหลดหน้านี้อีกครั้ง"
 
 # smartling.placeholder_format=C
 #. Instant Answer Tab Name
@@ -24305,7 +24524,9 @@ msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid ""
 "Weekly usage limit reached. You can keep chatting by using your monthly "
 "limit."
-msgstr "ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
+msgstr ""
+"ถึงขีดจำกัดการใช้งานรายสัปดาห์แล้ว "
+"คุณสามารถแชทต่อโดยใช้ขีดจำกัดรายเดือนของคุณ"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -24319,7 +24540,8 @@ msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
 msgstr ""
-"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
+"ยินดีต้อนรับสู่ Duck.ai การแชททั้งหมดที่นี่เป็นแบบส่วนตัว "
+"เราไม่ระบุชื่อและจะไม่ถูกใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24340,7 +24562,8 @@ msgid ""
 "to train AI models."
 msgstr ""
 "ยินดีต้อนรับสู่ DuckDuckGo AI Chat! เซสชันแชทนี้ขับเคลื่อนโดย %2$s ของ %1$s "
-"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo หรือใช้เพื่อฝึกโมเดล AI"
+"การแชททั้งหมดของคุณที่นี่เป็นแบบส่วนตัว และจะไม่ถูกจัดเก็บโดย DuckDuckGo "
+"หรือใช้เพื่อฝึกโมเดล AI"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24447,7 +24670,9 @@ msgctxt "Full sentence for finding a better word"
 msgid ""
 "What are some options for the word ‘better’ in the context of “We really "
 "need to do better.”"
-msgstr "มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ \"เราต้องทำให้ได้ดีกว่านี้\""
+msgstr ""
+"มีตัวเลือกใดบ้างสำหรับคำว่า 'ดีกว่านี้' ในบริบทของ "
+"\"เราต้องทำให้ได้ดีกว่านี้\""
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for uncovering pros and cons of annuities.
@@ -24472,10 +24697,11 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo สำหรับผู้ที่สนใจใช้ Duck.ai "
-"อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ "
-"ที่ชัดเจนพร้อมชื่อหัวข้อ โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น "
-"ง่าย และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
+"คุณจะได้ประโยชน์อะไรบ้างจากการดาวน์โหลดเบราว์เซอร์ DuckDuckGo "
+"สำหรับผู้ที่สนใจใช้ Duck.ai อ้างอิงเฉพาะแหล่งข้อมูลอย่างเป็นทางการของ "
+"DuckDuckGo เท่านั้น แบ่งคำตอบออกเป็นส่วนๆ ที่ชัดเจนพร้อมชื่อหัวข้อ "
+"โดยเน้นที่การบูรณาการ Duck.ai และการปกป้องความเป็นส่วนตัว ทำให้สั้น ง่าย "
+"และเข้าใจได้ง่ายสำหรับคนที่มีหรือไม่มีประสบการณ์ด้าน AI หรือเทคนิคมากนัก"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -25022,7 +25248,9 @@ msgctxt "Chat history about modal list item description"
 msgid ""
 "With chat history on, up to %s of your most recent chats will be saved on "
 "this device."
-msgstr "เมื่อเปิดใช้งานประวัติการแชท จะสามารถบันทึกแชทล่าสุดได้สูงสุด %1$s รายการบนอุปกรณ์นี้"
+msgstr ""
+"เมื่อเปิดใช้งานประวัติการแชท จะสามารถบันทึกแชทล่าสุดได้สูงสุด %1$s "
+"รายการบนอุปกรณ์นี้"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline in the About Chat History modal.
@@ -25335,7 +25563,9 @@ msgstr "คุณสามารถเข้าถึง DuckDuckGo AI Chat ไ�
 msgctxt "duckassist"
 msgid ""
 "You can adjust how %s works or turn it off anytime in %sSearch Settings%s."
-msgstr "คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน %2$sการตั้งค่าการค้นหา%3$s"
+msgstr ""
+"คุณสามารถปรับวิธีการทำงานของ %1$s หรือปิดได้ตลอดเวลาใน "
+"%2$sการตั้งค่าการค้นหา%3$s"
 
 # smartling.placeholder_format=C
 #. Assist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate Assist.
@@ -25344,7 +25574,8 @@ msgid ""
 "You can adjust how Assist works or turn it off anytime in %sSearch "
 "Settings%s."
 msgstr ""
-"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน %1$sการตั้งค่าการค้นหา%2$s"
+"คุณสามารถปรับวิธีการทำงานของ Assist หรือปิดได้ตลอดเวลาใน "
+"%1$sการตั้งค่าการค้นหา%2$s"
 
 # smartling.placeholder_format=C
 msgid "You can also use %sDuck.ai%s to answer questions or summarize text."
@@ -25483,7 +25714,9 @@ msgctxt "Organic result context menu"
 msgid ""
 "You can only block up to %s sites. To block %s, you'll need to unblock "
 "another site first."
-msgstr "คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s คุณต้องเลิกบล็อกไซต์อื่นก่อน"
+msgstr ""
+"คุณสามารถบล็อกได้เพียง %1$s ไซต์เท่านั้น ในการบล็อก %2$s "
+"คุณต้องเลิกบล็อกไซต์อื่นก่อน"
 
 # smartling.placeholder_format=C
 #. Text explaining the benefits of the cloud save feature.
@@ -25547,8 +25780,8 @@ msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
 msgstr ""
-"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 "
-"เท่า"
+"ตอนนี้คุณมีการเข้าถึง %1$s, การให้เหตุผล AI ที่สูงขึ้น, "
+"และขีดจำกัดการใช้งานสูงกว่า Plus ถึง 2 เท่า"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25623,7 +25856,8 @@ msgid ""
 "browse privately too. It’s already installed and can:"
 msgstr ""
 "ตอนนี้คุณกำลังค้นหาแบบเป็นส่วนตัวใน Chrome ใช้แอปของเราแทน Chrome "
-"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
+"เพื่อเรียกดูแบบเป็นส่วนตัวได้เช่นกัน "
+"แอปได้รับการติดตั้งไว้เรียบร้อยแล้วและสามารถ:"
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25636,7 +25870,8 @@ msgid ""
 "You're now searching with privacy. %sGet tips to reduce your footprint even "
 "more."
 msgstr ""
-"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว %1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
+"ตอนนี้คุณทำการกำลังค้นหาแบบมีความเป็นส่วนตัว "
+"%1$sดูเคล็ดลับเพื่อลดร่องรอยทางออนไลน์ให้มากยิ่งขึ้น"
 
 # smartling.placeholder_format=C
 #. Title of a notice thanking the user for turning off their adblocker
@@ -25712,8 +25947,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว ลบแชทที่เก่าที่สุด "
-"%1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณใช้พื้นที่จัดเก็บ Sync & Backup สำหรับการแชท Duck.ai พร้อมไฟล์แนบเต็มแล้ว "
+"ลบแชทที่เก่าที่สุด %1$s แชทเพื่อซิงค์ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25723,8 +25958,9 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท %1$s "
-"รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ แชทที่ปักหมุดไว้จะไม่ถูกลบ"
+"คุณหมดพื้นที่จัดเก็บข้อมูลสำรอง Sync & Backup สำหรับแชท Duck.ai แล้ว ลบแชท "
+"%1$s รายการที่เก่าที่สุดที่มีไฟล์แนบเพื่อดำเนินการ Sync ต่อ "
+"แชทที่ปักหมุดไว้จะไม่ถูกลบ"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25738,8 +25974,8 @@ msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
 msgstr ""
-"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน การดูวิดีโอ YouTube "
-"ที่นี่จะถูกติดตามโดย YouTube/Google"
+"YouTube (Google เป็นเจ้าของ) ไม่อนุญาตให้คุณดูวิดีโอแบบไม่ระบุตัวตน "
+"การดูวิดีโอ YouTube ที่นี่จะถูกติดตามโดย YouTube/Google"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25761,7 +25997,8 @@ msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
 msgstr ""
-"การแชทล่าสุด %1$s รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
+"การแชทล่าสุด %1$s "
+"รายการของคุณจะพร้อมใช้งานในที่เก็บข้อมูลในเครื่องบนเบราว์เซอร์เหล่านี้:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -25850,14 +26087,17 @@ msgid ""
 "Your browser provides a list of your most-visited sites. DuckDuckGo never "
 "has access to this data."
 msgstr ""
-"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
+"เบราว์เซอร์ของคุณแสดงรายการไซต์ที่คุณเยี่ยมชมบ่อยที่สุดDuckDuckGo "
+"ไม่มีสิทธิ์เข้าถึงข้อมูลนี้เด็ดขาด"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
 msgid ""
 "Your browser provides the list of most-visited sites. DuckDuckGo never has "
 "access to this data."
-msgstr "เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo ไม่เคยเข้าถึงข้อมูลนี้"
+msgstr ""
+"เบราว์เซอร์ของคุณแสดงรายชื่อเว็บไซต์ที่เยี่ยมชมบ่อยที่สุด DuckDuckGo "
+"ไม่เคยเข้าถึงข้อมูลนี้"
 
 # smartling.placeholder_format=C
 #. Disclaimer text shown bellow chat input. Example: 'You are chatting with GPT-3. AI chats may display inaccurate or offensive information.'
@@ -25905,7 +26145,8 @@ msgctxt "Menu item description"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไมบันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. Body text of the modal that provides information about the active privacy protection.
@@ -25913,7 +26154,8 @@ msgctxt "Modal body for privacy"
 msgid ""
 "Your chats are private, never saved by us, and not used to train AI models."
 msgstr ""
-"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI เด็ดขาด"
+"การแชทของคุณเป็นแบบส่วนตัว เราจะไม่บันทึกและใช้การแชทของคุณในการฝึกโมเดล AI "
+"เด็ดขาด"
 
 # smartling.placeholder_format=C
 #. List item in the About Chat History modal explaining that chats are stored locally on the user's device.
@@ -26013,7 +26255,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า %1$sSHA-2%2$s "
+"รหัสผ่านของคุณสร้างคีย์ 512 บิตโดยใช้อัลกอริทึมการแฮชที่ปลอดภัยที่เรียกว่า "
+"%1$sSHA-2%2$s "
 "เฉพาะคีย์และไฟล์การตั้งค่าที่เกี่ยวข้องเท่านั้นที่ออกจากเบราว์เซอร์ของคุณ "
 "เราบันทึกไฟล์การตั้งค่าโดยใช้คีย์เป็นชื่อ DuckDuckGo จะไม่ทราบรหัสผ่านของคุณ"
 
@@ -26030,7 +26273,8 @@ msgid ""
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
 msgstr ""
-"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
+"คำสั่งของเธอถูกส่งต่อผ่านเซิร์ฟเวอร์ DuckDuckGo "
+"และข้อมูลเมตาที่ระบุตัวตนส่วนบุคคลจะถูกลบออก "
 "เพื่อให้ผู้ให้บริการโมเดลไม่สามารถเชื่อมโยงการสนทนาของคุณกลับไปยังคุณ"
 
 # smartling.placeholder_format=C
@@ -26076,8 +26320,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น เปิดใช้งานส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะรีเซ็ตการตั้งค่าเหล่านั้น "
+"เปิดใช้งานส่วนขยาย %1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -26086,8 +26330,10 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"การตั้งค่าของคุณถูกบันทึกไว้แล้ว แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
-"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร %3$sศึกษาเพิ่มเติม%4$s"
+"การตั้งค่าของคุณถูกบันทึกไว้แล้ว "
+"แต่การล้างคุกกี้จะเป็นการรีเซ็ตการตั้งค่าเหล่านั้น ติดตั้งส่วนขยาย "
+"%1$sDuckDuckGo No AI%2$s เพื่อให้การตั้งค่านี้คงอยู่ถาวร "
+"%3$sศึกษาเพิ่มเติม%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -26464,7 +26710,9 @@ msgstr "เว็บไซต์อย่างเป็นทางการ"
 #. <em>%s</em> is for a hexadecimal color code as <em>#395323</em>, but it has to be safe encoded, and as <em>#</em> seems not safe, <em>%23</em> must be used in place of the sharp symbol, but they are the same for your browser.
 msgid ""
 "or write out the color code you want, e.g. %s (%s is an encoded %s char)."
-msgstr "หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s ตัวที่เข้ารหัสแล้ว)"
+msgstr ""
+"หรือพิมพ์รหัสสีที่คุณต้องการ เช่น %1$s (%2$s เป็นรหัสอักขระ %3$s "
+"ตัวที่เข้ารหัสแล้ว)"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/params under "Look & Feel Settings" under both "Link font: " and "Link font: "

--- a/locales/tl_PH/LC_MESSAGES/duckduckgo.po
+++ b/locales/tl_PH/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5213,6 +5224,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5302,6 +5318,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6759,6 +6780,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7014,6 +7040,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7761,6 +7792,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8683,6 +8719,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12617,6 +12658,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17660,6 +17706,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18018,6 +18069,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
+++ b/locales/tokipona_XX/LC_MESSAGES/duckduckgo.po
@@ -2377,6 +2377,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5228,6 +5239,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "lukin ala"
@@ -5317,6 +5333,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6775,6 +6796,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7032,6 +7058,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7780,6 +7811,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8707,6 +8743,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12648,6 +12689,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17708,6 +17754,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18067,6 +18118,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "kepeken mute ala nimi."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
+++ b/locales/tpi_PG/LC_MESSAGES/duckduckgo.po
@@ -2370,6 +2370,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5211,6 +5222,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5300,6 +5316,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6757,6 +6778,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7010,6 +7036,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7757,6 +7788,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8675,6 +8711,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12609,6 +12650,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17650,6 +17696,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18008,6 +18059,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -386,7 +386,8 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
+msgstr ""
+"%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -973,7 +974,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr ""
+"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1731,7 +1733,8 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr ""
+"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -2040,7 +2043,8 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr ""
+"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2339,7 +2343,8 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr ""
+"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2598,8 +2603,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve "
-"Wi-Fi üzerindeki IP adresinizi gizler."
+"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve Wi-"
+"Fi üzerindeki IP adresinizi gizler."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2662,13 +2667,15 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr ""
+"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2977,6 +2984,18 @@ msgstr ""
 "kaldırarak konuşmanızı anonim hale getirecektir."
 
 # smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -3126,7 +3145,8 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr ""
+"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3553,7 +3573,8 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr ""
+"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4660,7 +4681,8 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr ""
+"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4773,13 +4795,15 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr ""
+"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr ""
+"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4860,7 +4884,8 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr ""
+"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4912,7 +4937,8 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr ""
+"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5973,7 +5999,8 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6551,6 +6578,12 @@ msgid "Dislike source"
 msgstr "Kaynağı beğenmeme"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Kapat"
@@ -6661,6 +6694,12 @@ msgid "Djibouti"
 msgstr "Cibuti"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6708,7 +6747,8 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr ""
+"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7139,7 +7179,8 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7195,7 +7236,8 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr ""
+"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7219,7 +7261,8 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr ""
+"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7949,7 +7992,8 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr ""
+"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8072,7 +8116,8 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr ""
+"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8526,6 +8571,12 @@ msgid "Fast"
 msgstr "Hızlı"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8720,7 +8771,8 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr ""
+"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8771,7 +8823,8 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr ""
+"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8854,6 +8907,12 @@ msgstr "Takip sorusu"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Takip soruları gizli kalır."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8959,7 +9018,8 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr ""
+"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -8971,7 +9031,8 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr ""
+"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9798,6 +9859,12 @@ msgid "Good privacy policy"
 msgstr "İyi bir gizlilik politikası"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
 msgctxt "shortbelieve"
 msgid "Goodies"
@@ -10185,7 +10252,8 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr ""
+"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10243,7 +10311,8 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr ""
+"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10380,7 +10449,8 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr ""
+"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10634,7 +10704,8 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr ""
+"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10784,14 +10855,15 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
-"kitaplar/diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
+"diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr ""
+"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -10937,6 +11009,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Görsel istemler Duck.ai %1$s ile uyumlu olmalıdır."
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12099,7 +12177,8 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr ""
+"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -12998,7 +13077,8 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr ""
+"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13160,7 +13240,8 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr ""
+"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -15745,14 +15826,16 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr ""
+"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr ""
+"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15809,6 +15892,12 @@ msgstr "Lehçe"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Kötü biçimlendirme"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16325,7 +16414,8 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr ""
+"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -16974,9 +17064,8 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
-"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
-"yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
+"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17378,7 +17467,8 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr ""
+"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17741,7 +17831,8 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr ""
+"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17783,7 +17874,8 @@ msgstr "Duck.ai'a merhaba deyin!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr "Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
+msgstr ""
+"Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -17974,7 +18066,8 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr ""
+"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18246,7 +18339,8 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr ""
+"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18475,7 +18569,8 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr ""
+"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18544,7 +18639,8 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18610,7 +18706,8 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr ""
+"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18635,7 +18732,8 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr ""
+"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18665,7 +18763,8 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr ""
+"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19299,7 +19398,8 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr ""
+"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19416,7 +19516,8 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr ""
+"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19482,7 +19583,8 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
+msgstr ""
+"Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19576,12 +19678,14 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr ""
+"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19610,7 +19714,8 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr ""
+"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19697,7 +19802,8 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr ""
+"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19933,7 +20039,8 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr ""
+"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -19967,7 +20074,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20021,7 +20129,8 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr ""
+"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20281,7 +20390,8 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr ""
+"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20705,7 +20815,8 @@ msgstr "Model değiştir"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr ""
+"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -21370,7 +21481,8 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr ""
+"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21539,7 +21651,8 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr ""
+"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21745,7 +21858,8 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
+msgstr ""
+"Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21879,7 +21993,8 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr ""
+"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21899,7 +22014,8 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr ""
+"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -21917,7 +22033,8 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr ""
+"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -21991,7 +22108,8 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr ""
+"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22023,7 +22141,8 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr ""
+"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22096,7 +22215,8 @@ msgstr "Bugün"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr "Gizli yapay zeka sohbetine geçin veya ayarlardan %1$sdevre dışı bırakın%2$s."
+msgstr ""
+"Gizli yapay zeka sohbetine geçin veya ayarlardan %1$sdevre dışı bırakın%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22165,6 +22285,12 @@ msgstr "Bu kaynaktan çok fazla sonuç var"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Çok yavaş"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22285,7 +22411,8 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr ""
+"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22452,7 +22579,8 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr ""
+"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22607,6 +22735,12 @@ msgstr "Her bir modeli deneyin - farklı yanıtlar vereceklerdir."
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Daha az anahtar kelime deneyin."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22964,7 +23098,8 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr ""
+"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -22982,7 +23117,8 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr ""
+"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23188,8 +23324,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
-"https://duckduckgo.com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
+"com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23223,7 +23359,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr ""
+"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23709,7 +23846,8 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr ""
+"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24316,7 +24454,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr ""
+"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24418,7 +24557,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr ""
+"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24517,7 +24657,8 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr ""
+"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -25252,7 +25393,8 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr ""
+"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25811,7 +25953,8 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr ""
+"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25850,7 +25993,8 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr ""
+"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26137,7 +26281,8 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr ""
+"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26202,7 +26347,8 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
+msgstr ""
+"Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26394,7 +26540,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr ""
+"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26441,7 +26588,8 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr ""
+"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26586,7 +26734,8 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr ""
+"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26628,7 +26777,8 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr ""
+"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26711,7 +26861,8 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr ""
+"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -386,8 +386,7 @@ msgstr "%1$s kullanıldı"
 #. Dismissible banner inside the chat input on a new chat when Opus is selected (any reasoning mode). The first placeholder is the model short name in bold (e.g. 'Opus 4.8'). The second is a 'Learn More' link to the usage-limits help page (currently hidden until the URL is final). Example: '<strong>Opus 4.8</strong> uses limits up to 2-5x faster than basic models. <a>Learn More</a>'.
 msgctxt "Dismissible new-chat banner when Opus is selected"
 msgid "%s uses limits up to 2-5x faster than basic models %s"
-msgstr ""
-"%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
+msgstr "%1$s, limitleri temel modellere göre 2-5 kata kadar daha hızlı tüketir %2$s"
 
 # smartling.placeholder_format=C
 #. Label to add to describe the number of views of a video (e.g., 1 view). This is for the singular case (just 1 view). The placeholder indicates the number of view (typically 1).
@@ -974,8 +973,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of Duck.ai is available! Please refresh this page to continue."
-msgstr ""
-"Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
+msgstr "Duck.ai'ın yeni sürümü yayında! Devam etmek için lütfen bu sayfayı yenileyin."
 
 # smartling.placeholder_format=C
 #. Shown when the Duck.ai desktop app has been open a long time and a newer version exists.
@@ -1733,8 +1731,7 @@ msgstr "İndirdikten ve açtıktan sonra %1$sYükle%2$s seçeneğine tıklayın"
 #. Instructions on how to install the DuckDuckGo browser extension after it downloads.
 msgid ""
 "After it downloads, locate the extension file and double-click it to install"
-msgstr ""
-"İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
+msgstr "İndirdikten sonra uzantı dosyasını bulun ve yüklemek için çift tıklayın"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to an age below a web search result.
@@ -2043,8 +2040,7 @@ msgstr "Zaten senkronize edildi."
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Also search privately on your iPad, iPhone, or Android!"
-msgstr ""
-"Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
+msgstr "Ayrıca iPad, iPhone veya Android cihazınızda gizli arama yapabilirsiniz!"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -2343,8 +2339,7 @@ msgstr ""
 #. Body text of the modal that asks the user if they want to clear the conversation.
 msgctxt "Modal body for clearing conversation"
 msgid "Are you sure you want to clear this conversation and start a new one?"
-msgstr ""
-"Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
+msgstr "Bu konuşmayı silip yeni bir konuşma başlatmak istediğinizden emin misiniz?"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to delete their current chat, explaining that this action cannot be undone.
@@ -2603,8 +2598,8 @@ msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
 msgstr ""
-"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve Wi-"
-"Fi üzerindeki IP adresinizi gizler."
+"Kafede, havaalanında veya otelde DuckDuckGo VPN, bağlantınızı şifreler ve "
+"Wi-Fi üzerindeki IP adresinizi gizler."
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2667,15 +2662,13 @@ msgstr "Ses"
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description in consent disclaimer informing that audio from the voice chat session is not stored by us or by OpenAI after the voice chat ends.
 msgctxt "voice chat"
 msgid "Audio is not stored by us or by OpenAI after the chat ends."
-msgstr ""
-"Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
+msgstr "Sohbet sona erdikten sonra ses tarafımızdan veya OpenAI tarafından saklanmaz."
 
 # smartling.placeholder_format=C
 #. Description for the data retention highlight in the dictation consent modal.
@@ -2994,6 +2987,10 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"DuckDuckGo, bu raporu kaydetmeden önce yüklenen dosyaları ve oluşturulan "
+"görselleri kaldıracak ve isimler, e-posta adresleri ve tanımlayıcı meta "
+"veriler gibi kişiyi açığa çıkarabilecek bilgileri (PII) kaldırarak "
+"konuşmanızı anonim hale getirecektir."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3145,8 +3142,7 @@ msgstr "Bu siteyi tüm sonuçlarda engelleyin"
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Block trackers and take control of your personal data"
-msgstr ""
-"Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
+msgstr "Takip edicileri engelleyin ve kişisel verilerinizin kontrolünü elinize alın"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -3573,8 +3569,7 @@ msgstr "Kamerun"
 #. Text for a prompt suggestion for creating a few simple recipes using chicken, broccoli, and rice.
 msgctxt "Full sentence for crafting a recipe"
 msgid "Can you create a few simple recipes using chicken, broccoli, and rice?"
-msgstr ""
-"Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
+msgstr "Tavuk, brokoli ve pirinci kullanarak birkaç basit tarif hazırlayabilir misin?"
 
 # smartling.placeholder_format=C
 msgid "Canada"
@@ -4681,8 +4676,7 @@ msgstr "%1$sEkle%2$s seçeneğine tıklayın"
 #. Instructions on which buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "Click %sAllow%s, then %sAdd%s."
-msgstr ""
-"%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
+msgstr "%1$sİzin Ver%2$s seçeneğine, ardından %3$sEkle%4$s seçeneğine tıklayın."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -4795,15 +4789,13 @@ msgstr "Açılır menüden %1$sArama Ayarlarını Değiştir%2$s seçeneğine t�
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on %sSet as Default%s towards the bottom"
-msgstr ""
-"Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
+msgstr "Alta doğru yer alan %1$sVarsayılan Olarak Ayarla%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click on the %sSearch Providers%s under Add-on Types"
-msgstr ""
-"Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
+msgstr "Eklenti Türleri bölümündeki %1$sArama Sağlayıcıları%2$s seçeneğine tıklayın"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -4884,8 +4876,7 @@ msgstr "Adres çubuğundaki %1$sizinler simgesine%2$s tıklayın"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
+msgstr "Arama yapmak için tarayıcınızın üst kısmındaki ördek simgesine tıklayın!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -4937,8 +4928,7 @@ msgstr "Arama çubuğundaki büyüteç simgesine tıklayın"
 #. Tells users what icon to click in order to make DuckDuckGo the default engine in their browser.
 msgid ""
 "Click the magnifying glass in the search box (at the top of the browser)"
-msgstr ""
-"Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
+msgstr "Arama kutusundaki büyüteç simgesine tıklayın (tarayıcının üst tarafında)"
 
 #  IE default search engine instruction
 # smartling.placeholder_format=C
@@ -5999,8 +5989,7 @@ msgstr "Günlük limit doldu"
 #. Displayed when the user has reached a fixed daily Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Daily usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Günlük kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached a bypassable daily Duck.ai usage limit and can opt in to continue using the weekly limit.
@@ -6581,7 +6570,7 @@ msgstr "Kaynağı beğenmeme"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Görsel stili beğenmedim"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6697,7 +6686,7 @@ msgstr "Cibuti"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Talimatlara uymuyor"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6747,8 +6736,7 @@ msgstr "DuckDuckGo'yu listede göremiyor musunuz?"
 #. Link to download a file again if the user can't find it on their computer.
 msgctxt "install-extension"
 msgid "Don't see it? %s%s%sClick here to re-download%s"
-msgstr ""
-"Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
+msgstr "Göremiyor musunuz? %1$s%2$s%3$sTekrar indirmek için buraya tıklayın%4$s"
 
 #  IE < 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -7179,8 +7167,7 @@ msgstr ""
 #. Displayed when the AI chat service is temporarily unavailable.
 msgctxt "Error message for service unavailability"
 msgid "Duck.ai is temporarily unavailable. Please try again later."
-msgstr ""
-"Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Duck.ai geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7236,8 +7223,7 @@ msgstr ""
 msgctxt "Disclaimer above chat input during DuckAssist handoff - desktop"
 msgid ""
 "Duck.ai responses aren’t based on specific sources or checked for accuracy."
-msgstr ""
-"Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
+msgstr "Duck.ai yanıtları belirli kaynaklara dayanmaz ve doğruluğu kontrol edilmez."
 
 # smartling.placeholder_format=C
 #. Second, dimmer line of the highlight tooltip shown under the 'Try a different model' item title when the user activates that onboarding step.
@@ -7261,8 +7247,7 @@ msgstr "Duck.ai aboneliği yükseltildi!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
+msgstr "Duck.ai, gizli ve ücretsiz DuckDuckGo uygulamasında en iyi şekilde çalışır!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7992,8 +7977,7 @@ msgstr "Duck.ai'da sesli dikte özelliğini etkinleştir"
 #. Prompt to enable location service so that search results can be displayed near the user's current location.
 msgctxt "precise_user_location"
 msgid "Enable location settings on your device to use anonymous location"
-msgstr ""
-"Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
+msgstr "Anonim konumu kullanmak için cihazınızdan konum ayarlarını etkinleştirin"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -8116,8 +8100,7 @@ msgstr "Duck.ai'ı beğeniyor musunuz?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
+msgstr "'Konum' ayarı için %1$s'İzin Ver'%2$s ögesinin seçili olduğundan emin olun."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8574,7 +8557,7 @@ msgstr "Hızlı"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Hızlı görsel oluşturma"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8771,8 +8754,7 @@ msgstr "Finansal danışman"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
+msgstr "%1$sDuckDuckGo%2$s'yu bulun ve %3$sVarsayılan yap%4$s seçeneğine tıklayın"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8823,8 +8805,7 @@ msgstr "Size daha yakın sonuçlar bulun."
 msgctxt "Precise user location overlay"
 msgid ""
 "Find results near you. %sYour location stays private, secure, and anonymous."
-msgstr ""
-"Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
+msgstr "Yakınınızdan sonuçlar bulun. %1$sKonumunuz gizli, güvende ve anonim kalır."
 
 # smartling.placeholder_format=C
 #. Loading message shown while generating explore more follow-up questions
@@ -8912,7 +8893,7 @@ msgstr "Takip soruları gizli kalır."
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Talimatlara uydu"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9018,8 +8999,7 @@ msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler"
 #. Text describing that chats are free, private and anonymized by us. Chats in this context are chats with AI (Artificial Intelligence) models, like GPT.
 msgctxt "Onboarding welcome screen private claim"
 msgid "Free and private chats, anonymized by us. No account required."
-msgstr ""
-"Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
+msgstr "Tarafımızdan anonimleştirilmiş ücretsiz ve gizli sohbetler. Hesap gerekmez."
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC usage license
@@ -9031,8 +9011,7 @@ msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Kullanılabilen"
 #. a filter for images with the CC BY usage license
 msgctxt "image-licence"
 msgid "Free to Modify, Share, and Use Commercially"
-msgstr ""
-"Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
+msgstr "Ücretsiz Değiştirilebilen, Paylaşılabilen ve Ticari Olarak Kullanılabilen"
 
 # smartling.placeholder_format=C
 #. a filter for images with the CC BY-NC-ND usage license
@@ -9862,7 +9841,7 @@ msgstr "İyi bir gizlilik politikası"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Görsel stili beğendim"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10252,8 +10231,7 @@ msgstr "DuckDuckGo'yu geliştirmemize yardımcı olun"
 #. An invitation for users to leave feedback
 msgctxt "Feedback prompt"
 msgid "Help us improve DuckDuckGo searches with your feedback"
-msgstr ""
-"Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
+msgstr "Geri bildirimlerinizle DuckDuckGo aramalarını geliştirmemize yardımcı olun"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -10311,8 +10289,7 @@ msgstr "Arkadaşlarınızın ve ailenizin Duck Side'a katılmalarına yardımcı
 #. Text description for the Spread card in the SERP footer
 msgctxt "footer_card"
 msgid "Help your friends and family take back their privacy!"
-msgstr ""
-"Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
+msgstr "Arkadaşlarınızın ve ailenizin gizliliklerini geri almalarına yardımcı olun!"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -10449,8 +10426,7 @@ msgstr "E-posta adresinizi gizleyin"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Hides search term from being shown in browser tab/history"
-msgstr ""
-"Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
+msgstr "Arama ifadesinin tarayıcı sekmesinde/geçmişinde gösterilmesini engeller"
 
 # smartling.placeholder_format=C
 #. The highest stock price in a day
@@ -10704,8 +10680,7 @@ msgstr "Yapay zeka destekli cevapların ne kadar görünmesini istiyorsun?"
 #. Description for the Usage section in Duck.ai settings, explaining that the section shows how much of the user's daily and weekly limits they have used so far.
 msgctxt "Duck.ai settings usage section"
 msgid "How much of your daily and weekly limits you've used so far."
-msgstr ""
-"Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
+msgstr "Şimdiye kadar günlük ve haftalık limitlerinizin ne kadarını kullandığınız."
 
 # smartling.placeholder_format=C
 #. A header for the feedback form in the assist negative feedback flow. The user is being asked to update how often they want AI-assisted answers to appear.
@@ -10855,15 +10830,14 @@ msgid ""
 "I like the book Name of the Wind. What are some other good books/series most "
 "like it and why?"
 msgstr ""
-"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi kitaplar/"
-"diziler nelerdir ve neden?"
+"Rüzgârın Adı kitabını severim. Buna en çok benzeyen diğer iyi "
+"kitaplar/diziler nelerdir ve neden?"
 
 # smartling.placeholder_format=C
 #. Option for feedback when the user needs more help or information on how to use the chat.
 msgctxt "Feedback option for difficulty in using chat"
 msgid "I need more help/info on how to use Chat"
-msgstr ""
-"Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
+msgstr "Sohbeti nasıl kullanacağıma dair daha fazla yardım/bilgiye ihtiyacım var"
 
 # smartling.placeholder_format=C
 msgid "IR Iran"
@@ -11014,7 +10988,7 @@ msgstr "Görsel istemler Duck.ai %1$s ile uyumlu olmalıdır."
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Görsel kalitesi"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -12177,8 +12151,7 @@ msgstr "Bağlantılar:"
 #. Prompt sent to the AI when the user taps the "What will I need?" page-suggestion chip.
 msgctxt "Page suggestion prompt"
 msgid "List the tools, materials, or prerequisites I need for this."
-msgstr ""
-"Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
+msgstr "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele."
 
 # smartling.placeholder_format=C
 #. Used in 0-click bot for video results, e.g. <a href="https://duckduckgo.com/?q=blink182+song">https://duckduckgo.com/?q=blink182+song</a>
@@ -13077,8 +13050,7 @@ msgstr "Aylık limit doldu"
 #. Displayed when the user has reached a fixed monthly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale and reads as 'after <date/time>', e.g. 'after May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "Monthly usage limit reached. You can continue this chat after %s."
-msgstr ""
-"Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
+msgstr "Aylık kullanım limiti doldu. Bu sohbete %1$s sonrasında devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Used to point to additional social networking profiles (in results).
@@ -13240,8 +13212,7 @@ msgstr "Daha fazla bilgiyi %1$s %2$s makalesinde bulabilirsiniz."
 # smartling.placeholder_format=C
 #. Source (section, article and site) of the answer generated by duckassist (an instant answer based on generative AI)
 msgid "More info in the %s section of the %s %s article."
-msgstr ""
-"Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
+msgstr "Daha fazla bilgiyi %2$s %3$s makalesinin %1$s bölümünde bulabilirsiniz."
 
 # smartling.placeholder_format=C
 msgctxt ""
@@ -15826,16 +15797,14 @@ msgstr "Lütfen bekleyin..."
 #. Tagline for the subscription promo shown in the SERP sidemenu.
 msgctxt "Sidemenu subscription promo"
 msgid "Plus more premium features with a DuckDuckGo subscription."
-msgstr ""
-"DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
+msgstr "DuckDuckGo aboneliğiyle daha birçok premium özelliğe sahip olabilirsiniz."
 
 # smartling.placeholder_format=C
 #. A description to provide more detail on what Duck Player does (Duck Player is DDG's feature to watch youtube videos more privately)
 msgid ""
 "Plus, what you watch in Duck Player won’t influence your recommendations on "
 "YouTube."
-msgstr ""
-"Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
+msgstr "Ayrıca, Duck Player'da izledikleriniz YouTube'daki önerilerinizi etkilemez."
 
 # smartling.placeholder_format=C
 #. A link to the Substack page (https://insideduckduckgo.substack.com/?showWelcome=true)
@@ -15897,7 +15866,7 @@ msgstr "Kötü biçimlendirme"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Kötü görsel kalitesi"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16414,8 +16383,7 @@ msgstr "Bana sor"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Prompt me to use my approximate location to get nearby results."
-msgstr ""
-"Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
+msgstr "Yakınımdaki sonuçları almak için yaklaşık konumumu kullanmamı hatırlat."
 
 # smartling.placeholder_format=C
 #. DuckDuckGo Email Protection removes trackers from emails
@@ -17064,8 +17032,9 @@ msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
 msgstr ""
-"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya &quot;"
-"Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden yükleyin."
+"Talimatları izleyerek veya tarayıcınızın &quot;Yenile&quot; veya "
+"&quot;Yeniden Yükle&quot; düğmesine tıklayarak DuckDuckGo'yu yeniden "
+"yükleyin."
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -17467,8 +17436,7 @@ msgstr "Sonuçlar, engellenmiş sitelerden gelen bilgileri içermez."
 #. Message that appears when results exclude blocked sites
 msgctxt "Blocked sites filter disclaimer"
 msgid "Results exclude your blocked sites, which you can manage in your %s."
-msgstr ""
-"Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
+msgstr "Sonuçlar, %1$s bölümünden yönetebileceğin engellenmiş sitelerini içermez."
 
 # smartling.placeholder_format=C
 #. A label showing the source of the results, e.g. "Results from Reddit"
@@ -17831,8 +17799,7 @@ msgstr "En son 30 sohbetinizi cihazınıza yerel olarak kaydedin."
 msgctxt "Body copy for the Sync & Backup intro screen"
 msgid ""
 "Save your Duck.ai chats between your devices with end-to-end encryption."
-msgstr ""
-"Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
+msgstr "Duck.ai sohbetlerinizi cihazlar arasında uçtan uca şifreleme ile kaydedin"
 
 # smartling.placeholder_format=C
 #. Short description shown in Chat History settings when sync is enabled, explaining chats are saved across all devices.
@@ -17874,8 +17841,7 @@ msgstr "Duck.ai'a merhaba deyin!"
 #. Introduces Duck.ai to people who arrived through a shared-chat link. 'Duck.ai' and 'DuckDuckGo' are brand names and should not be translated.
 msgctxt "Promotional banner shown when viewing a shared Duck.ai chat"
 msgid "Say hello to Duck.ai – free, private AI chat by DuckDuckGo."
-msgstr ""
-"Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
+msgstr "Duck.ai'a merhaba deyin – DuckDuckGo'dan ücretsiz, gizli yapay zeka sohbeti."
 
 # smartling.placeholder_format=C
 #. Title displayed on the welcome screen of the onboarding.
@@ -18066,8 +18032,7 @@ msgstr "Ara"
 # smartling.placeholder_format=C
 #. e.g., 'Search coffee shop in san diego ca to find results closer to you?' (when the user searched with a local query like 'coffee shop near me')
 msgid "Search %s to find results closer to you?"
-msgstr ""
-"Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
+msgstr "Size daha yakın sonuçları bulmak için %1$s ifadesiyle arama yapılsın mı?"
 
 # smartling.placeholder_format=C
 #. Label of the Duck.ai entry in the 'Customize New Tab Page' menu.
@@ -18339,8 +18304,7 @@ msgstr "DuckDuckGo ile Ara"
 #. Text for a promotional card encouraging third-party browser users to download the DuckDuckGo browser. Not shown in the DuckDuckGo browser or on Linux.
 msgctxt "Promotional text"
 msgid "Search, browse, and chat privately in our free browser"
-msgstr ""
-"Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
+msgstr "Ücretsiz tarayıcımızda gizli şekilde arama yapın, gezinin ve sohbet edin"
 
 # smartling.placeholder_format=C
 #. Message displayed sometimes at top of results (for bang syntax), e.g. <a href="https://duckduckgo.com/?q=twitter+test">https://duckduckgo.com/?q=twitter+test</a>
@@ -18569,8 +18533,7 @@ msgstr "En son güncellemelerimizden bazılarını gör"
 #. Link to a page with more information about how user settings are stored in a URL.
 msgctxt "settings"
 msgid "See the %sURL Parameter Reference page%s for more details."
-msgstr ""
-"Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
+msgstr "Daha fazla bilgi için %1$sURL Parametre Referansı sayfasına%2$s göz atın."
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the context menu of a chat in chat history, that allows the user to select the chat and begin batch selection mode.
@@ -18639,8 +18602,7 @@ msgstr "Varsayılan Arama Motoru açılır menüsünden %1$sDuckDuckGo%2$s'yu se
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %sDuckDuckGo%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$sDuckDuckGo%2$s'yu seçin ve konum erişimine %3$sizin verin%4$s"
 
 #  IE 11 default search engine instruction
 # smartling.placeholder_format=C
@@ -18706,8 +18668,7 @@ msgstr "%1$sArama Motoru%2$s bölümünü seçin"
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSearch engine%s, then %sOthers...%s"
-msgstr ""
-"%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
+msgstr "%1$sArama motoru%2$s bölümünü, ardından %3$sDiğerleri..%4$s ögesini seçin"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -18732,8 +18693,7 @@ msgstr "Açılır menüden %1$sSeçenekler%2$s ögesini seçin."
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
 msgctxt "mobile homepage banner"
 msgid "Select %sSettings%s, then %sAdvanced settings%s"
-msgstr ""
-"%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
+msgstr "%1$sAyarlar%2$s bölümünü, ardından %3$sGelişmiş ayarlar%4$s bölümünü seçin"
 
 # smartling.placeholder_format=C
 #. Instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -18763,8 +18723,7 @@ msgstr ""
 #. Tells users to make sure location services are enabled for thier browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Select %syour browser%s in the list and %sallow%s location access"
-msgstr ""
-"Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
+msgstr "Listeden %1$starayıcınızı%2$s seçin ve konum erişimine %3$sizin verin%4$s"
 
 # smartling.placeholder_format=C
 #. Text for a button that appears in the modal for deleting all recent chats, that allows the user to select the chats to delete.
@@ -19398,8 +19357,7 @@ msgstr "DuckAssist <sup>BETA'</sup>yı göster"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show DuckAssist more often. (You can also completely %sturn it off%s.)"
-msgstr ""
-"DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
+msgstr "DuckAssist'i daha sık göster. (Ayrıca tamamen %1$skapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button to show more of the list of search results from within the Duck.ai interface when a web search has been conducted
@@ -19516,8 +19474,7 @@ msgstr "Tüm sonuçları gösterin"
 #. A message that asks whether the user wants to enable DuckAssist more frequently or turn it off. Duckassist is a feature that generates answers to search queries based on relevant content found on the web. Placeholder are for markup, please ignore. Please do not translate DuckAssist.
 msgctxt "duckassist_optin"
 msgid "Show answers more often. (You can also %sturn them off%s.)"
-msgstr ""
-"Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
+msgstr "Yanıtları daha sık göster. (İsterseniz %1$sbunları kapatabilirsiniz%2$s.)"
 
 # smartling.placeholder_format=C
 #. Accessible label for the button that reveals a popover listing multiple citation sources in Duck.ai chat responses.
@@ -19583,8 +19540,7 @@ msgstr "Kenar çubuğunu göster"
 #. Description of the settings row that controls the Duck.ai onboarding tips / getting-started checklist.
 msgctxt "Settings row description"
 msgid "Show step-by-step tips for getting the most out of Duck.ai."
-msgstr ""
-"Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
+msgstr "Duck.ai'dan en iyi şekilde yararlanmak için adım adım ipuçlarını gösterin."
 
 # smartling.placeholder_format=C
 #. Tooltip/label for the button to show the voice chat transcript.
@@ -19678,14 +19634,12 @@ msgstr "En çok ziyaret edilen bağlantıları yeni sekme sayfasında gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Tarayıcınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
+msgstr "Cihazlarınıza DuckDuckGo'yu eklemeniz için zaman zaman anımsatıcılar gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19714,8 +19668,7 @@ msgstr "Siz yazarken arama kutusunun altında öneriler gösterir"
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows the privacy benefits of using DuckDuckGo on the homepage"
-msgstr ""
-"Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
+msgstr "Giriş sayfasında DuckDuckGo'nun gizlilik açısından avantajlarını gösterir"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19802,8 +19755,7 @@ msgstr "Site İsimleri"
 #. A message saying that site filters are not currently working
 msgctxt "Site filter message"
 msgid "Site search is temporarily unavailable. We are working on a fix."
-msgstr ""
-"Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
+msgstr "Site araması geçici olarak kullanılamıyor. Bir çözüm üzerinde çalışıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20039,8 +19991,7 @@ msgctxt "Error message when an uploaded image cannot be decoded or processed"
 msgid ""
 "Sorry, the uploaded image couldn't be processed. Please try a different "
 "image or format."
-msgstr ""
-"Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
+msgstr "Üzgünüz, yüklenen görsel işlenemedi. Farklı bir görsel veya format deneyin."
 
 # smartling.placeholder_format=C
 #. Body copy shown when a scanned or pasted pairing payload fails schema validation.
@@ -20074,8 +20025,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
+msgstr "Üzgünüz, geri bildiriminizi gönderemedik. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20129,8 +20079,7 @@ msgstr "Kaynak metin temizlendi"
 msgctxt "Error message for summary selection input limit"
 msgid ""
 "Source text is too long to summarize. Try again with a shorter selection."
-msgstr ""
-"Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
+msgstr "Kaynak metin özetlenemeyecek kadar uzun. Daha kısa bir seçimle tekrar dene."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under Interface Settings.in the end. It is a header
@@ -20390,8 +20339,7 @@ msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicileri engelleyin."
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "Stop most hidden trackers lurking on other websites."
-msgstr ""
-"Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
+msgstr "Diğer web sitelerinde sizi bekleyen gizli takip edicilerin çoğunu engelleyin."
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20815,8 +20763,7 @@ msgstr "Model değiştir"
 #. Displayed when the user hits a non-bypassable advanced-model fixed-window usage limit but can continue the conversation by switching to a configured free/degraded model. %s is the reset date/time formatted in the user's locale.
 msgctxt "Error message for fixed-window Duck.ai usage limit."
 msgid "Switch this chat to a free model or wait until %s."
-msgstr ""
-"Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
+msgstr "Bu sohbeti ücretsiz bir modele geçirin veya %1$s tarihine kadar bekleyin."
 
 # smartling.placeholder_format=C
 #. Button that switches the conversation to the second-opinion model. %s is the model name.
@@ -21481,8 +21428,7 @@ msgstr ""
 msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "The model provider deletes any data associated with this chat within 30 days."
-msgstr ""
-"Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
+msgstr "Model sağlayıcı, bu sohbetle ilişkili tüm verileri 30 gün içinde siler."
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers.
@@ -21651,8 +21597,7 @@ msgstr ""
 #. Appears below a type of search results called 'Instant Answers'
 msgctxt "attribution"
 msgid "This Instant Answer was made by the %sDuckDuckHack%s Community."
-msgstr ""
-"Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
+msgstr "Bu Anında Yanıt, %1$sDuckDuckHack%2$s Topluluğu tarafından hazırlanmıştır."
 
 # smartling.placeholder_format=C
 #. Label for the monthly usage row in the Usage section of Duck.ai settings.
@@ -21858,8 +21803,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Use the Fire Button in the side menu to delete "
 "it!"
-msgstr ""
-"Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
+msgstr "Bu sadece bir örnek sohbet. Silmek için yan menüdeki Fire Button'ı kullanın!"
 
 # smartling.placeholder_format=C
 #. Title shown when the scanned or pasted payload does not match the expected pairing format.
@@ -21993,8 +21937,7 @@ msgstr "Bu video henüz burada izlenemiyor. %1$s üzerinden izleyebilirsiniz."
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
+msgstr "Bu web sayfası, güvenli ve şifrelenmiş bir bağlantı (HTTPS) kullanmıyor."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -22014,8 +21957,7 @@ msgctxt "Body text for clear all recent chats confirmation modal"
 msgid ""
 "This will delete all your recent chats, unless they're pinned. This cannot "
 "be undone."
-msgstr ""
-"Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
+msgstr "Bu işlem, sabitlenmemiş tüm son sohbetlerinizi siler. Bu işlem geri alınamaz."
 
 # smartling.placeholder_format=C
 #. Message explaining what will happen when the user deletes an image.
@@ -22033,8 +21975,7 @@ msgstr "Tüm ayarlarınız silinecek. Devam edilsin mi?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
+msgstr "Kayıtlı tüm ayarlarınız varsayılan değerlere sıfırlanacak. Devam edilsin mi?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22108,8 +22049,7 @@ msgstr "İpuçları"
 
 # smartling.placeholder_format=C
 msgid "Tired of being tracked online? %sWe can help.%s"
-msgstr ""
-"İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
+msgstr "İnternette takip edilmekten bıktınız mı? %1$sSize yardımcı olabiliriz.%2$s"
 
 # smartling.placeholder_format=C
 #. This is the name of a user setting
@@ -22141,8 +22081,7 @@ msgstr ""
 msgctxt ""
 "Copy stating agreement to Duck.ai Privacy Policy and Terms of Service."
 msgid "To continue, you must agree to Duck.ai’s %s and %s"
-msgstr ""
-"Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
+msgstr "Devam etmek için Duck.ai'ın %1$s ve %2$skoşullarını kabul etmeniz gerekiyor"
 
 # smartling.placeholder_format=C
 #. Text stating agreement to AI Chat Privacy Policy and Terms of Service. Variables used to link to the Privacy Policy and Terms of Service content. Example: 'To continue, you must agree to DuckDuckGo AI Chat’s Privacy Policy and Terms of Service'
@@ -22215,8 +22154,7 @@ msgstr "Bugün"
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The two placeholders wrap a link-styled control ('disable in settings') that opens the 'Customize New Tab Page' menu.
 msgctxt "new tab page"
 msgid "Toggle to private AI chat or %sdisable in settings%s."
-msgstr ""
-"Gizli yapay zeka sohbetine geçin veya ayarlardan %1$sdevre dışı bırakın%2$s."
+msgstr "Gizli yapay zeka sohbetine geçin veya ayarlardan %1$sdevre dışı bırakın%2$s."
 
 # smartling.placeholder_format=C
 #. Headline of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box. The first and last placeholders wrap a link-styled control that opens the 'Customize New Tab Page' menu; the middle placeholder is filled with the localized NTP_CUSTOMIZE button label.
@@ -22290,7 +22228,7 @@ msgstr "Çok yavaş"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Oluşturulması çok yavaş"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22411,8 +22349,7 @@ msgstr ""
 #. Placeholder for when we cannot report any blocked trackers yet
 msgctxt "tracker_stats"
 msgid "Tracking attempts blocked by DuckDuckGo will appear here"
-msgstr ""
-"DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
+msgstr "DuckDuckGo tarafından engellenen izleme girişimleri burada görünecektir"
 
 # smartling.placeholder_format=C
 #. Tooltip and accessible label for the confirm (checkmark) button that stops recording and sends audio for transcription.
@@ -22579,8 +22516,7 @@ msgstr "Bu tür mesajları görmeyi durdurmak için %1$s'u deneyin."
 #. Text for a promotional card that encourages users to try the encrypted AI model whose inference runs in a confidential environment so the model provider cannot access user data. %s is replaced with the model's full display name (e.g. 'GPT-OSS 120B').
 msgctxt "Promotional text for encrypted AI model"
 msgid "Try %s, our first model with zero provider visibility."
-msgstr ""
-"Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
+msgstr "Sıfır sağlayıcı görünürlüğüne sahip ilk modelimiz olan %1$s modelini deneyin."
 
 # smartling.placeholder_format=C
 msgid "Try %sDuck.ai%s, our private AI chat service:"
@@ -22740,7 +22676,7 @@ msgstr "Daha az anahtar kelime deneyin."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Ücretsiz Deneyin"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -23098,8 +23034,7 @@ msgstr "Daha doğru sonuçlar için %1$sKesin Konum%2$s'u açın"
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
 msgid "Turn on Duck Player to watch YouTube without targeted ads"
-msgstr ""
-"YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
+msgstr "YouTube'u hedeflenmiş reklamlar olmadan izlemek için Duck Player'ı açın"
 
 # smartling.placeholder_format=C
 #. Button that enables the Search/Duck.ai toggle.
@@ -23117,8 +23052,7 @@ msgstr "Daha doğru sonuçlar için \"Kesin Konum\"u açın."
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on “Use precise location” for more accurate results."
-msgstr ""
-"Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
+msgstr "Daha doğru sonuçlar için \"Kesin konumu kullan\" özelliğini etkinleştirin."
 
 # smartling.placeholder_format=C
 #. Short description shown below the 'Create Image' label in the Tools dropdown.
@@ -23324,8 +23258,8 @@ msgstr ""
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
 msgstr ""
-"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: https://duckduckgo."
-"com"
+"%1$sBAŞLANGIÇ > Giriş sayfası%2$s bölümünde şunu girin: "
+"https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23359,8 +23293,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
+msgstr "Arama bölümündeki açılır menüye tıklayın ve %1$sDuckDuckGo%2$s'yu seçin"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23846,8 +23779,7 @@ msgstr "DuckDuckGo Private Search'ü kullanın"
 #. Explains that DuckDuckGo is available for multiple devices.
 msgctxt "mobile promotion on desktop"
 msgid "Use DuckDuckGo private search on your iPad, iPhone, or Android!"
-msgstr ""
-"iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
+msgstr "iPad', iPhone ya da Android'inizde DuckDuckGo private search'ü kullanın!"
 
 # smartling.placeholder_format=C
 #. User clicks this button to share their device's location
@@ -24454,8 +24386,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
+msgstr "En az birinin şifrelenmiş olması nedeniyle ekli dosyaları okuyamıyoruz."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24557,8 +24488,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "We don’t track you in or out of private browsing mode."
-msgstr ""
-"Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
+msgstr "Gizli gezinme modunu kullansanız da kullanmasınız da sizi takip etmiyoruz."
 
 # smartling.placeholder_format=C
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with an Agree button is shown below.
@@ -24657,8 +24587,7 @@ msgstr "Biz dahil hiç kimse arama geçmişinize ulaşamaz."
 #. Message that appears after submitting a feedback form.
 msgctxt "feedback form"
 msgid "We use feedback like this to improve DuckDuckGo."
-msgstr ""
-"Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
+msgstr "Bunun gibi geri bildirimleri DuckDuckGo'yu geliştirmek için kullanıyoruz."
 
 # smartling.placeholder_format=C
 #. Placeholder can be Apple Maps, TripAdvisor, and/or Foursquare
@@ -25393,8 +25322,7 @@ msgstr "<strong>%1$s</strong>Nerede İzlenir?"
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Where it says Homepage click %sSet to Current Page%s."
-msgstr ""
-"Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
+msgstr "Giriş sayfası yazan yerde %1$sMevcut Sayfaya Ayarla%2$s seçeneğine tıklayın."
 
 # smartling.placeholder_format=C
 #. Heading of a module showing what streaming services are showing a movie or series, e.g. Where to Watch The Matrix
@@ -25953,8 +25881,7 @@ msgstr "Bunu istediğin zaman %1$sArama Ayarları%2$s'ndan değiştirebilirsin"
 #. Displayed when the user has reached a fixed weekly Duck.ai usage limit. %s is the reset date/time formatted in the user's locale, e.g. 'May 7, 2026, 5:00 PM'.
 msgctxt "Error message for fixed-window Duck.ai usage limit"
 msgid "You can continue this chat when your limit resets on %s."
-msgstr ""
-"Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
+msgstr "Limitiniz %1$s tarihinde sıfırlandığında bu sohbete devam edebilirsiniz."
 
 # smartling.placeholder_format=C
 #. Text explaning how to change a passphrase.
@@ -25993,8 +25920,7 @@ msgstr "Aylık limiti kullanarak sohbet etmeye devam edebilirsiniz."
 #. Text displayed in a popover informing existing users that the chat save limit has been increased to 100.
 msgctxt "Popover text notifying users of increased chat limit from 30 to 100"
 msgid "You can now save up to 100 chats on this device. Chat away!"
-msgstr ""
-"Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
+msgstr "Artık bu cihazda 100'e kadar sohbeti kaydedebilirsiniz. Sohbete başlayın!"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user has attached more files than are allowed in a conversation. Placeholder is the maximum number of files. E.g. You can only attach 3 files per conversation
@@ -26281,8 +26207,7 @@ msgstr "Tek bir oturum için maksimum sesli sohbet süresine ulaştınız."
 msgctxt "voice chat limit modal"
 msgid ""
 "You've reached the voice chat limit for today. Please try again tomorrow."
-msgstr ""
-"Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
+msgstr "Bugünlük sesli sohbet limitinize ulaştınız. Lütfen yarın tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when dictation is blocked because the user's voice/shared budget is exhausted.
@@ -26347,8 +26272,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
+msgstr "Son %1$s sohbetiniz şu tarayıcılarda yerel depolama alanında saklanacaktır:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26540,8 +26464,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
+msgstr "Sohbetleriniz içeri aktarıldı. Hadi, Duck.ai'da kaldığınız yerden devam edin."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.
@@ -26588,8 +26511,7 @@ msgctxt ""
 "Subtitle of the one-time popover shown above the thumbs up/down buttons on "
 "an AI response"
 msgid "Your feedback is anonymized and not used to train AI."
-msgstr ""
-"Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
+msgstr "Geri bildiriminiz anonimleştirilmiş ve yapay zekayı eğitmek için kullanılmaz."
 
 # smartling.placeholder_format=C
 #. Explains that the User's Location is always private to DuckDuckGo.
@@ -26734,8 +26656,7 @@ msgctxt "Error message for input limit"
 msgid ""
 "You’ve exceeded the maximum message size. Please shorten your message and "
 "try again."
-msgstr ""
-"Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
+msgstr "Maksimum mesaj boyutunu aştınız. Lütfen mesajınızı kısaltıp tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.
@@ -26777,8 +26698,7 @@ msgstr ""
 #. Description shown when a subscribed user has reached their voice chat limit for now, and should try to come back again later.
 msgctxt "voice chat limit modal"
 msgid "You’ve reached the voice chat limit for now. Please try again later."
-msgstr ""
-"Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
+msgstr "Şimdilik sesli sohbet limitinize ulaştınız. Lütfen daha sonra tekrar deneyin."
 
 # smartling.placeholder_format=C
 #. The name of the Yucatec Maya language
@@ -26861,8 +26781,7 @@ msgstr "(bir %1$s ürünü)"
 #. Trust line shown at the bottom of the explainer panel, summarizing DuckDuckGo's reputation for online protection.
 msgctxt "Footer banner text in the How Duck.ai Works panel"
 msgid "by DuckDuckGo — online protection trusted by millions every day."
-msgstr ""
-"DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
+msgstr "DuckDuckGo'dan — her gün milyonlarca kişinin güvendiği çevrimiçi koruma."
 
 # smartling.placeholder_format=C
 #. An abreviated unit of time indicating an age, e.g. "2d"

--- a/locales/tr_TR/LC_MESSAGES/duckduckgo.po
+++ b/locales/tr_TR/LC_MESSAGES/duckduckgo.po
@@ -5235,7 +5235,7 @@ msgstr "Yarışma"
 #. Positive feedback category a user can select on the Search Assist feedback form, meaning the answer was complete.
 msgctxt "feedback form"
 msgid "Complete"
-msgstr "Tamamlandı"
+msgstr "Kapsamlı"
 
 # smartling.placeholder_format=C
 #. An option that completely disables the Assist feature.
@@ -5611,7 +5611,7 @@ msgstr "Telif hakkı ihlali"
 #. Soccer match stats
 msgctxt "Sports module"
 msgid "Corners"
-msgstr "Köşeler"
+msgstr "Kornerler"
 
 # smartling.placeholder_format=C
 #. Title of the Covid 19 module

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,16 +2,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -23,8 +22,7 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr ""
-"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -516,8 +514,7 @@ msgstr "%1$sДізнатися більше%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr ""
-"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -961,8 +958,7 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr ""
-"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1078,9 +1074,10 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
-"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
-"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на "
+"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
+"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
+"тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1981,8 +1978,7 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr ""
-"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2322,8 +2318,7 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr ""
-"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2540,11 +2535,10 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
-"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
-"релевантності) або «Часто» (відображається частіше у різних пошукових "
-"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
-"(англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
+"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
+"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"відповіді штучного інтелекту доступні лише в США (англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2976,6 +2970,9 @@ msgid ""
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
 msgstr ""
+"Перш ніж зберегти цю скаргу DuckDuckGo видалить завантажені файли та "
+"згенеровані зображення й анонімізує розмову, видаливши персональні дані, "
+"такі як імена, адреси електронної пошти та ідентифікаційні метадані."
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4289,8 +4286,7 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr ""
-"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4716,8 +4712,7 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr ""
-"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4833,8 +4828,7 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr ""
-"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4851,8 +4845,7 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr ""
-"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -6546,7 +6539,7 @@ msgstr "Не подобається джерело"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "Не подобається візуальний стиль"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6662,7 +6655,7 @@ msgstr "Джибуті"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "Не дотримується інструкцій"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7221,8 +7214,7 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr ""
-"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7266,10 +7258,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
-"«Іноді» (показується лише в разі високої релевантності) або "
-"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"DuckAssist доступний лише у США (англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
+"(показується лише в разі високої релевантності) або «Часто» (відображається "
+"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7329,8 +7321,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
-"сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
+"веб-сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7565,8 +7557,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
-"ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
+"Duck.ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7574,8 +7566,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7782,8 +7773,7 @@ msgstr "Редагувати повідомлення"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr ""
-"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7796,8 +7786,7 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr ""
-"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8073,8 +8062,7 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr ""
-"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8122,15 +8110,13 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr ""
-"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8345,8 +8331,7 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr ""
-"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8543,7 +8528,7 @@ msgstr "Швидко"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "Швидка генерація зображень"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8699,8 +8684,7 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr ""
-"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8737,8 +8721,7 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr ""
-"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8750,8 +8733,7 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr ""
-"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8878,7 +8860,7 @@ msgstr "Додаткові повідомлення залишаються пр�
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "Інструкції дотримано"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9230,22 +9212,19 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr ""
-"Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9306,8 +9285,7 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr ""
-"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9835,7 +9813,7 @@ msgstr "Гарна політика конфіденційності"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "Гарний візуальний стиль"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10700,8 +10678,7 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr ""
-"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10983,7 +10960,7 @@ msgstr "Запити щодо зображень повинні відповід
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "Якість зображення"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11576,8 +11553,7 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr ""
-"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -12037,8 +12013,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до Duck."
-"ai"
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
+"Duck.ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12253,8 +12229,7 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr ""
-"Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -14478,8 +14453,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
-"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте QR-"
-"код для відновлення у вашому PDF-файлі."
+"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте "
+"QR-код для відновлення у вашому PDF-файлі."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14605,8 +14580,7 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr ""
-"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14783,8 +14757,7 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr ""
-"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15173,8 +15146,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
-"адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
+"IP-адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15587,8 +15560,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15596,8 +15568,7 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr ""
-"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15611,8 +15582,7 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr ""
-"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15871,7 +15841,7 @@ msgstr "Погане форматування"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "Погана якість зображення"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16669,8 +16639,7 @@ msgstr "Обґрунтування може надавати кращі відп
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr ""
-"Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
+msgstr "Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -17046,8 +17015,7 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr ""
-"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -18002,8 +17970,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr ""
-"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18357,8 +18324,7 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr ""
-"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18576,21 +18542,18 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr ""
-"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr ""
-"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18801,8 +18764,7 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr ""
-"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -19053,8 +19015,7 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr ""
-"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19641,14 +19602,12 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr ""
-"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19692,8 +19651,7 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr ""
-"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19929,8 +19887,7 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr ""
-"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -20034,8 +19991,7 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr ""
-"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20920,8 +20876,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr ""
-"Sync & Backup зберігає більше ваших чатів і синхронізує їх на всіх пристроях."
+msgstr "Sync & Backup зберігає більше ваших чатів і синхронізує їх на всіх пристроях."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21597,8 +21552,7 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr ""
-"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21774,16 +21728,14 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr ""
-"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr ""
-"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21870,8 +21822,7 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr ""
-"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21958,8 +21909,7 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr ""
-"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21999,8 +21949,7 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr ""
-"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22251,7 +22200,7 @@ msgstr "Занадто повільно"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "Занадто повільно генерується"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22689,8 +22638,7 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr ""
-"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
@@ -22702,7 +22650,7 @@ msgstr "Спробуйте менше ключових слів."
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "Спробуйте безкоштовно"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22789,8 +22737,7 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr ""
-"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22825,8 +22772,7 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr ""
-"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -23059,8 +23005,7 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr ""
-"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23291,8 +23236,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr ""
-"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23302,8 +23246,7 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr ""
-"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23323,8 +23266,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr ""
-"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23463,8 +23405,7 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr ""
-"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23695,8 +23636,7 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr ""
-"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -24016,8 +23956,7 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr ""
-"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24134,8 +24073,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
-"код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
+"QR-код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24421,8 +24360,7 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr ""
-"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24487,8 +24425,7 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr ""
-"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24639,8 +24576,7 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr ""
-"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -25073,8 +25009,7 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr ""
-"Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25225,8 +25160,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
-"параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від "
+"URL-параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25301,8 +25236,7 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr ""
-"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -26136,8 +26070,7 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr ""
-"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26305,8 +26238,7 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr ""
-"Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
+msgstr "Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26435,8 +26367,7 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr ""
-"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26496,8 +26427,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr ""
-"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/uk_UA/LC_MESSAGES/duckduckgo.po
+++ b/locales/uk_UA/LC_MESSAGES/duckduckgo.po
@@ -2,15 +2,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 # smartling.gettext_line_width = normalized : 79
 # smartling.placeholder_format=C
@@ -22,7 +23,8 @@ msgstr "Пошукові ярлики !Bang"
 msgctxt ""
 "Body copy for the Remove Device confirmation modal; %s is the device name"
 msgid "\"%s\" will no longer be able to access your synced data."
-msgstr "\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
+msgstr ""
+"\"%1$s\" більше не зможе отримати доступ до ваших синхронізованих даних."
 
 # smartling.placeholder_format=C
 #. Used to specify the rank of a team/player in a specific ranking in short form. This should be interpreted as 'Ranked number <rankNumber> in the <rankingName> ranking. Here you only need to translate the # symbol for ranked number. If your language doesn't provide a single-letter convention, please leave #.
@@ -514,7 +516,8 @@ msgstr "%1$sДізнатися більше%2$s"
 msgctxt "Footer text for About Sync modal"
 msgid ""
 "%sLearn more%s about how chats are stored privately on DuckDuckGo's server."
-msgstr "%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
+msgstr ""
+"%1$sДокладніше%2$s про захищене зберігання чатів на сервері DuckDuckGo."
 
 # smartling.placeholder_format=C
 #. Text explaining that you can learn more about how recent chats work. Placeholders are for page markup to add links to 'Learn more'. Example: '<a>Learn more</a> about how chats are stored privately on your device.'
@@ -958,7 +961,8 @@ msgstr ""
 msgctxt "Body text for new version available modal"
 msgid ""
 "A new version of AI Chat is available! Please refresh this page to continue."
-msgstr "Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
+msgstr ""
+"Доступна нова версія чату AI Chat! Оновіть цю сторінку, щоб продовжити."
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of Duck.ai is available and they need to refresh the page.
@@ -1074,10 +1078,9 @@ msgid ""
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
 "Наразі можливість ставити подальші запитання штучному інтелекту не "
-"підтримується. Однак ми також пропонуємо і часто посилаємось на "
-"%1$sDuck.ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai "
-"— це наша служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic "
-"тощо."
+"підтримується. Однак ми також пропонуємо і часто посилаємось на %1$sDuck."
+"ai%2$s для отримання відповідей на уточнювальні запитання. Duck.ai — це наша "
+"служба приватних чатів із ШІ на базі моделей OpenAI, Anthropic тощо."
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1978,7 +1981,8 @@ msgstr "Дозволити анонімний перегляд файлів у �
 # smartling.placeholder_format=C
 #. Title in a dialog informing the user how to disable their ad blocker for DuckDuckGo
 msgid "Allow privacy-respecting ads on DuckDuckGo Private Search"
-msgstr "Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
+msgstr ""
+"Дозволити рекламу, що поважає конфіденційність, у DuckDuckGo Private Search"
 
 # smartling.placeholder_format=C
 #. Description explaining privacy implications of enabling web search on encrypted models. The first two placeholders are the full model name (e.g. 'gpt-oss 120B'). The third and fourth placeholders wrap a clickable link reading 'zero provider visibility' that opens the privacy modal, please keep those around the link text in your translation. An example full sentence would be: Allows gpt-oss 120B to search the web to improve responses to relevant prompts. Only sends AI-generated queries to a search engine with limited data retention. Prompts and responses with gpt-oss 120B still have zero provider visibility.
@@ -2318,7 +2322,8 @@ msgstr "Ти ще тут?"
 msgctxt "Body text for clear all chats confirmation modal"
 msgid ""
 "Are you sure you want to clear all of your chats? This cannot be undone."
-msgstr "Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
+msgstr ""
+"Ви впевнені, що бажаєте очистити всі ваші чати? Цю дію не можна скасувати."
 
 # smartling.placeholder_format=C
 #. Body text of the modal that asks the user if they want to clear the conversation.
@@ -2535,10 +2540,11 @@ msgstr ""
 "Assist може анонімно генерувати відповіді ШІ на деякі пошукові запити, "
 "узагальнюючи релевантний веб-контент. Можна вибрати частоту відображення "
 "Assist: «Ніколи» (повністю приховує інтерфейс Assist із результатів пошуку), "
-"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки «Assist» "
-"), «Іноді» (відображаються лише відповіді ШІ в разі високої релевантності) "
-"або «Часто» (відображається частіше у різних пошукових запитах). Наразі "
-"відповіді штучного інтелекту доступні лише в США (англійською)."
+"«На вимогу» (відображаються лише відповіді ШІ при натисканні кнопки "
+"«Assist» ), «Іноді» (відображаються лише відповіді ШІ в разі високої "
+"релевантності) або «Часто» (відображається частіше у різних пошукових "
+"запитах). Наразі відповіді штучного інтелекту доступні лише в США "
+"(англійською)."
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2958,6 +2964,18 @@ msgstr ""
 "Перш ніж зберегти цю скаргу, DuckDuckGo анонімізує розмову, видаливши ваші "
 "персональні дані, як-от імена, адреси електронної пошти та ідентифікаційні "
 "метадані."
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -4271,7 +4289,8 @@ msgstr "Перевірте сабреддіт DuckDuckGo, щоб дізнати�
 #. Displayed during an outage indicating where users can find information about the outage and watch for updates
 msgctxt "noresults"
 msgid "Check the status page for updates on this outage."
-msgstr "Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
+msgstr ""
+"Перевірте сторінку статусу на наявність оновлень щодо цього відключення."
 
 # smartling.placeholder_format=C
 #. Title shown to the host device (the one that is logged in) after it sends the pairing code. The host can't confirm the peer applied it, so this is a title-only screen (no body) prompting the user to finish on the other device.
@@ -4697,7 +4716,8 @@ msgstr "Оберіть %1$sНалаштування%2$s з меню вибору
 # smartling.placeholder_format=C
 #. Tells the user how to make DuckDuckGo their home page.
 msgid "Click %sUse current pages%s then %sClick OK%s."
-msgstr "Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
+msgstr ""
+"Натисніть %1$sВикористати поточні сторінки%2$s, потім натисніть %3$sОК%4$s."
 
 #  Firefox 33 / SeaMonkey homepage instruction
 # smartling.placeholder_format=C
@@ -4813,7 +4833,8 @@ msgstr "Натисніть на вкладку %1$sЗагальні%2$s."
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Click the %sellipsis icon%s in the toolbar."
-msgstr "Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
+msgstr ""
+"Клацніть на %1$sпіктограмі у вигляді трьох точок%2$s в панелі інструментів."
 
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to enable location service. Part of a list of instructions on how to enable location service.
@@ -4830,7 +4851,8 @@ msgstr "Натисніть %1$sзначок дозволів%2$s в адресн
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to search using DuckDuckGo.
 msgid "Click the Duck icon at the top of your browser to search!"
-msgstr "Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
+msgstr ""
+"Натисніть на зображення качки у верхній частині браузера, щоб почати пошук!"
 
 #  UC Browser on Android
 # smartling.placeholder_format=C
@@ -6521,6 +6543,12 @@ msgid "Dislike source"
 msgstr "Не подобається джерело"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Відхилити"
@@ -6629,6 +6657,12 @@ msgstr "Статистика по дивізіонам"
 # smartling.placeholder_format=C
 msgid "Djibouti"
 msgstr "Джибуті"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -7187,7 +7221,8 @@ msgstr "Duck.ai оновлено!"
 #. Main body text of the RetentionBrowserPromo horizontal banner encouraging users to download the DuckDuckGo browser.
 msgctxt "Promotional banner body text"
 msgid "Duck.ai works best in our private and free DuckDuckGo app!"
-msgstr "Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
+msgstr ""
+"Duck.ai найкраще працює в конфіденційному й безкоштовному додатку DuckDuckGo!"
 
 # smartling.placeholder_format=C
 #. Meta keywords content for Duck.ai.
@@ -7231,10 +7266,10 @@ msgstr ""
 "У відповідь на деякі пошукові запити DuckAssist іноді анонімно шукає та "
 "узагальнює інформацію. Можна вибрати частоту відображення DuckAssist: "
 "«Ніколи» (повністю приховує інтерфейс DuckAssist із результатів пошуку), «На "
-"вимогу» (відображається лише при натисканні кнопки «Допомога»), «Іноді» "
-"(показується лише в разі високої релевантності) або «Часто» (відображається "
-"частіше у різних пошукових запитах). Наразі DuckAssist доступний лише у США "
-"(англійською)."
+"вимогу» (відображається лише при натисканні кнопки «Допомога»), "
+"«Іноді» (показується лише в разі високої релевантності) або "
+"«Часто» (відображається частіше у різних пошукових запитах). Наразі "
+"DuckAssist доступний лише у США (англійською)."
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7294,8 +7329,8 @@ msgstr ""
 "основі штучного інтелекту. Відповіді DuckAssist завжди містять пряме "
 "посилання на одне або два джерела відповіді, тому ви можете швидко знайти "
 "більш детальну інформацію. Важливо пам'ятати, що відповіді автоматично "
-"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих "
-"веб-сторінках%2$s."
+"генеруються із зазначених джерел і ґрунтуються на %1$sвідсканованих веб-"
+"сторінках%2$s."
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7530,8 +7565,8 @@ msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
 msgstr ""
-"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s "
-"Duck.ai."
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з %2$s Duck."
+"ai."
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7539,7 +7574,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
+msgstr ""
+"DuckDuckGo анонімізує чати. Натиснувши «%1$s», ви погоджуєтесь з нашими %2$s."
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7746,7 +7782,8 @@ msgstr "Редагувати повідомлення"
 #. Title text shown for an assistant response that contains an edited image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Edited image. Cost %s (internal only)"
-msgstr "Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Відредаговане зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is editing an image.
@@ -7759,7 +7796,8 @@ msgstr "Редагування зображення..."
 msgctxt "Info text for the editing message feature"
 msgid ""
 "Editing your message will remove the response below and generate a new one."
-msgstr "Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
+msgstr ""
+"Редагування вашого повідомлення видалить відповідь нижче та згенерує нову."
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of an editor in its responses.
@@ -8035,7 +8073,8 @@ msgstr "Користуєтеся Duck.ai?"
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure %s'Allow'%s is selected for the 'Location' setting."
-msgstr "Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
+msgstr ""
+"Переконайтеся, що для параметра 'Розташування' вибрано %1$s'Дозволити'%2$s."
 
 # smartling.placeholder_format=C
 #. Tells users to make sure location services are enabled on their device. Part of a list of instructions on how to enable location service.
@@ -8083,13 +8122,15 @@ msgstr "Переконайтеся, що доступ до розташуван�
 #. Tells users how to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s"
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s"
 
 # smartling.placeholder_format=C
 #. Tells users how to enable location service.
 msgctxt "precise_user_location"
 msgid "Ensure your browser is allowed %slocation access%s."
-msgstr "Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
+msgstr ""
+"Переконайтеся, що вашому браузеру дозволено %1$sдоступ до розташування%2$s."
 
 # smartling.placeholder_format=C
 #. Tells how to enable location service. Part of a list of instructions on how to enable location service.
@@ -8304,7 +8345,8 @@ msgstr "Поясніть прийняту відповідь простими с
 msgctxt "Full sentence for understanding a topic"
 msgid ""
 "Explain the fundamental concepts of black holes to me at a high-school level."
-msgstr "Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
+msgstr ""
+"Поясніть мені фундаментальні концепції чорних дір на рівні середньої школи."
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Explain the top answer", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -8498,6 +8540,12 @@ msgid "Fast"
 msgstr "Швидко"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8651,7 +8699,8 @@ msgstr "Відфільтровує створені ШІ зображення з
 msgctxt "settings"
 msgid ""
 "Filters out AI-generated images from image search results. %sLearn more%s"
-msgstr "Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
+msgstr ""
+"Відфільтровує створені ШІ зображення з результатів пошуку. %1$sДокладніше%2$s"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -8688,7 +8737,8 @@ msgstr "Фінансовий радник"
 # smartling.placeholder_format=C
 #. Tells users where to click in their browser to change the default search engine.
 msgid "Find %sDuckDuckGo%s and click%sMake default%s"
-msgstr "Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
+msgstr ""
+"Знайдіть %1$sDuckDuckGo%2$s та натисніть%3$sВибрати за замовчуванням%4$s"
 
 # smartling.placeholder_format=C
 #. Sentence shown after export, includes a placeholder for one or more filenames with bold formatting for the filename(s).
@@ -8700,7 +8750,8 @@ msgstr "Знайдіть <b>%1$s</b> у папці завантажень"
 # smartling.placeholder_format=C
 #. Tells users how to change their default search engine to DuckDuckGo.
 msgid "Find DuckDuckGo in the displayed list and click %sMake Default%s"
-msgstr "Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
+msgstr ""
+"Знайдіть DuckDuckGo у списку і натисніть %1$sОбрати за замовчуванням%2$s"
 
 # smartling.placeholder_format=C
 #. Short string representing a prompt suggestion for finding a better word.
@@ -8822,6 +8873,12 @@ msgstr "Додаткове запитання"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "Додаткові повідомлення залишаються приватними."
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -9173,19 +9230,22 @@ msgstr "Загальне призначення"
 #. Text with short description for an AI (Artificial Intelligence) Model that has a high moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with high built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою високою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою високою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a low moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with low built-in moderation"
-msgstr "Штучний інтелект загального призначення з вбудованою низькою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення з вбудованою низькою модерацією"
 
 # smartling.placeholder_format=C
 #. Text with short description for an AI (Artificial Intelligence) Model that has a medium moderation level. 'Built-in' in that sentence means that the moderation is part of the model.
 msgctxt "Label copy with short description of AI Model"
 msgid "General purpose AI with medium built-in moderation"
-msgstr "Штучний інтелект загального призначення із вбудованою середньою модерацією"
+msgstr ""
+"Штучний інтелект загального призначення із вбудованою середньою модерацією"
 
 # smartling.placeholder_format=C
 #. Text indicating that the AI (Artificial Intelligence) model is a model for general purpose use. General-purpose AI refers to AI systems that can perform a wide range of tasks, rather than being specialized for a specific task.
@@ -9246,7 +9306,8 @@ msgstr "Згенероване зображення"
 #. Title text shown for an assistant response that contains a generated image. Shown to internal users only
 msgctxt "Assistant response title"
 msgid "Generated image. Cost %s (internal only)"
-msgstr "Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
+msgstr ""
+"Згенероване зображення. Вартість %1$s (лише для внутрішнього використання)"
 
 # smartling.placeholder_format=C
 #. Aria label for the carousel (list of generated images) in the image generation mode.
@@ -9769,6 +9830,12 @@ msgstr "Хороший дизайн"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "Гарна політика конфіденційності"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10633,7 +10700,8 @@ msgctxt "Full sentence for preparing for a conversation"
 msgid ""
 "How should I tactfully approach a colleague about their constant pencil "
 "tapping and what should I say?"
-msgstr "Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
+msgstr ""
+"Як тактовно попросити колегу перестати постійно стукати олівцем по столу?"
 
 # smartling.placeholder_format=C
 #. The title for a feedback prompt that includes thumbs up and thumbs down buttons
@@ -10910,6 +10978,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "Запити щодо зображень повинні відповідати %1$s Duck.ai"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -11502,7 +11576,8 @@ msgstr "Приєднуйтесь до нашої команди!"
 # smartling.placeholder_format=C
 msgctxt "showcase_donate"
 msgid "Join our $500,000 Privacy Challenge"
-msgstr "Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
+msgstr ""
+"Приєднуйтеся до нашого змагання з приватності із призовим фондом у $500 000"
 
 # smartling.placeholder_format=C
 msgid "Jordan"
@@ -11962,8 +12037,8 @@ msgctxt "new tab page"
 msgid ""
 "Lets you switch between submitting search queries and prompts to Duck.ai"
 msgstr ""
-"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до "
-"Duck.ai"
+"Дозволяє перемикатися між надсиланням пошукових запитів та промптів до Duck."
+"ai"
 
 # smartling.placeholder_format=C
 msgid "Liberia"
@@ -12178,7 +12253,8 @@ msgstr "Завантаження..."
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Loads more image and video results when scrolling"
-msgstr "Завантаження інших результатів для зображень та відео при прокручуванні"
+msgstr ""
+"Завантаження інших результатів для зображень та відео при прокручуванні"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -14402,8 +14478,8 @@ msgid ""
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
 "На іншому пристрої перейдіть у %1$s«Налаштування Duck.ai»%2$s › %3$s«Чати» › "
-"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте "
-"QR-код для відновлення у вашому PDF-файлі."
+"Sync & Backup › «Синхронізувати з іншим пристроєм»%4$s. Або відскануйте QR-"
+"код для відновлення у вашому PDF-файлі."
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14529,7 +14605,8 @@ msgstr "Відкрити вебсайт %1$s"
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open %sLocation%s, and ensure location is %senabled%s"
-msgstr "Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
+msgstr ""
+"Відкрийте %1$s«Розташування»%2$s і переконайтеся, що воно %3$sувімкнене%4$s"
 
 #  Chrome/Firefox on Android/iOS
 # smartling.placeholder_format=C
@@ -14706,7 +14783,8 @@ msgstr "Відкрити панель «Як працює Duck.ai»"
 #. Tells how to find the settings menu in their browser. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Open the Safari menu and select %sSettings for DuckDuckGo...%s"
-msgstr "Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
+msgstr ""
+"Відкрийте меню Safari та виберіть %1$sНалаштування для DuckDuckGo...%2$s"
 
 # smartling.placeholder_format=C
 #. Label for the time a business opens. For example: 'Opens at 10am'
@@ -15095,8 +15173,8 @@ msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
 msgstr ""
-"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу "
-"IP-адресу, відбиток браузера чи інші дані з файлом."
+"Неможливо відновити парольні фрази, оскільки ми не пов'язуємо вашу IP-"
+"адресу, відбиток браузера чи інші дані з файлом."
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15509,7 +15587,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this prompt was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей запит здійснено людиною."
 
 # smartling.placeholder_format=C
 #. Bot challenge explanation
@@ -15517,7 +15596,8 @@ msgctxt "Anomaly modal"
 msgid ""
 "Please complete the following challenge to confirm this search was made by a "
 "human."
-msgstr "Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
+msgstr ""
+"Виконайте наступне завдання, щоб підтвердити, що цей пошук здійснено людиною."
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
@@ -15531,7 +15611,8 @@ msgstr ""
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content when sharing the prompt and response with DuckDuckGo
 msgctxt "Feedback prompt"
 msgid "Please describe why the chat response is illegal or harmful. (Optional)"
-msgstr "Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
+msgstr ""
+"Поясніть, чому відповідь у чаті є незаконною або небезпечною. (Необов'язково)"
 
 # smartling.placeholder_format=C
 #. A prompt asking users to enter their passphrase.
@@ -15785,6 +15866,12 @@ msgstr "Польська"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "Погане форматування"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16582,7 +16669,8 @@ msgstr "Обґрунтування може надавати кращі відп
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but takes longer and uses limits 2-5x faster. <a>Learn More</a>'.
 msgctxt "Usage warning in the reasoning mode dropdown"
 msgid "Reasoning is more thorough, but reaches usage limits 2-5x sooner. %s"
-msgstr "Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
+msgstr ""
+"Поглиблена логіка, але досягає лімітів використання у 2–5 разів швидше. %1$s"
 
 # smartling.placeholder_format=C
 #. Non-dismissible banner at the top of the reasoning mode dropdown. Warns that reasoning modes consume usage limits more quickly. The placeholder is a 'Learn More' link to a help page about usage limits. Example: 'Reasoning is more thorough, but uses limits 2-5x faster. <a>Learn More</a>'.
@@ -16958,7 +17046,8 @@ msgstr "Запам'ятати вибір"
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings
 msgid "Remember my choice (this can be changed in %s%s%sSettings%s)"
-msgstr "Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
+msgstr ""
+"Запам'ятати мій вибір (це можна змінити в %1$s%2$s%3$sНалаштуваннях%4$s)"
 
 # smartling.placeholder_format=C
 #. Button that saves the user's current settings. The placehoder is to wrap Settings in a link.
@@ -17913,7 +18002,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Scroll down to the %sServices%s section and click %sAddress bar%s."
-msgstr "Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
+msgstr ""
+"Прокрутіть вниз до розділу %1$sСервіси%2$s та клацніть %3$sПанель адреси%4$s."
 
 # smartling.placeholder_format=C
 #. Rugby match stats
@@ -18267,7 +18357,8 @@ msgstr "Друга думка"
 #. Description shown in the Sync & Backup settings section when sync is not yet enabled, explaining the feature.
 msgctxt "Description for sync and backup feature"
 msgid "Securely save and sync your chats across all your devices."
-msgstr "Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
+msgstr ""
+"Безпечно зберігайте та синхронізуйте твої чати на всіх своїх пристроях."
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18485,18 +18576,21 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Instructions to add a search engine in Microsoft Edge
 msgid "Select %sDuckDuckGo%s and click %sAdd as default%s!"
-msgstr "Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
+msgstr ""
+"Оберіть %1$sDuckDuckGo%2$s та клацніть %3$sВстановити за замовчуванням%4$s!"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s"
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
 #. Tells users how to add DuckDuckGo to the list of search engines in their browser.
 msgid "Select %sDuckDuckGo%s and click %sSet as default%s."
-msgstr "Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
+msgstr ""
+"Виберіть %1$sDuckDuckGo%2$s і натисніть %3$sВстановити за замовчуванням%4$s."
 
 #  Firefox 33
 # smartling.placeholder_format=C
@@ -18707,7 +18801,8 @@ msgstr "Вибраний текст із %1$s"
 #. Displayed when the user's text selection exceeds the maximum message size for AI tools (summary, translation, etc.).
 msgctxt "Error message for selection input limit"
 msgid "Selected text is too long. Try again with a shorter selection."
-msgstr "Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
+msgstr ""
+"Вибраний текст занадто довгий. Спробуйте ще раз, вибравши коротший фрагмент."
 
 # smartling.placeholder_format=C
 #. Label for the semi-finals knockout stage in e.g. the soccer World Cup
@@ -18958,7 +19053,8 @@ msgstr "Поділитися"
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
 msgid "Share DuckDuckGo and help friends take their privacy back!"
-msgstr "Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
+msgstr ""
+"Розкажіть про DuckDuckGo та допоможіть вашим друзям повернути приватність!"
 
 # smartling.placeholder_format=C
 #. Text displayed on a button that opens a feedback modal when clicked.
@@ -19545,12 +19641,14 @@ msgstr "Показує найпопулярніші посилання у нов
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your browser"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo до вашого браузера"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows occasional reminders to add DuckDuckGo to your devices"
-msgstr "Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
+msgstr ""
+"Показує періодичні нагадування про додавання DuckDuckGo на ваших пристроях"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -19594,7 +19692,8 @@ msgstr "Показує привітальне повідомлення вгор�
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid "Shows welcome message to EU Android preference menu users"
-msgstr "Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
+msgstr ""
+"Показує привітальне повідомлення користувачам з меню налаштувань Android в ЄС"
 
 # smartling.placeholder_format=C
 #. An option that shows AI-assisted answers sometimes.
@@ -19830,7 +19929,8 @@ msgstr "Щось пішло не так при збереженні на сер�
 #. Body copy displayed under the Set Up Now button when the sync setup call fails.
 msgctxt "Generic error shown when sync setup fails"
 msgid "Something went wrong while enabling Sync & Backup. Please try again."
-msgstr "Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
+msgstr ""
+"Сталася помилка під час увімкнення функції Sync & Backup. Повторіть спробу."
 
 # smartling.placeholder_format=C
 #. Displayed when the voice chat session ends with an unknown error.
@@ -19934,7 +20034,8 @@ msgstr ""
 #. The main message for when the feedback form failed to send. For example, if the user lost connectivity.
 msgctxt "feedback form"
 msgid "Sorry, we weren’t able to submit your feedback. Please try again later."
-msgstr "На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
+msgstr ""
+"На жаль, нам не вдалося надіслати ваш відгук. Будь ласка, спробуйте пізніше."
 
 # smartling.placeholder_format=C
 #. Error message header displayed when Duck.ai will not process an uploaded image (e.g., bad image).
@@ -20819,7 +20920,8 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Sync & Backup saves more of your chats and syncs them across all of your "
 "devices."
-msgstr "Sync & Backup зберігає більше ваших чатів і синхронізує їх на всіх пристроях."
+msgstr ""
+"Sync & Backup зберігає більше ваших чатів і синхронізує їх на всіх пристроях."
 
 # smartling.placeholder_format=C
 #. Reuses the existing Sync Another Device pairing modal stack.
@@ -21495,7 +21597,8 @@ msgctxt "AI Chat: Error message for when a model is removed"
 msgid ""
 "This AI model is no longer available. Try starting a new chat with a "
 "different model."
-msgstr "Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
+msgstr ""
+"Ця модель ШІ більше не доступна. Спробуйте почати новий чат з іншою моделлю."
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is no longer supported because it has been upgraded to a newest version.
@@ -21671,14 +21774,16 @@ msgstr "Це зображення не вдалося створити."
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF"
-msgstr "Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
+msgstr ""
+"Цей тип зображення не підтримується, прикріпіть файл JPG, PNG, WebP або GIF"
 
 # smartling.placeholder_format=C
 #. Error message displayed when a file that the user tried to upload is not of a supported format
 msgctxt "Error message when an uploaded file is not the right format"
 msgid ""
 "This image type is not supported, please attach a JPG,  PNG, WebP, or GIF."
-msgstr "Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
+msgstr ""
+"Цей тип зображення не підтримується. Додайте файл JPG, PNG, WebP або GIF."
 
 # smartling.placeholder_format=C
 #. Given as an option to select when providing feedback
@@ -21765,7 +21870,8 @@ msgstr "Для роботи цієї сторінки необхідний Javas
 #. Information tooltip text explaining that the current page's content will be included with the chat message.
 msgctxt "Tooltip explaining that page content will be sent to Duck.ai"
 msgid "This page's content will be sent with your message to Duck.ai"
-msgstr "Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
+msgstr ""
+"Вміст цієї сторінки буде надіслано до Duck.ai разом із вашим повідомленням"
 
 # smartling.placeholder_format=C
 #. Category of feedback a user can select on a feedback form.
@@ -21852,7 +21958,8 @@ msgstr ""
 #. Message indicating that a website is not using an encrypted connection and is not secure.
 msgctxt "Lock icon next to HTTP search result"
 msgid "This webpage does not use a secure, encrypted, connection (HTTPS)."
-msgstr "Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
+msgstr ""
+"Ця вебсторінка не використовує захищене, зашифроване, з'єднання (HTTPS)."
 
 # smartling.placeholder_format=C
 #. Text explaining that disabling chat history will delete chats from this browser and disconnect Sync & Backup, but chats remain accessible from other connected browsers.
@@ -21892,7 +21999,8 @@ msgstr "Це зітре усі налаштування. Продовжити?"
 #. Confirmation message asking if the user is sure they want to reset all of their settings.
 msgctxt "settings"
 msgid "This will reset your saved settings to default values. Continue?"
-msgstr "Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
+msgstr ""
+"Це призведе до скидання ваших налаштувань до стандартних значень. Продовжити?"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard column: holes completed in current round
@@ -22138,6 +22246,12 @@ msgstr "Занадто багато результатів із цього дж�
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "Занадто повільно"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -22575,13 +22689,20 @@ msgstr "Спробуйте увімкнути анонімне розташув�
 msgctxt "Onboarding pick a chat model screen subtitle"
 msgid ""
 "Try experimenting with each model — they will provide different responses."
-msgstr "Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
+msgstr ""
+"Спробуйте поекспериментувати з кожною моделлю — вони дадуть різні відповіді."
 
 # smartling.placeholder_format=C
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Спробуйте менше ключових слів."
+
+# smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22668,7 +22789,8 @@ msgstr "Спробуйте наш браузер,"
 # smartling.placeholder_format=C
 #. Link to a version of the DuckDuckGo homepage that doesn't show any promotional messages.
 msgid "Try our homepage that never shows these messages:"
-msgstr "Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
+msgstr ""
+"Спробуйте нашу домашню сторінку, яка ніколи не показує ці повідомлення:"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time; shown in the US. Invites the user to start a free trial of the paid subscription.
@@ -22703,7 +22825,8 @@ msgstr "Спробуйте налаштувати ваше розташуван�
 #. Body text in a popover encouraging the user to try the DuckDuckGo browser
 msgctxt "Browser Promo Popover"
 msgid "Try the %sDuckDuckGo Browser.%s Fast. Free. Private."
-msgstr "Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
+msgstr ""
+"Спробуйте браузер %1$sDuckDuckGo.%2$s Швидко. Безплатно. Конфіденційно."
 
 # smartling.placeholder_format=C
 #. Link to a page where users can download the DuckDuckGo Browser for iOS or Android.
@@ -22936,7 +23059,8 @@ msgstr "Вимкнути:"
 #. Tells users which setting to change to enable location service. Part of a list of instructions on how to enable location service.
 msgctxt "precise_user_location"
 msgid "Turn on %sPrecise Location%s for more accurate results"
-msgstr "Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
+msgstr ""
+"Увімкніть «%1$sТочне розташування%2$s» для отримання точніших результатів"
 
 # smartling.placeholder_format=C
 #. A headline letting the user choose between two video player options
@@ -23167,7 +23291,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid "Under %sSTARTUP > Homepage%s enter: https://duckduckgo.com"
-msgstr "В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
+msgstr ""
+"В меню %1$sЗАПУСК > Домашня сторінка%2$s введіть: https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
@@ -23177,7 +23302,8 @@ msgstr "В %1$sНалаштуваннях пошуку%2$s оберіть %3$sDu
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine.
 msgid "Under %sSearch in the address bar with%s select %sAdd New%s"
-msgstr "В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
+msgstr ""
+"В розділі %1$sПошук в адресному рядку%2$s виберіть %3$sДодати новий%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -23197,7 +23323,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Tells users where in the settings menu they can change their default search engine
 msgid "Under Search click the drop down and select %sDuckDuckGo%s"
-msgstr "Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
+msgstr ""
+"Під рядком пошуку натисніть на випадне меню та виберіть %1$sDuckDuckGo%2$s"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Look & Feel Settings" header
@@ -23336,7 +23463,8 @@ msgctxt ""
 "Text shown in the subscription promo card, with a trailing call-to-action "
 "link."
 msgid "Unlock more capable AI models with a DuckDuckGo subscription. %s"
-msgstr "Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
+msgstr ""
+"Розблокуйте більше потужних моделей ШІ, підписавшись на DuckDuckGo. %1$s"
 
 # smartling.placeholder_format=C
 #. Copy on the sticky pill at the bottom of the mobile search results page that promotes the DuckDuckGo subscription. One of several messages rotated over time. 'Premium protections' are the paid subscription features.
@@ -23567,7 +23695,8 @@ msgstr ""
 #. Upsell message shown in the voice chat limit and duration limit modals for Plus subscribers, encouraging them to upgrade to Pro.
 msgctxt "voice chat limit modal"
 msgid "Upgrade to Pro to unlock 2x higher usage limits than Plus"
-msgstr "Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
+msgstr ""
+"Переходьте на план Pro, щоб розблокувати вдвічі вищі ліміти, ніж у плані Plus"
 
 # smartling.placeholder_format=C
 #. Heading in a promotion for a desktop web browser
@@ -23887,7 +24016,8 @@ msgstr "Переглянути ціни на проживання"
 # smartling.placeholder_format=C
 #. A description for the ads tooltip that explains that viewing ads is privacy protected by DuckDuckGo.
 msgid "Viewing ads is privacy protected by DuckDuckGo."
-msgstr "Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
+msgstr ""
+"Перегляд оголошень виконується із захистом конфіденційності DuckDuckGo."
 
 # smartling.placeholder_format=C
 msgctxt "Ads GDPR, internal use only. Do not change"
@@ -24004,8 +24134,8 @@ msgid ""
 msgstr ""
 "Відвідайте сайт Duck.ai в іншому браузері або в додатку DuckDuckGo та "
 "відкрийте налаштування Duck.ai. Виберіть «Увімкнути» у розділі «Sync & "
-"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте "
-"QR-код у PDF-файлі для відновлення."
+"Backup» та виберіть «Синхронізувати з іншим пристроєм». Або відскануйте QR-"
+"код у PDF-файлі для відновлення."
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -24291,7 +24421,8 @@ msgstr ""
 msgctxt "Error message when at least one attached file is encrypted"
 msgid ""
 "We can't read the files attached because at least one of them is encrypted."
-msgstr "Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
+msgstr ""
+"Не вдається зчитати додані файли, оскільки принаймні один із них зашифровано."
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -24356,7 +24487,8 @@ msgstr "Ми ніколи не стежимо за вами."
 #. Shown when a user arrives with a prompt in the URL but has not yet agreed to the Duck.ai terms of service. The pending prompt is shown as a chat bubble above this header, and a decision card with a Continue button is shown below.
 msgctxt "Header above terms-of-service decision card on Duck.ai"
 msgid "We don't track you. That's our Privacy Policy in a nutshell."
-msgstr "Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
+msgstr ""
+"Ми не відстежуємо вас. Це наша Політика конфіденційності, якщо коротко."
 
 # smartling.placeholder_format=C
 #. Description for the audio identification highlight in the dictation consent modal.
@@ -24507,7 +24639,8 @@ msgstr ""
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
 msgid "We'll block trackers trying to collect your data as you browse."
-msgstr "Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
+msgstr ""
+"Трекери, що намагаються збирати ваші дані під час перегляду, блокуватимуться."
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information.
@@ -24940,7 +25073,8 @@ msgstr "Які страви тут варто скуштувати?"
 msgctxt "Page suggestion prompt"
 msgid ""
 "What are the opening hours, location, and contact details for this place?"
-msgstr "Які години роботи, місцезнаходження та контактна інформація цього місця?"
+msgstr ""
+"Які години роботи, місцезнаходження та контактна інформація цього місця?"
 
 # smartling.placeholder_format=C
 #. Prompt sent to the AI when the user taps the "What are the pros and cons?" page-suggestion chip.
@@ -25091,8 +25225,8 @@ msgid ""
 "What is the Cloud Save bookmarklet and how does it differ from the URL "
 "parameter bookmarklet?"
 msgstr ""
-"Що таке збережена в хмарі закладка і чим вона відрізняється від "
-"URL-параметрів?"
+"Що таке збережена в хмарі закладка і чим вона відрізняється від URL-"
+"параметрів?"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for looking up the capital city of Albania.
@@ -25167,7 +25301,8 @@ msgstr "Про що б ви хотіли залишити відгук?"
 #. Explains the benefits of using our custom video player, the Duck Player
 msgid ""
 "What you watch in DuckDuckGo won't influence your recommendations on YouTube."
-msgstr "Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
+msgstr ""
+"Те, що ви дивитеся в DuckDuckGo, не вплине на ваші рекомендації на YouTube."
 
 # smartling.placeholder_format=C
 #. A link to a page that provides the latest updates on DuckDuckGo products. (https://duckduckgo.com/updates/)
@@ -26001,7 +26136,8 @@ msgstr ""
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
 msgid "You won't see this message again unless you clear your browser data."
-msgstr "Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
+msgstr ""
+"Ви більше не побачите це повідомлення, якщо не очистите дані свого браузера."
 
 # smartling.placeholder_format=C
 #. The second paragraph of a pop up where we explain how to update the browser manually.
@@ -26169,7 +26305,8 @@ msgctxt ""
 msgid ""
 "Your %s most recent chats will be available in local storage on these "
 "browsers:"
-msgstr "Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
+msgstr ""
+"Ваші %1$s останні чати будуть доступні у локальному сховищі на цих браузерах:"
 
 # smartling.placeholder_format=C
 #. Tells the user their chats are being kept in sync privately. 'End-to-end encryption' means only the user's own devices can read the data.
@@ -26298,7 +26435,8 @@ msgstr ""
 #. Text for a promotional card that informs users that their chats with the AI model are private and are never saved or used to train AI models.
 msgctxt "Promotional text emphasizing privacy of user chats"
 msgid "Your chats are private, and are never used to train AI models"
-msgstr "Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
+msgstr ""
+"Ваші чати є приватними і ніколи не використовуються для навчання моделей ШІ"
 
 # smartling.placeholder_format=C
 #. Text for a description of the active privacy protection for DuckDuckGo's AI Chat feature.
@@ -26358,7 +26496,8 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats have been imported. Go ahead and pick up where you left off in "
 "Duck.ai."
-msgstr "Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
+msgstr ""
+"Ваші чати імпортовано. Продовжуйте з того місця, де ви зупинилися у Duck.ai."
 
 # smartling.placeholder_format=C
 #. Body copy shown on the joiner device's success screen after a successful pairing.

--- a/locales/ur_PK/LC_MESSAGES/duckduckgo.po
+++ b/locales/ur_PK/LC_MESSAGES/duckduckgo.po
@@ -2372,6 +2372,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5215,6 +5226,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr ""
@@ -5304,6 +5320,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6761,6 +6782,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7016,6 +7042,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7763,6 +7794,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8687,6 +8723,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12625,6 +12666,11 @@ msgstr ""
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17668,6 +17714,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18026,6 +18077,11 @@ msgstr ""
 #. A prompt asking users to try searching with fewer words.
 msgctxt "noresults"
 msgid "Try fewer keywords."
+msgstr ""
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
 msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.

--- a/locales/vi_VN/LC_MESSAGES/duckduckgo.po
+++ b/locales/vi_VN/LC_MESSAGES/duckduckgo.po
@@ -2378,6 +2378,17 @@ msgid ""
 "removing PII like names, email addresses, and identifying metadata."
 msgstr ""
 
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
+
 #. Label that's displayed next to a past start date below a web search result.
 msgctxt "Rich Facts label"
 msgid "Began"
@@ -5247,6 +5258,11 @@ msgctxt "Feedback prompt"
 msgid "Dislike source"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "Huỷ bỏ"
@@ -5336,6 +5352,11 @@ msgid "Division Record"
 msgstr ""
 
 msgid "Djibouti"
+msgstr ""
+
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
 msgstr ""
 
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6809,6 +6830,11 @@ msgctxt "Label for fast reasoning mode in Duck.ai"
 msgid "Fast"
 msgstr ""
 
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -7063,6 +7089,11 @@ msgstr ""
 #. Explains that messages added after the shared copy remain private to the person continuing the chat.
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
 msgstr ""
 
 #. Link to DuckDuckGo's Twitter profile.
@@ -7810,6 +7841,11 @@ msgstr ""
 #. A positive feedback suggestion saying the feature has a good privacy policy
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
+msgstr ""
+
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
 msgstr ""
 
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -8741,6 +8777,11 @@ msgstr ""
 msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
+msgstr ""
+
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
 msgstr ""
 
 msgctxt "settingsvalue"
@@ -12697,6 +12738,11 @@ msgstr "Tiếng Ba Lan"
 #. A negative feedback suggestion about the responses provided by the AI (Artificial Intelligence) chat bot having poor text formatting
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
+msgstr ""
+
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
 msgstr ""
 
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -17769,6 +17815,11 @@ msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr ""
 
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
+
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
 msgctxt ""
 "Label and tooltip for the Tools dropdown button in the Duck.ai chat input "
@@ -18128,6 +18179,11 @@ msgstr ""
 msgctxt "noresults"
 msgid "Try fewer keywords."
 msgstr "Hãy thử ít từ khóa hơn."
+
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
 
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,7 +189,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -198,7 +200,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
+msgstr ""
+"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
+"者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,7 +217,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
+msgstr ""
+"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
+"或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -323,7 +329,9 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
+msgstr ""
+"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
+"响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -437,7 +445,8 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -446,7 +455,9 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr ""
+"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
+"定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -915,7 +926,8 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr ""
+"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -973,8 +985,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
-"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
+"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
+"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1035,8 +1048,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
-"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
+"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
+"OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1805,7 +1819,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
+msgstr ""
+"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
+"你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1927,8 +1943,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
-"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
+"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2093,7 +2109,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr ""
+"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2310,7 +2327,9 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
+msgstr ""
+"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
+"护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2452,9 +2471,11 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
-"Assist "
-"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
+"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
+"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
+"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2466,8 +2487,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist "
-"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
+"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
+"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
+"通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2492,7 +2515,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-Fi 环境下隐藏你的 IP 地址。"
+msgstr ""
+"无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-"
+"Fi 环境下隐藏你的 IP 地址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2637,7 +2662,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
+"Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2645,7 +2672,9 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr ""
+"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
+"搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2850,7 +2879,21 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
+msgstr ""
+"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
+"份信息，对你的对话进行匿名化处理。"
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2979,7 +3022,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
+msgstr ""
+"订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3238,20 +3282,26 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
+"还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
+"蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr ""
+"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
+"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3358,15 +3408,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
-"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
+"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
+"也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
+"之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3374,7 +3427,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
+msgstr ""
+"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
+"使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3872,9 +3927,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
-"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
+"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
+"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4016,7 +4072,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr "聊天记录采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
+msgstr ""
+"聊天记录采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有"
+"人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4024,7 +4082,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
+msgstr ""
+"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
+"史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4036,8 +4096,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
+"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4059,7 +4120,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr ""
+"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
+"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4418,7 +4481,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr ""
+"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
+"在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4427,7 +4492,9 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr ""
+"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
+"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4444,8 +4511,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
-"等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
+"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4486,7 +4553,9 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
+msgstr ""
+"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
+"项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4516,7 +4585,9 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
+msgstr ""
+"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
+"标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4606,7 +4677,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr ""
+"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
+"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4616,7 +4689,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr ""
+"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
+"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4684,7 +4759,9 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5344,7 +5421,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr "从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备同步%2$s”并重试。"
+msgstr ""
+"从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备"
+"同步%2$s”并重试。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6077,7 +6156,9 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr "删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的副本。"
+msgstr ""
+"删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的"
+"副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6190,7 +6271,8 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr ""
+"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6320,6 +6402,12 @@ msgid "Dislike source"
 msgstr "不喜欢资料来源"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "隐藏"
@@ -6430,6 +6518,12 @@ msgid "Djibouti"
 msgstr "吉布提"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6514,7 +6608,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
+msgstr ""
+"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
+"AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6523,8 +6619,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
-"生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
+"掉 AI 生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6806,7 +6902,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
+msgstr ""
+"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
+"你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6815,7 +6913,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
+msgstr ""
+"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
+"序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6838,7 +6938,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
+"希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6852,7 +6954,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6866,7 +6970,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
+"%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6886,7 +6992,9 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr ""
+"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
+"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6897,9 +7005,10 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
-"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
+"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
+"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
+"使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6960,8 +7069,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
+"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
+"AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6989,10 +7099,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
-"DuckAssist "
-"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
-"目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
+"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
+"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
+"示）。DuckAssist 目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7001,8 +7111,9 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
-"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
+"模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7011,8 +7122,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
+"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7024,10 +7135,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
-"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
+"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
+"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
+"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
+"实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7041,10 +7152,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
-"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
+"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
+"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
+"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
+"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7067,7 +7179,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7075,7 +7189,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
+"和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7091,7 +7207,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
+msgstr ""
+"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
+"%1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7254,14 +7372,18 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
+msgstr ""
+"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
+"来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
+"%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7269,7 +7391,8 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr ""
+"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7277,7 +7400,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr ""
+"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
+"踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7289,8 +7414,9 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo "
-"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
+"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
+"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7309,7 +7435,8 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr ""
+"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7401,8 +7528,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
-"个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
+"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7657,7 +7784,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
+msgstr ""
+"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
+"信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7857,7 +7986,8 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr ""
+"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8197,6 +8327,12 @@ msgid "Fast"
 msgstr "快速"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8248,7 +8384,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
+msgstr ""
+"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
+"题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8510,6 +8648,12 @@ msgid "Follow-ups remain private."
 msgstr "后续问题会保密。"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
 msgctxt "new user poll"
 msgid "Following us on Twitter"
@@ -8724,8 +8868,9 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
-"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
+"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
+"择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9011,8 +9156,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 "
+"Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9104,8 +9249,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以"
+"及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9113,7 +9258,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服务。"
+msgstr ""
+"获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服"
+"务。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9121,7 +9268,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9131,7 +9280,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
+msgstr ""
+"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
+"其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9174,7 +9325,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多高级保护功能。"
+msgstr ""
+"获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多"
+"高级保护功能。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9183,15 +9336,16 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
-"Restoration 服务。"
+"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 "
+"Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
+msgstr ""
+"获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9291,8 +9445,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
-"与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
+"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9301,8 +9455,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9312,8 +9466,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9323,8 +9477,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
-"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
+"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9332,7 +9486,8 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr "前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
+msgstr ""
+"前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9354,7 +9509,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
+"%3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9421,6 +9578,12 @@ msgstr "优秀的设计"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "良好的隐私政策"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10068,7 +10231,9 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
+msgstr ""
+"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
+"设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10081,7 +10246,9 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
+msgstr ""
+"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
+"护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10432,7 +10599,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
+msgstr ""
+"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
+"隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10442,8 +10611,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
-"DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
+"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10457,7 +10626,8 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr ""
+"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10465,7 +10635,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
+msgstr ""
+"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
+"%2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10473,7 +10645,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
+msgstr ""
+"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
+"以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10488,7 +10662,9 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
+msgstr ""
+"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
+"本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10533,6 +10709,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "图像提示必须符合 Duck.ai %1$s。"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10635,7 +10817,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
+msgstr ""
+"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
+"露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10645,7 +10829,8 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr ""
+"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10659,7 +10844,9 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
+msgstr ""
+"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
+"体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11064,8 +11251,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
-"不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
+"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -13121,8 +13308,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
-"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
+"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
+"回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13956,7 +14144,9 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
+msgstr ""
+"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
+"置%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13964,7 +14154,9 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”"
+msgstr ""
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
+"设备同步%4$s”"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13972,7 +14164,9 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”并扫描此代码："
+msgstr ""
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
+"设备同步%4$s”并扫描此代码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13981,8 +14175,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。或者扫描恢复 "
-"PDF 中的二维码。"
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
+"设备同步%4$s”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14379,7 +14573,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
+msgstr ""
+"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
+"单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14392,7 +14588,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护功能。一站式订阅服务。"
+msgstr ""
+"我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护"
+"功能。一站式订阅服务。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14406,7 +14604,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
+msgstr ""
+"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
+"现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14658,7 +14858,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
+msgstr ""
+"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
+"令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14813,7 +15015,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr "Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然后，我们会努力为你将其删除。"
+msgstr ""
+"Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然"
+"后，我们会努力为你将其删除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14883,7 +15087,9 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr ""
+"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
+"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14892,8 +15098,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
+"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14903,8 +15109,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
-"%1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
+"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14944,7 +15150,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr ""
+"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15100,7 +15307,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
+"或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15108,7 +15317,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
+msgstr ""
+"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
+"或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15317,6 +15528,12 @@ msgstr "波兰语"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "格式不佳"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16163,7 +16380,8 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16171,7 +16389,8 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr ""
+"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16180,7 +16399,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr ""
+"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
+"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16461,7 +16682,9 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
+msgstr ""
+"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
+"新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16568,14 +16791,18 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
+"答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
+msgstr ""
+"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
+"缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16638,14 +16865,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
+msgstr ""
+"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
+"供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
+"息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16653,7 +16884,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr ""
+"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
+"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16744,7 +16977,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
+"的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16752,7 +16987,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
+msgstr ""
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
+"我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16762,8 +16999,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
-"受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
+"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17187,7 +17424,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
+msgstr ""
+"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
+"录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17359,7 +17598,9 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
+msgstr ""
+"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
+"添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17367,7 +17608,9 @@ msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
+msgstr ""
+"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
+"%5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17453,10 +17696,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist "
-""
-"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
-"Assist 目前仅供部分英语地区使用。"
+"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
+"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
+"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
+"示）。Search Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17472,8 +17715,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist "
-"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
+"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17593,7 +17836,8 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr ""
+"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17611,7 +17855,9 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
+msgstr ""
+"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
+"%1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17630,8 +17876,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
-"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
+"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
+"且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17733,7 +17980,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17741,7 +17990,9 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
+"访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17749,7 +18000,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
+msgstr ""
+"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
+"步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17757,7 +18010,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
+msgstr ""
+"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
+"关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17771,7 +18026,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
+msgstr ""
+"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
+"到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -17985,14 +18242,16 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr ""
+"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18177,7 +18436,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
+msgstr ""
+"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
+"的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18405,7 +18666,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
+msgstr ""
+"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
+"能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18506,7 +18769,8 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr ""
+"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18554,7 +18818,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或关闭。"
+msgstr ""
+"使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或"
+"关闭。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18917,14 +19183,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
+"会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
+msgstr ""
+"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
+"会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20247,7 +20517,8 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
+"法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -20259,7 +20530,8 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
+"将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20397,7 +20669,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
+msgstr ""
+"随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调"
+"用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20405,7 +20679,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
+msgstr ""
+"随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能"
+"快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20648,7 +20924,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
+msgstr ""
+"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
+"行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20664,7 +20942,9 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr "Duck.ai 开关让你可以在私密搜索和 AI 聊天之间快速切换，由 DuckDuckGo 进行匿名化处理。"
+msgstr ""
+"Duck.ai 开关让你可以在私密搜索和 AI 聊天之间快速切换，由 DuckDuckGo 进行匿名"
+"化处理。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20772,7 +21052,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr ""
+"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20804,7 +21085,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
+msgstr ""
+"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
+"为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20887,7 +21170,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
+"准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20896,7 +21181,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
+msgstr ""
+"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
+"令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20904,7 +21191,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
+msgstr ""
+"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
+"的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20914,8 +21203,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
-"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
+"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -20931,7 +21220,9 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr "此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留在本地存储中。"
+msgstr ""
+"此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留"
+"在本地存储中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21036,7 +21327,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
+msgstr ""
+"这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记"
+"录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21064,7 +21357,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
+msgstr ""
+"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21072,7 +21367,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
+msgstr ""
+"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
+"保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21108,7 +21405,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
+msgstr ""
+"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
+"之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21116,7 +21415,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
+msgstr ""
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21126,8 +21427,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
-"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
+"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
+"示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21178,8 +21480,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
-"的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
+"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21324,7 +21626,8 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr ""
+"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21333,7 +21636,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
+msgstr ""
+"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
+"式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21341,7 +21646,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
+msgstr ""
+"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
+"试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21437,6 +21744,12 @@ msgstr "太多结果来自此资料来源"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "太慢了"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21549,7 +21862,8 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr ""
+"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -21873,6 +22187,12 @@ msgid "Try fewer keywords."
 msgstr "尝试减少关键词数量。"
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22081,7 +22401,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
+"置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22089,7 +22411,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
+msgstr ""
+"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
+"设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22289,7 +22613,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
+msgstr ""
+"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
+"出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22418,14 +22744,16 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr ""
+"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr ""
+"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22540,7 +22868,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
+"的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22922,7 +23252,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
+msgstr ""
+"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
+"司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23106,7 +23438,9 @@ msgctxt "duckai_seo"
 msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
-msgstr "查看来自 Duck.ai 的共享聊天记录，这是 DuckDuckGo 提供的免费、私密人工智能聊天工具。将其保存到你的聊天记录中，并继续私密对话。"
+msgstr ""
+"查看来自 Duck.ai 的共享聊天记录，这是 DuckDuckGo 提供的免费、私密人工智能聊天"
+"工具。将其保存到你的聊天记录中，并继续私密对话。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23148,7 +23482,8 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr ""
+"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23198,8 +23533,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23209,8 +23544,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
+"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23220,8 +23555,9 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
+"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
+"步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23231,8 +23567,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
-"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
+"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
+"中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23433,7 +23770,9 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
+msgstr ""
+"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
+"YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23453,8 +23792,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
-"没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
+"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23477,7 +23816,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
+"DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23488,7 +23829,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
+msgstr ""
+"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
+"复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23541,7 +23884,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
+"踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23549,7 +23894,9 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
+msgstr ""
+"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
+"跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23613,7 +23960,8 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr "我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
+msgstr ""
+"我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23653,7 +24001,8 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr ""
+"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23661,7 +24010,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr "我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我们的进度。"
+msgstr ""
+"我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我"
+"们的进度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23687,7 +24038,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
+msgstr ""
+"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
+"正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23700,7 +24053,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr "我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有关你的任何信息。"
+msgstr ""
+"我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有"
+"关你的任何信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23708,7 +24063,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -23716,7 +24072,8 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr ""
+"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -23859,7 +24216,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
+"于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23867,7 +24226,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
+"理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23877,8 +24238,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
-"绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
+"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24010,8 +24371,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
-"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
+"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
+"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24546,7 +24908,9 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
+msgstr ""
+"使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时"
+"在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24850,7 +25214,8 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr ""
+"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -24894,7 +25259,8 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr ""
+"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25069,7 +25435,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
+msgstr ""
+"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
+"额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25077,7 +25445,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
+msgstr ""
+"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
+"DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25098,7 +25468,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25107,7 +25479,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr ""
+"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
+"存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25134,7 +25508,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
+msgstr ""
+"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
+"的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25222,8 +25598,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
-"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
+"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25233,8 +25609,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
-"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
+"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25247,7 +25623,9 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
+msgstr ""
+"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
+"Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25315,7 +25693,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25324,7 +25704,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr ""
+"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
+"览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25363,7 +25745,8 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr ""
+"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25388,14 +25771,16 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr ""
+"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25423,7 +25808,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
+msgstr ""
+"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
+"按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25462,7 +25849,9 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
+msgstr ""
+"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
+"message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25505,8 +25894,9 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
-"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
+"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
+"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25520,7 +25910,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
+msgstr ""
+"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
+"无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25564,7 +25956,9 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
+msgstr ""
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No "
+"AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25573,8 +25967,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
-"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
+"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25601,7 +25995,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
+msgstr ""
+"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
+"多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_CN/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_CN/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或"
-"者切换到 Plus 或免费模型。"
+msgstr "%1$s 仅限 Pro 订户使用。请在此浏览器中再次升级 DuckDuckGo 订阅以继续聊天，或者切换到 Plus 或免费模型。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，"
-"或切换到免费模式。"
+msgstr "%1$s 仅限 DuckDuckGo 订阅用户使用。在这个浏览器中重新激活你的订阅以继续聊天，或切换到免费模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -329,9 +323,7 @@ msgid ""
 "%s runs in a Trusted Execution Environment. This means not even the model "
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
-msgstr ""
-"%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的"
-"响应，也不会在其服务器上保存此聊天记录。"
+msgstr "%1$s 在可信执行环境中运行。这意味着即使是模型提供商也无法查看您的提示或模型的响应，也不会在其服务器上保存此聊天记录。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -445,8 +437,7 @@ msgstr "%1$s点击%2$s添加%3$s勾选%4$s允许%5$s，然后点击%6$s确定%7$
 #. Instructions on what buttons the user has to click in order to add the DuckDuckGo extension to their browser.
 msgctxt "install-duckduckgo"
 msgid "%sClick %sAllow%sClick %sAdd%sCheck %sAllow%s, then click %sOkay%s"
-msgstr ""
-"%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
+msgstr "%1$s点击%2$s允许%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # Firefox
 # smartling.placeholder_format=C
@@ -455,9 +446,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确"
-"定%9$s"
+msgstr "%1$s点击%2$s继续安装%3$s点击%4$s添加%5$s勾选%6$s允许%7$s，然后点击%8$s确定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -926,8 +915,7 @@ msgstr "客场"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
+msgstr "网络问题导致 Search Assist 无法生成答案。请检查网络连接，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -985,9 +973,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 "
-"DuckDuckGo Search 中的 AI Chat 功能。关闭此设置后，仍可以通过访问 "
-"%1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
+"可以利用 AI Chat 与第三方人工智能聊天模型进行匿名对话。关闭此功能将隐藏 DuckDuckGo Search 中的 AI Chat "
+"功能。关闭此设置后，仍可以通过访问 %1$sduckduckgo.com/aichat%2$s 来使用 AI Chat。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1048,9 +1035,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s 并"
-"通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 "
-"OpenAI 和 Anthropic 等公司的聊天模型。"
+"人工智能辅助的答案目前不直接支持后续问题。不过，我们还提供 %1$sDuck.ai%2$s "
+"并通常会与其链接来解答后续问题，这是我们基于人工智能的私人聊天服务，支持 OpenAI 和 Anthropic 等公司的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1819,9 +1805,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用"
-"你的对话来训练聊天模型"
+msgstr "DuckDuckGo 会对所有聊天内容进行匿名处理，并且 DuckDuckGo 或模型提供方不会使用你的对话来训练聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1943,8 +1927,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给"
-"数据留存期有限的搜索引擎。%2$s 的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
+"允许 %1$s 搜索网络，以改善对相关提示的回复质量。仅将人工智能生成的查询发送给数据留存期有限的搜索引擎。%2$s "
+"的提示和回复仍然%3$s完全不会向提供商显示%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2109,8 +2093,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
+msgstr "根据网页内容匿名生成搜索查询答案。你可以选择该功能的显示频率，或完全关闭它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2327,9 +2310,7 @@ msgstr "截至"
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保"
-"护隐私。"
+msgstr "根据我们的隐私协议，我们本身不会收集或传播任何隐私信息，仅会立足于你的设备保护隐私。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2471,11 +2452,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可"
-"以选择显示 Assist 的频率：从不（从搜索结果中完全移除 Assist 用户界面)、按需"
-"（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人"
-"工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案"
-"目前仅供美国（英语）地区使用。"
+"Assist 可以在总结相关网页内容的基础上，为某些搜索匿名生成人工智能辅助答案。可以选择显示 Assist 的频率：从不（从搜索结果中完全移除 "
+"Assist "
+"用户界面)、按需（仅在点击“Assist”按钮时显示人工智能辅助的答案）、有时（仅在高度相关时显示人工智能辅助的答案）或经常（在更广泛的搜索中更频繁地显示）。人工智能辅助的答案目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2487,10 +2466,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答"
-"案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，"
-"根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并"
-"通过%1$s爬取网络内容%2$s自动生成。"
+"Assist "
+"是我们搜索结果中的一项可选功能，可以匿名生成人工智能辅助的搜索查询答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2515,9 +2492,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-"
-"Fi 环境下隐藏你的 IP 地址。"
+msgstr "无论是在咖啡馆、机场还是酒店，DuckDuckGo VPN 都能加密你的网络连接，并在 Wi-Fi 环境下隐藏你的 IP 地址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2662,9 +2637,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。"
-"Assist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 Assist。Assist 可以匿名查找和汇总信息，以响应某些搜索。Assist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2672,9 +2645,7 @@ msgid ""
 "Automatically shows DuckAssist for relevant searches. DuckAssist can "
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
-msgstr ""
-"为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些"
-"搜索。DuckAssist 目前仅供英语地区使用。"
+msgstr "为相关搜索自动显示 DuckAssist。DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。DuckAssist 目前仅供英语地区使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2879,9 +2850,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身"
-"份信息，对你的对话进行匿名化处理。"
+msgstr "在存储此报告之前，DuckDuckGo 会通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2893,7 +2862,7 @@ msgid ""
 "Before storing this report, DuckDuckGo will remove uploaded files and "
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "在存储此报告之前，DuckDuckGo 会删除上传的文件和生成的图片，并通过删除姓名、电子邮件地址和识别元数据等个人身份信息，对你的对话进行匿名化处理。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3022,8 +2991,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
+msgstr "订阅我们的服务即可屏蔽有害网站、隐藏你的 IP 地址，并解锁更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3282,26 +3250,20 @@ msgstr "浏览文件"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，"
-"还能屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，让我们来保护你的隐私。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏"
-"蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们的 %1$s%2$s 扩展 %3$s 中预置了搜索引擎，还能屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即"
-"可匿名搜索、屏蔽跟踪程序、开启网站加密。"
+msgstr "正常上网，剩下的交给我们。我们为 %1$s 主流浏览器 %2$s 提供了扩展，一键下载即可匿名搜索、屏蔽跟踪程序、开启网站加密。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3408,18 +3370,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 "
-"Cloud Save 功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令"
-"也只有浏览器知道。"
+"默认情况下，设置存储在浏览器 Cookie 中，不含隐私信息。你也可以使用匿名的 Cloud Save "
+"功能把设置长期存放在我们的云服务器上，同样不会泄露隐私，使用的口令也只有浏览器知道。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用"
-"之前，请参阅我们的%1$s。"
+msgstr "启用听写，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3427,9 +3386,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始"
-"使用之前，请参阅我们的%1$s。"
+msgstr "启用语音聊天，即表示你同意将自己的语音数据发送给 OpenAI，以使用此功能。在开始使用之前，请参阅我们的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3927,10 +3884,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿"
-"名对话，该功能支持 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
-"DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过"
-"访问 %1$shttps://duck.ai%2$s 来使用聊天功能。 "
+"可以利用聊天功能（通过我们的 Duck.ai 服务提供）与第三方人工智能聊天模型进行匿名对话，该功能支持 OpenAI、Anthropic "
+"等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 上的聊天按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用聊天功能。 "
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4072,9 +4028,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
-"聊天记录采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有"
-"人可以看到你的数据，甚至我们也不行。"
+msgstr "聊天记录采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4082,9 +4036,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历"
-"史记录会删除已置顶的聊天记录。"
+msgstr "聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或远程服务器上。禁用聊天历史记录会删除已置顶的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4096,9 +4048,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删"
-"除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
+"聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4120,9 +4071,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审"
-"核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
+msgstr "与 %1$s 的聊天内容对提供商完全不可见，但上传到 Duck.ai 的所有文件均会由内容审核提供商以匿名方式进行审核，以检查是否包含 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4481,9 +4430,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者"
-"在超过 7 天未使用 AI Chat 后自动将其删除。"
+msgstr "清除浏览器数据会删除聊天记录。某些浏览器可能会无限期保留最近的聊天记录，或者在超过 7 天未使用 AI Chat 后自动将其删除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4492,9 +4439,7 @@ msgid ""
 "Clearing browser data deletes recent chats. Recent chats may be saved "
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
-msgstr ""
-"清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近"
-"期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
+msgstr "清除浏览器数据会删除近期聊天记录。在不使用 Duck.ai 的情况下，可以无限期保存近期聊天记录，或在 7 天后自动删除，具体取决于浏览器的设置。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4511,8 +4456,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密"
-"人工智能聊天服务支持 OpenAI、Anthropic 等聊天模型。"
+"点击“更多”以深入了解某个主题，并通过 %1$sDuck.ai%2$s 提出后续问题，我们的私密人工智能聊天服务支持 OpenAI、Anthropic "
+"等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4553,9 +4498,7 @@ msgstr "在弹出的菜单中点击 %1$s更改搜索设置%2$s"
 msgid ""
 "Click %sEdit > Preferences%s (on Windows) %sSeaMonkey > Preferences%s (on "
 "Mac)"
-msgstr ""
-"Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选"
-"项%4$s"
+msgstr "Windows 系统点击 %1$s编辑 > 首选项%2$s，Mac 系统点击 %3$sSeaMonkey > 首选项%4$s"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4585,9 +4528,7 @@ msgstr "在左侧的列表中点击 %1$s隐私和服务%2$s。"
 msgid ""
 "Click %sSafari%s in the top menu (On Windows, click the %sgears icon%s in "
 "the top right)"
-msgstr ""
-"在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图"
-"标%4$s）"
+msgstr "在顶部菜单栏中点击 %1$sSafari 浏览器%2$s（Windows 系统点击右上角的 %3$s齿轮图标%4$s）"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4677,9 +4618,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻"
-"触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
+msgstr "点击或轻触“%1$s删除我的数据%2$s”，即可删除来自云端的数据，但只要不点击／轻触“%3$s重置所有搜索设置%4$s”，相关数据就会一直保留在浏览器中。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4689,9 +4628,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设"
-"置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
+msgstr "点击“%1$s删除我的数据%2$s”即可将云端的数据删除，但只要不点击“%3$s恢复初始设置%4$s”，从云端同步的设置就会一直保留在浏览器中。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4759,9 +4696,7 @@ msgstr "点击搜索栏中的下拉菜单"
 msgid ""
 "Click the dropdown menu beside %sSearch engine used in the address bar%s and "
 "select %sDuckDuckGo%s."
-msgstr ""
-"点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "点击 %1$s在地址栏中使用的搜索引擎%2$s 旁边的下拉菜单，选择 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. First step in a list of steps to take to disable the user's ad blocker
@@ -5421,9 +5356,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
-"从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备"
-"同步%2$s”并重试。"
+msgstr "从其他设备复制代码。前往“%1$sDuck.ai 设置 › 聊天 › Sync & Backup › 与其他设备同步%2$s”并重试。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6156,9 +6089,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的"
-"副本。"
+msgstr "删除链接会导致该链接失效。已打开对话并将其添加到自己聊天中的人，将保留各自的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6271,8 +6202,7 @@ msgstr "暂时无法使用听写功能"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
+msgstr "听写功能使用 OpenAI 模型将语音转为文本，因此无需输入便可以在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6405,7 +6335,7 @@ msgstr "不喜欢资料来源"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "不喜欢视觉风格"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6521,7 +6451,7 @@ msgstr "吉布提"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "未遵循指令"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6608,9 +6538,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 "
-"AI 生成的图像。 %3$s了解详情%4$s"
+msgstr "不想使用人工智能？%1$snoai.duckduckgo.com%2$s 不提供任何 AI 功能，并会筛选掉 AI 生成的图像。 %3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6619,8 +6547,8 @@ msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
 msgstr ""
-"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤"
-"掉 AI 生成的图像。%3$s了解详情%4$s"
+"不想使用 AI？请访问 %1$snoai.duckduckgo.com%2$s 以在搜索时禁用 AI 功能并过滤掉 AI "
+"生成的图像。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6902,9 +6830,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非"
-"你选择在设置中自动附加页面。"
+msgstr "Duck.ai 现在可以帮助回答你正在浏览的页面问题。页面内容仅在你附加时纳入，除非你选择在设置中自动附加页面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6913,9 +6839,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程"
-"序再试一次。"
+msgstr "Duck.ai 无法访问本地存储来保存您的聊天记录。请检查浏览器设置或禁用任何扩展程序再试一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6938,9 +6862,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何"
-"希望重新掌控自己个人信息的人。"
+msgstr "Duck.ai 由 DuckDuckGo 创建。我们是一家独立的在线安全保护公司，致力于帮助任何希望重新掌控自己个人信息的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6954,9 +6876,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 的产品，但现在将拥有一个更容易记住的网站主页：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6970,9 +6890,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 "
-"%2$s"
+msgstr "暂时无法使用 Duck.ai。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6992,9 +6910,7 @@ msgctxt "settings"
 msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
-msgstr ""
-"Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链"
-"接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
+msgstr "Duck.ai 让你能够私密地与热门 AI 模型进行对话。禁用后将隐藏 Duck.ai 按钮和链接，但你仍然可以直接访问 %1$sduck.ai%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7005,10 +6921,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、"
-"Anthropic 等公司的模型。关闭此设置将隐藏 DuckDuckGo Search 中的 Duck.ai 按钮"
-"和链接。不过，即使关闭该设置，仍然可以直接通过访问 %1$shttps://duck.ai%2$s 来"
-"使用 Duck.ai。"
+"可以利用 Duck.ai 与第三方人工智能聊天模型进行匿名对话，包括来自 OpenAI、Anthropic 等公司的模型。关闭此设置将隐藏 "
+"DuckDuckGo Search 中的 Duck.ai 按钮和链接。不过，即使关闭该设置，仍然可以直接通过访问 "
+"%1$shttps://duck.ai%2$s 来使用 Duck.ai。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7069,9 +6984,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需"
-"注册的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 "
-"AI、无需账户的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私人 AI 聊天机器人、免费 AI 聊天、匿名 AI 聊天、无需注册的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、开源 AI 模型、注重隐私的 AI、无需账户的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7099,10 +7013,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示"
-"频率：从不（从搜索结果中完全移除 DuckAssist 用户界面)、按需（仅在点击“协助”按"
-"钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显"
-"示）。DuckAssist 目前仅供美国（英语）地区使用。"
+"DuckAssist 可以匿名查找和汇总信息，以响应某些搜索。可以选择 DuckAssist 的显示频率：从不（从搜索结果中完全移除 "
+"DuckAssist "
+"用户界面)、按需（仅在点击“协助”按钮时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中更频繁地显示）。DuckAssist "
+"目前仅供美国（英语）地区使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7111,9 +7025,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天"
-"模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 %1$sDuckDuckGo AI "
+"Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持包括 OpenAI 和 Anthropic 在内的多种聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7122,8 +7035,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这"
-"是一种人工智能驱动的私密聊天服务，支持 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 无法回答后续问题，但是，我们还提供 DuckDuckGo %1$sAI Chat%2$s，这是一种人工智能驱动的私密聊天服务，支持 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7135,10 +7048,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该"
-"功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生"
-"成这些信息的摘要。 请注意，其回复目前基于维基百科和相关内容，其准确性未经核"
-"实。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项新功能，可以匿名生成搜索查询的答案。为此，该功能会扫描维基百科和相关网站的相关内容，然后使用人工智能驱动的自然语言技术生成这些信息的摘要。 "
+"请注意，其回复目前基于维基百科和相关内容，其准确性未经核实。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7152,11 +7065,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，"
-"该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的"
-"相关信息生成简短的答案。DuckAssist 的回复始终直接链接到一个或两个资料来源，并"
-"注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资"
-"料来源，并通过%1$s爬取网络内容%2$s自动生成。"
+"DuckAssist "
+""
+"是我们搜索结果中的一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会扫描网络上的相关内容，然后使用人工智能驱动的自然语言技术，根据找到的相关信息生成简短的答案。DuckAssist "
+"的回复始终直接链接到一个或两个资料来源，并注明答案的出处，以便你轻松获取更详细的信息。请务必记住，这些回复来自引用的资料来源，并通过%1$s爬取网络内容%2$s自动生成。"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7179,9 +7091,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7189,9 +7099,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s "
-"和 %3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一种私密人工智能驱动型聊天服务，目前支持 %1$s 的 %2$s 和 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7207,9 +7115,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 "
-"%1$s 发送到 %2$s"
+msgstr "暂时无法使用 DuckDuckGo AI Chat。如果仍有问题，请通过电子邮件将此匿名代码 %1$s 发送到 %2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7372,18 +7278,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息"
-"来对这些报告进行匿名化。"
+msgstr "DuckDuckGo 通过自动删除姓名、电子邮件地址、电话号码和识别元数据等个人身份信息来对这些报告进行匿名化。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 "
-"%2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意 Duck.ai 的 %2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7391,8 +7293,7 @@ msgctxt ""
 "Inline terms-of-service disclaimer below chat or image-gen input for new "
 "users"
 msgid "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to our %s."
-msgstr ""
-"DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
+msgstr "DuckDuckGo 会对你的聊天内容进行匿名处理。点击“%1$s”即表示你同意我们的 %2$s。"
 
 # smartling.placeholder_format=C
 #. An information popup explaining that we block trackers
@@ -7400,9 +7301,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟"
-"踪程序，这些公司经常试图在其他网站上跟踪你。"
+msgstr "DuckDuckGo 会屏蔽所访问网站的跟踪程序，包括来自 Google 和 Facebook 等公司的跟踪程序，这些公司经常试图在其他网站上跟踪你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7414,9 +7313,8 @@ msgid ""
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
 msgstr ""
-"DuckDuckGo 的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时"
-"会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名"
-"性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
+"DuckDuckGo "
+"的设计力图保护用户隐私，定位信息仅存储于你的设备中，只有发起搜索时会上传给我们用以优化搜索结果，搜索完成后我们也不会保留，以保证搜索匿名性。%1$s详细了解我们是如何设计这一功能来保护隐私的%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7435,8 +7333,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
+msgstr "DuckDuckGo 只需了解你的大致位置即可优化你附近的搜索结果。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7528,8 +7425,8 @@ msgid ""
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
 msgstr ""
-"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，"
-"并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 个字符。"
+"当你选择自动生成口令时，我们会从 DuckDuckGo 服务器获取一系列随机的英文词汇，并在浏览器端从中选取四五个，保证总长度至少有 18 到 20 "
+"个字符。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7784,9 +7681,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置"
-"信息。"
+msgstr "启用匿名定位功能可获得更精确的结果，但 DuckDuckGo 仍会保密你的搜索和确切位置信息。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7986,8 +7881,7 @@ msgstr "输入文本"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
+msgstr "输入下列信息：%1$s名称%2$s：DuckDuckGo%3$s搜索串%4$s：%5$s快捷字%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8330,7 +8224,7 @@ msgstr "快速"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "图像生成速度快"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8384,9 +8278,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问"
-"题。"
+msgstr "类似你这样的反馈会直接影响我们的产品更新和改进。希望我们也能解决你提出的问题。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8651,7 +8543,7 @@ msgstr "后续问题会保密。"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "遵循了指令"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8868,9 +8760,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; "
-"“<strong>Check for Updates...</strong>”（查看更新……），然后选"
-"择“<strong>Install Update</strong>”（安装更新）。"
+"在 Mac 的应用程序菜单栏中选择“<strong>DuckDuckGo</strong>” &gt; “<strong>Check for "
+"Updates...</strong>”（查看更新……），然后选择“<strong>Install Update</strong>”（安装更新）。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9156,8 +9047,8 @@ msgid ""
 "Get DuckDuckGo VPN, advanced Duck.ai, Personal Info Removal, and Identity "
 "Theft Restoration."
 msgstr ""
-"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取 DuckDuckGo VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
@@ -9249,8 +9140,8 @@ msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以"
-"及 Identity Theft Restoration 服务。"
+"获取快速的无日志 VPN、可选高级人工智能聊天、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9258,9 +9149,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服"
-"务。"
+msgstr "获取快速的无日志 VPN、可选高级人工智能聊天以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9268,9 +9157,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "订阅 DuckDuckGo 即可使用 Duck.ai 的高级人工智能模型，同时还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9280,9 +9167,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和"
-"其他高级隐私保护功能。"
+msgstr "通过 DuckDuckGo 订阅使用 Duck.ai 的高级人工智能模型，其中还包括我们的 VPN 和其他高级隐私保护功能。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9325,9 +9210,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多"
-"高级保护功能。"
+msgstr "获取我们快速的无日志 VPN、可选高级人工智能模型（具备更高的聊天限额）以及更多高级保护功能。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9336,16 +9219,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 "
-"Identity Theft Restoration 服务。"
+"获取我们安全的无日志 VPN、高级 Duck.ai、Personal Information Removal 以及 Identity Theft "
+"Restoration 服务。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
+msgstr "获取我们安全的无日志 VPN，高级 Duck.ai 以及 Identity Theft Restoration 服务。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9445,8 +9327,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊"
-"天 › Sync & Backup › 与其他设备同步 › 复制文本二维码%4$s"
+"在其他浏览器中前往 %1$sDuck.ai 设置%2$s，或在 DuckDuckGo 应用程序中前往%3$s聊天 › Sync & Backup › "
+"与其他设备同步 › 复制文本二维码%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9455,8 +9337,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9466,8 +9348,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s并扫描此二维码："
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后加入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s并扫描此二维码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9477,8 +9359,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊"
-"天 › Sync & Backup › 与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器或 DuckDuckGo 应用程序中前往 %1$sDuck.ai 设置%2$s，然后进入%3$s聊天 › Sync & Backup › "
+"与其他设备同步%4$s。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9486,8 +9368,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
+msgstr "前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9509,9 +9390,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 "
-"%3$sDuckDuckGo%4$s。"
+msgstr "转到%1$s“设置” > “隐私” > “权限管理器” > “定位”%2$s，然后向下滚动至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9583,7 +9462,7 @@ msgstr "良好的隐私政策"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "出色的视觉风格"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10231,9 +10110,7 @@ msgstr "历史"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s"
-"设为默认搜索引擎%6$s"
+msgstr "按下键盘上的 %1$s回车键%2$s%3$s将 DuckDuckGo 添加到列表中，%4$s然后点击 %5$s设为默认搜索引擎%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10246,9 +10123,7 @@ msgstr "白苗语"
 msgid ""
 "Hold on! Changing it back will disable the DuckDuckGo extension and you'll "
 "lose our privacy protection."
-msgstr ""
-"稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保"
-"护。"
+msgstr "稍等！将其改回默认搜索引擎将禁用 DuckDuckGo 扩展程序，并将失去我们的隐私保护。"
 
 # smartling.placeholder_format=C
 #. Heading shown above warning messages in the AI chat, for non-critical issues like unsupported file formats or file size limits. Analogous to 'Oops...' for error messages.
@@ -10599,9 +10474,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与"
-"隐私”%2$s。"
+msgstr "如果仍然无法使用浏览器定位，请前往%1$s“设置” > “通用” > “还原” > “还原位置与隐私”%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10611,8 +10484,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站"
-"设置” > “位置”%2$s，并确认已允许 DuckDuckGo 使用定位信息。"
+"如果仍然无法使用浏览器定位，请在浏览器中转到%1$s“⋮” > “菜单” > “设置” > “网站设置” > “位置”%2$s，并确认已允许 "
+"DuckDuckGo 使用定位信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10626,8 +10499,7 @@ msgstr "如果你继续看到此错误，请联系 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
+msgstr "如果找不到 %1$sDuckDuckGo%2$s，你需要手动将其添加到 %3$s其他搜索引擎%4$s 中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10635,9 +10507,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 "
-"%2$s 支持页面。"
+msgstr "如果你对我们的聊天提供商或任何特定的聊天回复有疑虑，也可以直接联系 %1$s 和 %2$s 支持页面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10645,9 +10515,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码"
-"以文本文件的形式保存到设备中。"
+msgstr "如果您无法访问自己的设备，则将需要此代码来恢复保存的聊天记录。您可以将此代码以文本文件的形式保存到设备中。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10662,9 +10530,7 @@ msgstr "如果你仍愿支持我们，可%1$s协助推广 DuckDuckGo%2$s"
 msgid ""
 "If you want to use DuckDuckGo without JavaScript, please use our %s or %s "
 "versions."
-msgstr ""
-"如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版"
-"本。"
+msgstr "如需在关闭 JavaScript 的情况下使用 DuckDuckGo，请使用我们的 %1$s 或者 %2$s 版本。"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -10714,7 +10580,7 @@ msgstr "图像提示必须符合 Duck.ai %1$s。"
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "图像质量"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10817,9 +10683,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄"
-"露搜索内容。%1$s了解详情%2$s。"
+msgstr "如果使用某些过时的浏览器，点击搜索结果后需要经过我们的服务器重定向才能避免泄露搜索内容。%1$s了解详情%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10829,8 +10693,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
+msgstr "在 DuckDuckGo 浏览器中，前往设置 › Sync & Backup，然后选择“与其他设备同步”。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -10844,9 +10707,7 @@ msgctxt "cloudsave"
 msgid ""
 "In the interest of transparency, this data is not encrypted: You can see "
 "exactly what information we store."
-msgstr ""
-"本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具"
-"体都存了什么。"
+msgstr "本着透明公开的原则，上传的信息也没有加密处理，如果你感兴趣的话可以看到我们具体都存了什么。"
 
 # smartling.placeholder_format=C
 msgid "In the menu at the top select %sTools%s > %sSettings%s"
@@ -11251,8 +11112,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向"
-"商户页面，与广告不同，DuckDuckGo 不会通过这些搜索结果获得收益。"
+"结果根据与搜索词的相关程度排序，并通过 Microsoft 的广告网络提供。链接直接指向商户页面，与广告不同，DuckDuckGo "
+"不会通过这些搜索结果获得收益。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -13308,9 +13169,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互"
-"联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和"
-"回复的临时存储功能。"
+"新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo "
+"服务器上，以便在断开互联网连接时帮助恢复聊天记录。禁用聊天记录将删除置顶的聊天记录，并禁用新提示和回复的临时存储功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14144,9 +14004,7 @@ msgstr "按需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设"
-"置%5$s"
+msgstr "Mac 系统 %1$s点击 Maxthon > 设置%2$s，Windows 系统 %3$s点击 %4$s 图标 > 设置%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14154,9 +14012,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”"
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14164,9 +14020,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”并扫描此代码："
+msgstr "在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”并扫描此代码："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14175,8 +14029,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他"
-"设备同步%4$s”。或者扫描恢复 PDF 中的二维码。"
+"在另一台设备上，前往“%1$sDuck.ai 设置%2$s › %3$s聊天 › Sync & Backup › 与其他设备同步%4$s”。或者扫描恢复 "
+"PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14573,9 +14427,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简"
-"单。"
+msgstr "即使在隐私浏览模式中，某些搜索引擎照样会跟踪你。而我们不会跟踪你，就这么简单。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14588,9 +14440,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护"
-"功能。一站式订阅服务。"
+msgstr "我们快速的无日志 VPN 附带更智能、限额更高的人工智能聊天功能，以及更多高级保护功能。一站式订阅服务。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14604,9 +14454,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。"
-"现已支持 %1$siOS 和 Android%2$s。"
+msgstr "我们的移动端隐私浏览器预置了搜索引擎，还可以屏蔽跟踪程序、开启网站加密等等。现已支持 %1$siOS 和 Android%2$s。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14858,9 +14706,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口"
-"令。"
+msgstr "我们存储设置时并未记录你的 IP 地址、浏览器指纹或任何其他信息，因此无法找回口令。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15015,9 +14861,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
-"Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然"
-"后，我们会努力为你将其删除。"
+msgstr "Personal Information Removal 会在出售个人信息的数据中介网站上查找你的信息。然后，我们会努力为你将其删除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15087,9 +14931,7 @@ msgid ""
 "assisted answers more likely to appear automatically and often yields better "
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
-msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获"
-"得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
+msgstr "以问题和完整的句子进行搜索，会更有可能自动显示人工智能辅助的答案，通常也能获得更佳答案。若要将其关闭并隐藏“Assist”按钮，请访问“%1$s搜索设置%2$s”。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15098,8 +14940,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答"
-"案。 如需调整此功能的工作方式或将其关闭，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能显示 DuckAssist，通常也能获得更佳答案。 如需调整此功能的工作方式或将其关闭，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15109,8 +14951,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答"
-"案。若要将其关闭并隐藏“协助”按钮，请访问 %1$sDuckAssist 设置%2$s。"
+"以问题和完整的句子进行搜索，会更有可能自动显示 DuckAssist，通常也能获得更佳答案。若要将其关闭并隐藏“协助”按钮，请访问 "
+"%1$sDuckAssist 设置%2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15150,8 +14992,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, "
 "Mistral, etc."
-msgstr ""
-"选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
+msgstr "选择热门 AI 并与之对话，比如 GPT-5 mini、Claude Haiku 4.5、Mistral 等。"
 
 # smartling.placeholder_format=C
 #. The description of the third party map app picker, shown on iOS when a user is given an option of which app to navigate to a destination with
@@ -15307,9 +15148,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害"
-"或非法。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除所有个人信息），并说明相关内容为何有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15317,9 +15156,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法"
-"或有害。"
+msgstr "请粘贴你的提示和有问题的输出内容（删除任何个人信息），并说明相关内容为何违法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15533,7 +15370,7 @@ msgstr "格式不佳"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "图像质量不佳"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16380,8 +16217,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16389,8 +16225,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
+msgstr "近期聊天记录会存储在设备本机上，而非 DuckDuckGo 服务器或其他远程服务器上。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16399,9 +16234,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 "
-"DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
+msgstr "最近的聊天记录会存储在本地设备上。新的提示和回复在发送后会被加密并暂时存储在 DuckDuckGo 服务器上，以便在断开互联网连接时帮助恢复聊天记录。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16682,9 +16515,7 @@ msgstr "重新加载 Duck.ai"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重"
-"新加载）按钮。"
+msgstr "请按照说明重新加载 DuckDuckGo，或点击浏览器的“Refresh”（刷新）或“Reload”（重新加载）按钮。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16791,18 +16622,14 @@ msgctxt "settings"
 msgid ""
 "Removes the \"Ask\" button so answers appear automatically in response to "
 "relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的"
-"答案。"
+msgstr "移除“Ask”（询问）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Removes the \"Generate\" button so answers appear automatically in response "
 "to relevant searches. Cached answers always display automatically."
-msgstr ""
-"移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示"
-"缓存的答案。"
+msgstr "移除“Generate”（生成）按钮，以便在相关搜索的响应中自动显示答案。一律自动显示缓存的答案。"
 
 # smartling.placeholder_format=C
 #. Text for a button to rename a chat, as in it will allow the user to change the title of the chat.
@@ -16865,18 +16692,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提"
-"供给 %1$s，以便共同提高服务质量。"
+msgstr "你的反馈将以匿名方式发送至 DuckDuckGo，以帮助我们改进搜索服务，同时也将匿名提供给 %1$s，以便共同提高服务质量。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信"
-"息。"
+msgstr "发给 DuckDuckGo 的报告均为匿名。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16884,9 +16707,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是"
-"匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
+msgstr "发送给 DuckDuckGo 的报告包括你在此页面加载过程中要求我们翻译的所有文本，且是匿名形式。请不要在反馈中包含任何个人或可识别身份的信息。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16977,9 +16798,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助"
-"的答案受我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。人工智能辅助的答案受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16987,9 +16806,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受"
-"我们的%1$s服务条款%2$s约束。"
+msgstr "回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议。DuckAssist 受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16999,8 +16816,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内"
-"容生成，可能包含不准确的信息。Search Assist 受我们的%1$s服务条款%2$s约束。"
+"回复仅供教育用途，不应视为医疗、法律、财务、投资或其他专业建议，且根据网络内容生成，可能包含不准确的信息。Search Assist "
+"受我们的%1$s服务条款%2$s约束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17424,9 +17241,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记"
-"录。"
+msgstr "在本地设备上保存多达 30 条最新聊天记录，还可使用加密存储功能保存更多聊天记录。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17598,9 +17413,7 @@ msgstr "向下滚动并点击 %1$s查看高级设置%2$s。"
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)"
-msgstr ""
-"向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s"
-"添加搜索引擎%6$s）"
+msgstr "向下滚动并找到%1$s地址栏使用的搜索引擎%2$s，点击%3$s更改搜索引擎%4$s（或%5$s添加搜索引擎%6$s）"
 
 #  Edge Legacy default search engine instruction
 # smartling.placeholder_format=C
@@ -17608,9 +17421,7 @@ msgstr ""
 msgid ""
 "Scroll down and find %sSearch in the address bar%s. Click on %sChange%s (or "
 "%sAdd new%s)."
-msgstr ""
-"向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 "
-"%5$s添加搜索引擎%6$s）。"
+msgstr "向下滚动并找到 %1$s地址栏使用的搜索引擎%2$s，点击 %3$s更改搜索引擎%4$s（或 %5$s添加搜索引擎%6$s）。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -17696,10 +17507,10 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，"
-"然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点"
-"击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显"
-"示）。Search Assist 目前仅供部分英语地区使用。"
+"Search Assist "
+""
+"匿名生成搜索查询的答案。为此，该功能会扫描网络以查找相关内容，然后使用人工智能生成简短的答案。可以选择其出现的频率：从不、按需（仅在点击“Assist”时显示）、有时（仅在高度相关时显示）或经常（在更广泛的搜索中显示）。Search "
+"Assist 目前仅供部分英语地区使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
@@ -17715,8 +17526,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s"
-"扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
+"Search Assist "
+"是一项可选功能，可以匿名生成搜索查询的答案。为此，该功能会%1$s扫描网络%2$s以查找相关内容，然后使用人工智能根据找到的信息生成简短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17836,8 +17647,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
+msgstr "使用 %1$s 快捷键搜索其他网站：搜索“!w ducks”将直接在维基百科上搜索“ducks”。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17855,9 +17665,7 @@ msgstr "匿名搜索并屏蔽跟踪程序"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 "
-"%1$sduckduckgo.com%2$s 发起搜索。"
+msgstr "通过我们的移动应用或扩展程序匿名搜索，或将搜索引擎加入浏览器，抑或直接打开 %1$sduckduckgo.com%2$s 发起搜索。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17876,9 +17684,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud "
-"Save 将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，"
-"且你的口令仅限在你的浏览器中使用。"
+"搜索设置会存储在非个人浏览器 Cookie 和浏览器的本地存储中，但也可以使用 Cloud Save "
+"将设置匿名存储在云端的远程服务器上。系统不会在云端存储任何个人身份信息，且你的口令仅限在你的浏览器中使用。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17980,9 +17787,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Encrypted Storage feature stores the user's chats encrypted on their device.
@@ -17990,9 +17795,7 @@ msgctxt "Description for encrypted storage feature"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备"
-"访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18000,9 +17803,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同"
-"步的设备访问。"
+msgstr "使用端到端加密安全地在我们的服务器上存储几乎无限量的聊天记录，并可从所有已同步的设备访问。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -18010,9 +17811,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相"
-"关内容。"
+msgstr "利用端到端加密功能将聊天记录安全地存储在我们的服务器上，并可从所有设备访问相关内容。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18026,9 +17825,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看"
-"到你的数据，甚至我们也不行。"
+msgstr "采用端到端加密技术，安全存储在 DuckDuckGo 服务器上。除了你之外，没有人可以看到你的数据，甚至我们也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18242,16 +18039,14 @@ msgstr "在弹出的菜单中点击 %1$s管理加载项%2$s"
 #. Tells users where in the settings menu they can change their default search engine.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sMenu > Settings%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$s菜单 > 设置%4$s"
 
 #  Opera homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Select %sOpera > Preferences%s (on Mac) or %sOpera > Options%s (on Windows)"
-msgstr ""
-"Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
+msgstr "Mac 系统点击 %1$sOpera > 设置%2$s，Windows 系统点击 %3$sOpera > 选项%4$s"
 
 #  Safari homepage instruction
 # smartling.placeholder_format=C
@@ -18436,9 +18231,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后"
-"的所有对话。"
+msgstr "向人工智能模型发送包含你的消息的提示，并附带回复说明。这些说明将适用于你今后的所有对话。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18666,9 +18459,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智"
-"能模型透露你的精确位置。"
+msgstr "与人工智能模型共享城市级位置信息，以提升相关性。Duck.ai 绝不会向我们或人工智能模型透露你的精确位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18769,8 +18560,7 @@ msgctxt ""
 msgid ""
 "Share your prompt and chat response with DuckDuckGo (required for illegal "
 "and harmful report)"
-msgstr ""
-"将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
+msgstr "将您的提示和聊天回复分享给 DuckDuckGo（举报非法和有害内容时需要执行此步骤）"
 
 # smartling.placeholder_format=C
 #. An invitation for users to leave feedback
@@ -18818,9 +18608,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或"
-"关闭。"
+msgstr "使用我们快速的无日志 VPN 来保护你的在线活动。易于设置，并且可以随时轻松开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19183,18 +18971,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不"
-"会影响搜索隐私。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索均为匿名搜索。关闭此功能可隐藏提醒，且不会影响搜索隐私。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不"
-"会影响搜索保护。"
+msgstr "提醒：在 DuckDuckGo 上进行的所有搜索始终受到保护。关闭此功能可隐藏提醒，且不会影响搜索保护。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20517,8 +20301,7 @@ msgid ""
 msgstr ""
 "同步恢复代码\n"
 "\n"
-"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无"
-"法访问某个设备时恢复已同步的数据。\n"
+"恢复代码允许你在多个设备之间同步密码、自动填充数据和 Duck.ai 聊天记录，并在无法访问某个设备时恢复已同步的数据。\n"
 "\n"
 "请妥善保管此信息。\n"
 "任何可访问此代码的人都可以访问你的同步数据。\n"
@@ -20530,8 +20313,7 @@ msgstr ""
 "2. 选择“开启 Sync & Backup”，然后选择“恢复同步数据”\n"
 " 3. 复制上方的恢复代码，并将其粘贴到“在此处粘贴代码”处\n"
 "\n"
-"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据"
-"将从服务器中删除且无法恢复。"
+"如果你超过 18 个月未使用启用 Sync & Backup 功能的 DuckDuckGo 浏览器，你的数据将从服务器中删除且无法恢复。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20669,9 +20451,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调"
-"用。"
+msgstr "随时随地使用 Duck.ai。下载内置此功能的免费应用——无论你身在何处，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20679,9 +20459,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能"
-"快速调用。"
+msgstr "随时随地使用 Duck.ai。将其内置于我们的免费浏览器中——无论你何时浏览网页，都能快速调用。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20924,9 +20702,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银"
-"行账号。"
+msgstr "这意味着你与网站之间传输的信息更有可能被第三方截获，其中甚至包括你的密码和银行账号。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20942,9 +20718,7 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr ""
-"Duck.ai 开关让你可以在私密搜索和 AI 聊天之间快速切换，由 DuckDuckGo 进行匿名"
-"化处理。"
+msgstr "Duck.ai 开关让你可以在私密搜索和 AI 聊天之间快速切换，由 DuckDuckGo 进行匿名化处理。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21052,8 +20826,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
+msgstr "在本地保存此聊天时出现了错误。请检查你的浏览器设置以确保已启用本地数据存储。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21085,9 +20858,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设"
-"为默认搜索引擎，从而保护你的隐私。"
+msgstr "所需的浏览器权限用于屏蔽网页跟踪程序、尽可能建立加密连接，并将 DuckDuckGo 设为默认搜索引擎，从而保护你的隐私。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21170,9 +20941,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不"
-"准确或令人反感的信息（详情请参阅%4$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21181,9 +20950,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或"
-"令人反感的信息（详情请参阅%2$s）。"
+msgstr "此对话由 Duck.ai (%1$s) 使用多个聊天模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21191,9 +20958,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感"
-"的信息。（详情请参见 %2$s）。"
+msgstr "这段对话通过 Duck.ai 语音聊天生成 (%1$s)。人工智能可能会提供不准确或令人反感的信息。（详情请参见 %2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21203,8 +20968,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s 模型生成。人工智能聊天可"
-"能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
+"此对话由 DuckDuckGo AI Chat (%1$s) 使用 %2$s 的 %3$s "
+"模型生成。人工智能聊天可能会显示不准确或令人反感的信息（详情请参阅%4$s）。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21220,9 +20985,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留"
-"在本地存储中。"
+msgstr "此设备将无法再访问你在其他设备上已同步的数据。最近的 %1$s 条聊天记录仍将保留在本地存储中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21327,9 +21090,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记"
-"录顶部！"
+msgstr "这只是一个示例聊天记录。打开其菜单（三个点），然后选择“置顶”，将其置于聊天记录顶部！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21357,9 +21118,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据"
-"保留模式。"
+msgstr "该模型提供商会在 30 天内删除与此聊天记录相关的数据。其他模型提供商遵循零数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21367,9 +21126,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据"
-"保留模式。"
+msgstr "该模型提供商不会存储与此聊天记录相关的任何数据。其他模型提供商遵循有限的数据保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21405,9 +21162,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，"
-"之后可以通过任何浏览器访问这些记录。"
+msgstr "这将使用端到端加密技术将您的聊天记录安全地存储在 DuckDuckGo 的安全服务器上，之后可以通过任何浏览器访问这些记录。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21415,9 +21170,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。"
+msgstr "此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI 辅助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21427,9 +21180,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那"
-"么你可能会再次看到 AI 辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显"
-"示 AI 辅助答案。"
+"此设置存储在你的浏览器中，这意味着如果清除了 duckduckgo.com 的浏览器数据，那么你可能会再次看到 AI "
+"辅助的答案。不过，我们还有一个起始页，它从不在 %1$s 显示 AI 辅助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21480,8 +21232,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你"
-"仍然可以在连接到 Sync & Backup 的其他浏览器中浏览你的聊天记录。"
+"这将删除你在此浏览器中的所有 Duck.ai 聊天记录，并断开 Sync & Backup 连接。你仍然可以在连接到 Sync & Backup "
+"的其他浏览器中浏览你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21626,8 +21378,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
+msgstr "打印路线具体操作：%1$s返回地图。%2$s选择要打印的路线。%3$s点击打印图标。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21636,9 +21387,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格"
-"式保存到最初用于设置同步的设备上。"
+msgstr "需要使用首次设置同步时保存的恢复代码来还原已同步的数据。此代码可能已以 PDF 格式保存到最初用于设置同步的设备上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21646,9 +21395,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再"
-"试一次。"
+msgstr "如需将聊天记录转移到 Duck.ai，请先将 DuckDuckGo 浏览器升级至最新版本，然后再试一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21749,7 +21496,7 @@ msgstr "太慢了"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "生成太慢了"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21862,8 +21609,7 @@ msgctxt "tracker_stats"
 msgid ""
 "Tracking attempts blocked by DuckDuckGo appear here. Keep browsing to see "
 "how many we block."
-msgstr ""
-"此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
+msgstr "此处将显示被 DuckDuckGo 阻止的跟踪企图。继续浏览以查看我们阻止了多少次。"
 
 # smartling.placeholder_format=C
 #. Placeholder for when we cannot report any blocked trackers yet
@@ -22190,7 +21936,7 @@ msgstr "尝试减少关键词数量。"
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "免费试用"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22401,9 +22147,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设"
-"置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？安装 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22411,9 +22155,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的"
-"设置。%3$s了解详情%4$s"
+msgstr "想要禁用 AI 功能？切换到 %1$sDuckDuckGo No AI%2$s 搜索扩展程序，以便记住你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22613,9 +22355,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间"
-"出现短暂的延迟。"
+msgstr "在生成 DuckAssist 答案时键入相关内容。关闭此功能可能会导致搜索与显示答案之间出现短暂的延迟。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22744,16 +22484,14 @@ msgstr "了解优点和缺点"
 msgid ""
 "Under %sOn startup%s, click %sOpen a specific page%s then click %sSet "
 "Pages%s."
-msgstr ""
-"在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
+msgstr "在%1$s启动时%2$s下，点击%3$s打开特定页面%4$s，然后点击 %5$s设置页面%6$s。"
 
 #  Maxthon homepage instruction
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
 msgid ""
 "Under %sOn startup%s, select %sHomepage%s and enter: https://duckduckgo.com"
-msgstr ""
-"在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
+msgstr "在%1$s启动时%2$s下，选择%3$s主页%4$s并将主页设为 https://duckduckgo.com"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -22868,9 +22606,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍"
-"的使用限额。"
+msgstr "升级至 Pro 计划，即可解锁 %1$s、更强大的 AI 推理能力，以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23252,9 +22988,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公"
-"司的侵害。确保信息保密。免费。无需账户。"
+msgstr "私密地使用 ChatGPT、Claude 和其他人工智能工具。保护聊天内容免受黑客、骗子和公司的侵害。确保信息保密。免费。无需账户。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23438,9 +23172,7 @@ msgctxt "duckai_seo"
 msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
-msgstr ""
-"查看来自 Duck.ai 的共享聊天记录，这是 DuckDuckGo 提供的免费、私密人工智能聊天"
-"工具。将其保存到你的聊天记录中，并继续私密对话。"
+msgstr "查看来自 Duck.ai 的共享聊天记录，这是 DuckDuckGo 提供的免费、私密人工智能聊天工具。将其保存到你的聊天记录中，并继续私密对话。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23482,8 +23214,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
+msgstr "DuckDuckGo 会保护观看广告的隐私。广告点击量由 TripAdvisor 广告网络管理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23533,8 +23264,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
+"在您的另一个浏览器中访问 Duck.ai，然后前往 %1$sDuck.ai 设置%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，然后选择%7$s与另一台设备同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23544,8 +23275,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup 栏下选择“开"
-"启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
+"在其他浏览器中访问 Duck.ai 并打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23555,9 +23286,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设"
-"置%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同"
-"步%8$s”。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后前往“%1$sDuck.ai 设置%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s”，然后选择“%7$s与其他设备同步%8$s”。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23567,9 +23297,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。"
-"在 Sync & Backup 栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF "
-"中的二维码。"
+"在另一个浏览器或 DuckDuckGo 应用程序中访问 Duck.ai，然后打开 Duck.ai 设置。在 Sync & Backup "
+"栏下选择“开启”，然后选择“与其他设备同步”。或者扫描恢复 PDF 中的二维码。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23770,9 +23499,7 @@ msgstr "在 Duck Player 中观看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 "
-"YouTube 推荐。"
+msgstr "在 Duck Player 中观看，以屏蔽 YouTube 上的个性化广告，并防止你的观看活动影响 YouTube 推荐。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23792,8 +23519,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。"
-"DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube 没有任何关系。"
+"在此处观看视频意味着其托管网站可以跟踪你，因为我们必须从该网站流式传输内容。DuckDuckGo 是一家独立公司，与托管大多数视频的 YouTube "
+"没有任何关系。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23816,9 +23543,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 "
-"DuckDuckGo，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请分享此对话给 DuckDuckGo，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23829,9 +23554,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回"
-"复，这样我们才能调查并处理这个问题。"
+msgstr "我们只能处理我们看得到的问题。要举报有害或非法的回复，请先分享您的提示词和回复，这样我们才能调查并处理这个问题。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23884,9 +23607,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what brought you "
 "back today:"
-msgstr ""
-"我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟"
-"踪："
+msgstr "我们想请你聊聊是什么让你继续使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 #. Message prompting users to fill out a feedback form.
@@ -23894,9 +23615,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们"
-"跟踪："
+msgstr "我们想请你聊聊是什么让你信任并使用 DuckDuckGo，你所写和浏览的一切将不会被我们跟踪："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23960,8 +23679,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
+msgstr "我们会从数据中介网站查找并删除你的个人信息。此外，还可以获取 VPN 及更多功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -24001,8 +23719,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
+msgstr "匿名定位仅用于为你提供更近、更优质的搜索结果，将来你也可以随时选择关闭。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24010,9 +23727,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我"
-"们的进度。"
+msgstr "我们会定期在数据中介网站上扫描你的个人信息，并通过易于使用的仪表板与你共享我们的进度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24038,9 +23753,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更"
-"正可能需要一段时间。"
+msgstr "你的反馈意见能帮助我们改进 DuckDuckGo。%1$s 将酌情采纳你的建议，但搜索结果更正可能需要一段时间。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24053,9 +23766,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有"
-"关你的任何信息。"
+msgstr "我们会在数据中介网站上扫描你的电子邮件、姓名、地址等信息，并努力删除找到的有关你的任何信息。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24063,8 +23774,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. If you "
 "continue to see this error, please reach out to %s."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
+msgstr "我们了解这个问题，目前正在努力解决。如果你继续看到此错误，请联系 %1$s。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -24072,8 +23782,7 @@ msgctxt "noresults"
 msgid ""
 "We're aware of this issue and are currently working to resolve it. Sometimes "
 "clearing your browser's cache can help."
-msgstr ""
-"我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
+msgstr "我们了解这个问题，目前正在努力解决。有时候，清除浏览器的缓存可能会有帮助。"
 
 # smartling.placeholder_format=C
 #. Header for a feedback form for new users.
@@ -24216,9 +23925,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用"
-"于训练人工智能模型。"
+msgstr "欢迎使用 Duck.ai！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24226,9 +23933,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处"
-"理，不会用于训练人工智能模型。"
+msgstr "欢迎使用 DuckDuckGo AI Chat！此处所有聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24238,8 +23943,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天"
-"内容均为私密，DuckDuckGo 绝不会存储或用于训练 AI 模型。"
+"欢迎使用 DuckDuckGo AI Chat！此聊天会话由 %1$s 的 %2$s 提供支持。此处所有聊天内容均为私密，DuckDuckGo "
+"绝不会存储或用于训练 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24371,9 +24076,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官"
-"方 DuckDuckGo 来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。"
-"保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
+"对于有兴趣使用 Duck.ai 的人来说，下载 DuckDuckGo 浏览器有哪些好处？仅参考官方 DuckDuckGo "
+"来源。将响应分为清晰的部分，标题聚焦于 Duck.ai 集成和隐私保护。保持内容简短、简单，易于理解，适合有或没有太多人工智能或技术经验的人。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24908,9 +24612,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时"
-"在“%1$s”菜单中开启或关闭。"
+msgstr "使用 Duck.ai，你的聊天内容均已匿名处理，且绝不会用于训练 AI。 可以随时在“%1$s”菜单中开启或关闭。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -25214,8 +24916,7 @@ msgctxt "noresults"
 msgid ""
 "You can %s or search directly on other search engines from DuckDuckGo using "
 "%s search shortcuts."
-msgstr ""
-"可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
+msgstr "可以%1$s或使用 %2$s 搜索快捷键从 DuckDuckGo 在其他搜索引擎上直接进行搜索。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that they can access DuckDuckGo AI Chat directly at a specific URL. The placeholder %s will be replaced with the link. Example: 'You can access DuckDuckGo AI Chat directly at duck.ai.'
@@ -25259,8 +24960,7 @@ msgstr "您最多可以附加 %1$s 个文本选中内容。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
+msgstr "可以在%1$s搜索设置%2$s中更改显示 Search Assist 的频率，或者将其完全关闭。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25435,9 +25135,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限"
-"额。"
+msgstr "你现在可以享用 %1$s、更强大的人工智能推理能力以及比 Plus 计划高 2 倍的使用限额。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25445,9 +25143,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 "
-"DuckDuckGo 订阅保护功能。"
+msgstr "现在可以使用高级人工智能模型。可以在 DuckDuckGo 浏览器中使用 VPN 和其他 DuckDuckGo 订阅保护功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25468,9 +25164,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25479,9 +25173,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地"
-"存储中。这不会从加密服务器中删除你的聊天记录。"
+msgstr "你将无法再通过此浏览器访问已保存的聊天记录。最近 30 条聊天记录仍将保留在本地存储中。这不会从加密服务器中删除你的聊天记录。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25508,9 +25200,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装"
-"的 App 上网还能进一步保护隐私，它可以："
+msgstr "现在使用 Chrome 搜索再也不用担心泄露隐私了。与 Chrome 相比，使用我们已经安装的 App 上网还能进一步保护隐私，它可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25598,8 +25288,8 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
 msgstr ""
-"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 "
-"%1$s 条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
+"包含附件的 Duck.ai 聊天记录的 Sync & Backup 存储空间已经用完。删除最早的 %1$s "
+"条聊天记录以恢复同步。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25609,8 +25299,8 @@ msgid ""
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
 msgstr ""
-"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s 条包含"
-"附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
+"您已经用完 Duck.ai 聊天记录的 Sync & Backup 存储空间。删除最早的 %1$s "
+"条包含附件的聊天记录，以恢复同步功能。置顶的聊天记录不会被删除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25623,9 +25313,7 @@ msgstr "你已用尽存储空间"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 "
-"Google 与 YouTube 跟踪。"
+msgstr "Google 旗下的 YouTube 不允许匿名观看视频，因此在这里观看 YouTube 视频仍会被 Google 与 YouTube 跟踪。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25693,9 +25381,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 %1$s 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25704,9 +25390,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏"
-"览器中，你最近的 100 条聊天记录将保存在本地存储中："
+msgstr "系统将从 DuckDuckGo 服务器中删除你的备份。所有设备都会断开同步连接。在以下浏览器中，你最近的 100 条聊天记录将保存在本地存储中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25745,8 +25429,7 @@ msgctxt "Disclaimer bellow chat input - desktop"
 msgid ""
 "Your chat with %s is private. AI chats may display inaccurate or offensive "
 "information."
-msgstr ""
-"你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
+msgstr "你与 %1$s 的聊天内容将保密。人工智能聊天可能会显示不准确或令人反感的信息。"
 
 # smartling.placeholder_format=C
 #. Body copy shown after Sync & Backup is enabled, confirming chats are now syncing.
@@ -25771,16 +25454,14 @@ msgstr "你的聊天内容均为私密，绝不会用于训练人工智能模型
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
+msgstr "你的聊天内容均为私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25808,9 +25489,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请"
-"按照以下步骤保留聊天记录。"
+msgstr "聊天记录仍会保持私密，我们已对其进行匿名化处理，不会用于训练人工智能模型。请按照以下步骤保留聊天记录。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25849,9 +25528,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample "
-"message%3$s]"
+msgstr "我们绝不会透露你的电子邮件地址，%1$s或把它与匿名搜索关联。[%2$sExample message%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25894,9 +25571,8 @@ msgid ""
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
 msgstr ""
-"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 "
-"512 位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密"
-"钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
+"我们采用一种名为 %1$sSHA-2%2$s 的安全散列算法将你的口令不可逆地映射到一个 512 "
+"位的密钥，浏览器仅发送这一密钥和你要保存的设置，以便我们将收到的设置与密钥相关联。因此，DuckDuckGo 不可能得知你使用的口令。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25910,9 +25586,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商"
-"无法将对话内容与你本人关联起来。"
+msgstr "你的提示词会经由 DuckDuckGo 服务器中转，并剥离个人身份元数据，因此模型提供商无法将对话内容与你本人关联起来。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25956,9 +25630,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。"
+msgstr "已保存你的设置，但清理浏览器 Cookie 会将其重置。启用 %1$sDuckDuckGo No AI%2$s 扩展插件，以便永久保存你的设置。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25967,8 +25639,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No "
-"AI%2$s 扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
+"已保存你的设置，但清理浏览器 Cookie 会将其重置。安装 %1$sDuckDuckGo No AI%2$s "
+"扩展插件，以便永久保存你的设置。%3$s了解详情%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25995,9 +25667,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更"
-"多保护。已安装该浏览器并可以："
+msgstr "你现在正在使用 Chrome 进行私密搜索。不妨使用我们的浏览器代替 Chrome，以获得更多保护。已安装该浏览器并可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"Last-Translator: Community\n"
-"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "POT-Creation-Date: 2019-01-16 23:42-0500\n"
 "PO-Revision-Date: 2019-01-16 23:42-0500\n"
+"Last-Translator: Community\n"
+"Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,7 +189,9 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
+"至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -198,7 +200,9 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
+msgstr ""
+"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
+"換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -213,7 +217,9 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
+msgstr ""
+"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
+"切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -324,8 +330,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution "
-"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
+"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -410,7 +416,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -420,7 +427,8 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr ""
+"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -448,7 +456,8 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr ""
+"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -917,7 +926,8 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr ""
+"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -975,8 +985,9 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
-"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
+"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
+"aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1037,8 +1048,9 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
-"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
+"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
+"Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1807,7 +1819,9 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
+msgstr ""
+"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
+"供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1859,7 +1873,9 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
+msgstr ""
+"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
+"被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1929,8 +1945,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
-"的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
+"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2095,7 +2111,8 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr ""
+"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2275,7 +2292,9 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
+msgstr ""
+"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
+"記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2312,7 +2331,9 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
+msgstr ""
+"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
+"皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2454,9 +2475,10 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
-"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
+"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
+"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
+"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2468,8 +2490,10 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
-"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
+"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
+"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
+"根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2494,7 +2518,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr "無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-Fi 上隱藏你的 IP 位址。"
+msgstr ""
+"無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-"
+"Fi 上隱藏你的 IP 位址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2639,7 +2665,9 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
+msgstr ""
+"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
+"尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2648,8 +2676,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
-"僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
+"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2854,7 +2882,21 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
+msgstr ""
+"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
+"份資訊，將你的對話匿名化。"
+
+# smartling.placeholder_format=C
+#. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
+msgctxt ""
+"Disclaimer at the bottom of the Duck.ai response feedback form, replacing "
+"DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER when the rated response "
+"generated an image"
+msgid ""
+"Before storing this report, DuckDuckGo will remove uploaded files and "
+"generated images, and will anonymize your conversation by removing PII like "
+"names, email addresses, and identifying metadata."
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -2983,7 +3025,8 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr "封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
+msgstr ""
+"封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3242,20 +3285,26 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
+"合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
+"行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr ""
+"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
+"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3362,15 +3411,18 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
-"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
+"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
+"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
+"之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3378,7 +3430,9 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
+msgstr ""
+"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
+"始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3876,9 +3930,10 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
-"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
-"直接使用聊天功能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
+"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
+"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
+"能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4020,7 +4075,9 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr "聊天記錄採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
+msgstr ""
+"聊天記錄採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人"
+"可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4028,7 +4085,9 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
+msgstr ""
+"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
+"聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4040,8 +4099,9 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
+"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
+"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4063,7 +4123,9 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
+msgstr ""
+"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
+"供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4422,7 +4484,9 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr ""
+"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
+"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4432,8 +4496,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
-"天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
+"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4450,8 +4514,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
-"OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
+"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4612,7 +4676,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr ""
+"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
+"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4622,7 +4688,9 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr ""
+"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
+"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4897,7 +4965,8 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr ""
+"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5350,7 +5419,9 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr "從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝置同步%2$s，然後再試一次。"
+msgstr ""
+"從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝"
+"置同步%2$s，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6083,7 +6154,8 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr "刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
+msgstr ""
+"刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6196,7 +6268,9 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
+msgstr ""
+"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
+"Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6326,6 +6400,12 @@ msgid "Dislike source"
 msgstr "不喜歡的來源"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Dislike visual style"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
 msgid "Dismiss"
 msgstr "隱藏"
@@ -6436,6 +6516,12 @@ msgid "Djibouti"
 msgstr "吉布地"
 
 # smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
+msgctxt "Feedback prompt"
+msgid "Doesn't follow instructions"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
 msgctxt "settingsvalue"
 msgid "Domains Only"
@@ -6520,7 +6606,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
+"片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6528,7 +6616,9 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
+msgstr ""
+"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
+"片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6810,7 +6900,9 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
+msgstr ""
+"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
+"含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6819,7 +6911,9 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
+msgstr ""
+"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
+"何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6842,7 +6936,9 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
+msgstr ""
+"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
+"新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6856,7 +6952,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
+msgstr ""
+"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
+"https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6870,7 +6968,8 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6891,8 +6990,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
-"直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
+"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -6903,9 +7002,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
-"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
-"Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
+"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
+"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -6966,8 +7065,9 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
-"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
+"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
+"的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -6995,9 +7095,10 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
-"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
-"DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
+"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
+"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
+"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7006,8 +7107,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7016,8 +7117,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
-"OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
+"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7029,8 +7130,10 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
-"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
+"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
+"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
+"尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7044,10 +7147,11 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist "
-""
-"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
-"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
+"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
+"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
+"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
+"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7070,7 +7174,9 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7078,7 +7184,9 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
+msgstr ""
+"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
+"%3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7094,7 +7202,9 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr ""
+"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
+"傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7257,14 +7367,17 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
+msgstr ""
+"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
+"訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr ""
+"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7280,7 +7393,9 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr ""
+"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
+"器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7291,7 +7406,11 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
+msgstr ""
+"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
+"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
+"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
+"護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7310,7 +7429,9 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr ""
+"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
+"接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7401,7 +7522,10 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
+msgstr ""
+"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
+"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
+"至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7656,7 +7780,9 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
+msgstr ""
+"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
+"密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7831,7 +7957,9 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
+msgstr ""
+"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
+"密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7856,7 +7984,8 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr ""
+"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8196,6 +8325,12 @@ msgid "Fast"
 msgstr "快速"
 
 # smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Fast image generation"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
 msgctxt "Browser Promo Popover"
 msgid "Fast. Secure. Free."
@@ -8247,7 +8382,9 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
+msgstr ""
+"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
+"問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8489,7 +8626,8 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr ""
+"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8507,6 +8645,12 @@ msgstr "後續問題"
 msgctxt "Share modal info bullet about private original chat"
 msgid "Follow-ups remain private."
 msgstr "後續內容仍將保密。"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Followed instructions"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8723,8 +8867,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
-"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
+"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9102,7 +9246,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
-msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity Theft Restoration 服務。"
+msgstr ""
+"取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity "
+"Theft Restoration 服務。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9110,7 +9256,8 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
+msgstr ""
+"取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9118,7 +9265,9 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9128,7 +9277,9 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
+msgstr ""
+"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
+"隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9171,7 +9322,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr "取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以及更多高級防護。"
+msgstr ""
+"取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以"
+"及更多高級防護。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9180,15 +9333,16 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 Identity Theft "
-"Restoration。"
+"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 "
+"Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr "取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+msgstr ""
+"取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9288,8 +9442,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
+"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9298,8 +9452,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
-"› 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
+"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9309,8 +9463,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
+"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9320,8 +9474,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
-"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
+"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9329,7 +9483,8 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr "前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
+msgstr ""
+"前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9343,7 +9498,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr ""
+"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9351,7 +9507,8 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr ""
+"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9418,6 +9575,12 @@ msgstr "良好設計"
 msgctxt "Feedback prompt"
 msgid "Good privacy policy"
 msgstr "良好的隱私政策"
+
+# smartling.placeholder_format=C
+#. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
+msgctxt "Feedback prompt"
+msgid "Good visual style"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10065,7 +10228,9 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
+msgstr ""
+"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
+"為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10429,7 +10594,9 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
+msgstr ""
+"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
+"隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10439,8 +10606,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
-"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
+"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10454,7 +10621,8 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr ""
+"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10462,7 +10630,9 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
+msgstr ""
+"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
+"%2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10470,7 +10640,9 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
+msgstr ""
+"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
+"復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10530,6 +10702,12 @@ msgctxt ""
 "Disclaimer below chat input in Duck.ai when image generation is enabled"
 msgid "Image prompts must comply with the Duck.ai %s."
 msgstr "圖片提示必須符合 Duck.ai %1$s。"
+
+# smartling.placeholder_format=C
+#. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
+msgctxt "Feedback prompt"
+msgid "Image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10632,7 +10810,9 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr ""
+"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
+"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10642,7 +10822,9 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
+msgstr ""
+"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
+"步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11061,8 +11243,9 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
-"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
+"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
+"到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11070,7 +11253,9 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
+msgstr ""
+"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
+"全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -13118,8 +13303,9 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
-"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
+"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
+"的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -13953,7 +14139,9 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
+msgstr ""
+"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
+"定%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -13961,7 +14149,9 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s"
+msgstr ""
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
+"同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -13969,7 +14159,9 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
+msgstr ""
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
+"同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -13978,8 +14170,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描你復原 "
-"PDF 上的 QR 碼。"
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
+"同步%4$s。或掃描你復原 PDF 上的 QR 碼。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14006,7 +14198,8 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr ""
+"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14376,7 +14569,8 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr ""
+"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14389,7 +14583,9 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr "我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保護。一站式訂閱。"
+msgstr ""
+"我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保"
+"護。一站式訂閱。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14403,7 +14599,9 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
+msgstr ""
+"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
+"能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14655,7 +14853,9 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
+msgstr ""
+"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
+"回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -14810,7 +15010,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr "Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下來，我們會努力為你將該資訊移除。"
+msgstr ""
+"Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下"
+"來，我們會努力為你將該資訊移除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -14881,8 +15083,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
-"%1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
+"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14891,8 +15093,9 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
-"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
+"%1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -14902,8 +15105,9 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
-"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
+"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
+"DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -14935,7 +15139,8 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr ""
+"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -14951,7 +15156,8 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr ""
+"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15099,7 +15305,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
+"法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15107,7 +15315,9 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
+msgstr ""
+"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
+"害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15316,6 +15526,12 @@ msgstr "波蘭語"
 msgctxt "Feedback prompt"
 msgid "Poor formatting"
 msgstr "格式不佳"
+
+# smartling.placeholder_format=C
+#. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
+msgctxt "Feedback prompt"
+msgid "Poor image quality"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16162,7 +16378,9 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16170,7 +16388,9 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
+"中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16179,7 +16399,9 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr ""
+"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
+"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16460,7 +16682,8 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr ""
+"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16637,14 +16860,18 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
+msgstr ""
+"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
+"給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
+"身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16652,7 +16879,9 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr ""
+"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
+"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16743,7 +16972,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
+"答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16751,7 +16982,9 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
+msgstr ""
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
+"受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16761,8 +16994,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
-"%1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
+"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17186,7 +17419,9 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
+msgstr ""
+"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
+"多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17452,16 +17687,18 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
-"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
-"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
+"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
+"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
+"Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr ""
+"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17470,8 +17707,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
-"根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
+"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17591,7 +17828,9 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
+msgstr ""
+"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
+"「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17609,7 +17848,9 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr ""
+"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
+"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17628,8 +17869,9 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
-"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
+"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
+"料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17747,7 +17989,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
+msgstr ""
+"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
+"的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17755,7 +17999,9 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
+msgstr ""
+"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -17769,7 +18015,9 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
+msgstr ""
+"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
+"你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18175,7 +18423,9 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
+msgstr ""
+"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
+"對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18297,7 +18547,8 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr ""
+"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18403,7 +18654,9 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
+msgstr ""
+"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
+"露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18552,7 +18805,9 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr "使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或關閉。"
+msgstr ""
+"使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或"
+"關閉。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -18915,14 +19170,18 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
+"響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
+msgstr ""
+"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
+"響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20245,16 +20504,19 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
+"你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
+"Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
+"從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20392,7 +20654,9 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
+msgstr ""
+"隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存"
+"取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20400,7 +20664,9 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
+msgstr ""
+"隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快"
+"速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20643,7 +20909,9 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr ""
+"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
+"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20659,7 +20927,9 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr "Duck.ai 切換按鈕可讓你快速在私密搜尋與 AI 聊天之間切換，並由 DuckDuckGo 提供匿名化保護。"
+msgstr ""
+"Duck.ai 切換按鈕可讓你快速在私密搜尋與 AI 聊天之間切換，並由 DuckDuckGo 提供"
+"匿名化保護。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -20767,7 +21037,8 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr ""
+"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -20799,7 +21070,9 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr ""
+"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
+"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -20883,8 +21156,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
-"取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
+"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20893,7 +21166,9 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr ""
+"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
+"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -20901,7 +21176,9 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
+msgstr ""
+"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
+"的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -20911,8 +21188,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
-"(請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
+"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -20928,7 +21205,9 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr "此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在本機儲存空間中。"
+msgstr ""
+"此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在"
+"本機儲存空間中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21033,7 +21312,9 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
+msgstr ""
+"這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最"
+"上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21061,7 +21342,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
+msgstr ""
+"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
+"模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21069,7 +21352,9 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
+msgstr ""
+"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
+"式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21105,7 +21390,9 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
+msgstr ""
+"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
+"任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21113,7 +21400,9 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
+msgstr ""
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21123,8 +21412,9 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
-"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
+"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
+"AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21175,8 +21465,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
-"的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
+"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21321,7 +21611,9 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
+msgstr ""
+"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
+"示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21330,7 +21622,9 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
+msgstr ""
+"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
+"存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21338,7 +21632,9 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
+msgstr ""
+"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
+"試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21434,6 +21730,12 @@ msgstr "此來源的結果太多"
 msgctxt "Feedback prompt"
 msgid "Too slow"
 msgstr "太慢"
+
+# smartling.placeholder_format=C
+#. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
+msgctxt "Feedback prompt"
+msgid "Too slow to generate"
+msgstr ""
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21593,7 +21895,8 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21601,7 +21904,8 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr ""
+"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -21870,6 +22174,12 @@ msgid "Try fewer keywords."
 msgstr "嘗試使用較少關鍵字。"
 
 # smartling.placeholder_format=C
+#. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
+msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
+msgid "Try for Free"
+msgstr ""
+
+# smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid "Try for Free"
@@ -22078,7 +22388,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22086,7 +22398,9 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
+msgstr ""
+"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
+"定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22286,7 +22600,9 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
+msgstr ""
+"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
+"遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22537,7 +22853,9 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
+msgstr ""
+"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
+"方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -22919,7 +23237,9 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
+msgstr ""
+"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
+"害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23103,7 +23423,9 @@ msgctxt "duckai_seo"
 msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
-msgstr "查看從 Duck.ai 分享的對話——由 DuckDuckGo 提供的免費、私密 AI 聊天功能。 儲存到你自己的聊天記錄中，並私密地繼續聊天。"
+msgstr ""
+"查看從 Duck.ai 分享的對話——由 DuckDuckGo 提供的免費、私密 AI 聊天功能。 儲存"
+"到你自己的聊天記錄中，並私密地繼續聊天。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23137,7 +23459,8 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23145,7 +23468,9 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
+"理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23153,7 +23478,8 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Yelp 的廣告網路管理。"
+msgstr ""
+"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Yelp 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23195,8 +23521,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
-"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23206,8 +23532,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
+"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23217,8 +23543,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
+"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23228,8 +23554,9 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
-"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
+"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
+"PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23430,7 +23757,9 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
+msgstr ""
+"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
+"播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23450,8 +23779,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
-"沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
+"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23474,7 +23803,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
+"分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23485,7 +23816,9 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr ""
+"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
+"提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23525,7 +23858,8 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr ""
+"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23546,7 +23880,8 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr ""
+"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23585,7 +23920,9 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
+msgstr ""
+"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
+"商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23610,7 +23947,8 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr "我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
+msgstr ""
+"我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23618,7 +23956,9 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
+msgstr ""
+"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
+"慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23650,7 +23990,9 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
+msgstr ""
+"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
+"意。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -23658,7 +24000,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr "我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我們的進度。"
+msgstr ""
+"我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我"
+"們的進度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -23684,7 +24028,9 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
+msgstr ""
+"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
+"刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23697,7 +24043,9 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr "我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任何相關資訊移除。"
+msgstr ""
+"我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任"
+"何相關資訊移除。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -23856,7 +24204,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
+"用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -23864,7 +24214,9 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
+msgstr ""
+"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
+"化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -23874,8 +24226,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
-"DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
+"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24007,8 +24359,9 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
-"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
+"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
+"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24543,7 +24896,9 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
+msgstr ""
+"使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時"
+"在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24572,7 +24927,8 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr "直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
+msgstr ""
+"直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -24891,7 +25247,8 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr ""
+"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -24911,7 +25268,8 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr ""
+"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25066,7 +25424,9 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
+msgstr ""
+"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
+"出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25074,7 +25434,9 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
+msgstr ""
+"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
+"DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25095,7 +25457,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25104,7 +25468,9 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr ""
+"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
+"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25131,7 +25497,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
+"覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25218,7 +25586,9 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25227,7 +25597,9 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr ""
+"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
+"聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25240,7 +25612,9 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
+msgstr ""
+"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
+"Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25308,7 +25682,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25317,7 +25693,9 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr ""
+"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
+"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25381,14 +25759,16 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr ""
+"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25416,7 +25796,9 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
+msgstr ""
+"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
+"步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25455,7 +25837,8 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr ""
+"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25497,7 +25880,10 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
+msgstr ""
+"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
+"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
+"案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25511,7 +25897,9 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
+msgstr ""
+"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
+"無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25555,7 +25943,9 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
+msgstr ""
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No "
+"AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25564,8 +25954,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
-"%3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
+"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25592,7 +25982,9 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr ""
+"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
+"更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -25608,7 +26000,8 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr ""
+"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.

--- a/locales/zh_TW/LC_MESSAGES/duckduckgo.po
+++ b/locales/zh_TW/LC_MESSAGES/duckduckgo.po
@@ -2,10 +2,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DuckDuckGo-1.0\n"
-"POT-Creation-Date: 2019-01-16 23:42-0500\n"
-"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Last-Translator: Community\n"
 "Language-Team: DuckDuckGo Community <community@duckduckgo.com>\n"
+"POT-Creation-Date: 2019-01-16 23:42-0500\n"
+"PO-Revision-Date: 2019-01-16 23:42-0500\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -189,9 +189,7 @@ msgctxt "Error message when a Plus subscriber tries to use a Pro-only model"
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換"
-"至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Text for the disclaimer message that appears when a Plus subscriber tries to use a Pro-only model. %s is replaced with the model name. Example: Claude Opus 4.6 is only available with Pro. Upgrade your DuckDuckGo subscription in this browser again to continue the chat, or switch to a Plus or free model.
@@ -200,9 +198,7 @@ msgctxt ""
 msgid ""
 "%s is only available with Pro. Upgrade your DuckDuckGo subscription in this "
 "browser again to continue the chat, or switch to a Plus or free model."
-msgstr ""
-"%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切"
-"換至 Plus 或免費模式。"
+msgstr "%1$s 只適用於 Pro。請在此瀏覽器中再次升級你的 DuckDuckGo 訂閱以繼續聊天，或切換至 Plus 或免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI (Artificial Intelligence) chat model is temporarily unavailable. Example: 'GPT 4o is only available with a DuckDuckGo subscription.'
@@ -217,9 +213,7 @@ msgid ""
 "%s is only available with a DuckDuckGo subscription. Activate your "
 "subscription in this browser again to continue the chat, or switch to a free "
 "model."
-msgstr ""
-"%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或"
-"切換至免費模式。"
+msgstr "%1$s 只有訂閱 DuckDuckGo 才能使用。在此瀏覽器中再次啟用你的訂閱以繼續聊天，或切換至免費模式。"
 
 # smartling.placeholder_format=C
 #. Displayed when an AI chat model is temporarily unavailable. Example: 'GPT 3.5 Turbo is temporarily unavailable. Please switch to a different model or try again later.'
@@ -330,8 +324,8 @@ msgid ""
 "provider can see your prompts or the model’s responses, or save this chat on "
 "their servers."
 msgstr ""
-"%1$s 運行於受信任執行環境（Trusted Execution Environment）。這表示即使是模型"
-"提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
+"%1$s 運行於受信任執行環境（Trusted Execution "
+"Environment）。這表示即使是模型提供商也無法看到您的提示或模型的回應，也不會在其伺服器上儲存此聊天。"
 
 # smartling.placeholder_format=C
 #. Label shown in the batch selection toolbar when exactly one chat is selected. %s is replaced with 1. Use singular agreement where the language requires it.
@@ -416,8 +410,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in %s days (%s). After that, you can switch "
 "models to continue this chat."
-msgstr ""
-"%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 %2$s 天後離開 Duck.ai (%3$s)。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Displayed in a saved chat when its AI model is about to be retired tomorrow. First placeholder is the friendly model name, second placeholder is the removal date formatted in the user's browser locale (e.g., 'June 15, 2026' in en-US). Singular-day form.
@@ -427,8 +420,7 @@ msgctxt ""
 msgid ""
 "%s will be leaving Duck.ai in 1 day (%s). After that, you can switch models "
 "to continue this chat."
-msgstr ""
-"%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
+msgstr "%1$s 將在 1 天後 (%2$s) 離開 Duck.ai。之後，您可以切換模型以繼續此聊天。"
 
 # smartling.placeholder_format=C
 #. Shown in a text selection chip when the selection contains multiple words. %s is replaced with the number of words, e.g. '142 words'.
@@ -456,8 +448,7 @@ msgctxt "install-duckduckgo"
 msgid ""
 "%sClick %sContinue To Installation%sClick %sAdd%sCheck %sAllow%s, then click "
 "%sOkay%s"
-msgstr ""
-"%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
+msgstr "%1$s按%2$s繼續安裝%3$s按%4$s新增%5$s勾選%6$s允許%7$s，然後按%8$s確定%9$s"
 
 # smartling.placeholder_format=C
 #. A button that reloads search results when an error occurs.
@@ -926,8 +917,7 @@ msgstr "客場戰績"
 msgid ""
 "A network issue is preventing Search Assist from generating an answer. "
 "Please check your connection and try again."
-msgstr ""
-"網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
+msgstr "網路問題導致 Search Assist 無法生成答案。請檢查你的連線，接著再試一次。"
 
 # smartling.placeholder_format=C
 #. Text informing the user that a new version of AI Chat is available and they need to refresh the page.
@@ -985,9 +975,8 @@ msgid ""
 "still access AI Chat when this setting is off by visiting %sduckduckgo.com/"
 "aichat%s."
 msgstr ""
-"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo "
-"Search 上的 AI Chat 功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/"
-"aichat%2$s 使用 AI Chat 功能。"
+"AI Chat 能讓您與第三方 AI Chat 模型匿名對話。關閉此功能將隱藏 DuckDuckGo Search 上的 AI Chat "
+"功能。關閉此設定後，您仍可透過造訪 %1$sduckduckgo.com/aichat%2$s 使用 AI Chat 功能。"
 
 # smartling.placeholder_format=C
 #. A label for a setting that appears on a menu, used to control global AI features settings.
@@ -1048,9 +1037,8 @@ msgid ""
 "questions, which is our private AI-powered chat service that supports chat "
 "models from OpenAI, and Anthropic, and more."
 msgstr ""
-"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck."
-"ai%2$s 以回答後續問題，這是我們的私密 AI 驅動的聊天服務，支援來自 OpenAI、"
-"Anthropic 等的聊天模型。"
+"AI 輔助的答案目前不直接支援後續問題。不過，我們也提供並經常連結到 %1$sDuck.ai%2$s 以回答後續問題，這是我們的私密 AI "
+"驅動的聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has turned off AI features and will no longer see AI-assisted answers.
@@ -1819,9 +1807,7 @@ msgctxt "Privacy & Terms section description on the Duck.ai settings page"
 msgid ""
 "All chats are anonymized by DuckDuckGo, and your conversations are not used "
 "to train chat models by DuckDuckGo or the model providers"
-msgstr ""
-"所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型"
-"供應商用於訓練聊天模型"
+msgstr "所有聊天內容均由 DuckDuckGo 進行匿名處理，且你的對話不會由 DuckDuckGo 或模型供應商用於訓練聊天模型"
 
 # smartling.placeholder_format=C
 #. Title displayed at the top of the privacy protection modal in Duck.ai, summarizing that all conversations are private.
@@ -1873,9 +1859,7 @@ msgctxt "Body copy for the anonymized card in the How Duck.ai Works panel"
 msgid ""
 "All personal metadata (for example, your IP address) is removed before "
 "sending a chat to the AI provider."
-msgstr ""
-"在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會"
-"被移除。"
+msgstr "在將聊天內容傳送給 AI 服務提供者之前，所有個人元資料（例如您的 IP 位址）都會被移除。"
 
 # smartling.placeholder_format=C
 #. A filter that shows search results from all countries.
@@ -1945,8 +1929,8 @@ msgid ""
 "sends AI-generated queries to a search engine with limited data retention. "
 "Prompts and responses with %s still have %szero provider visibility%s."
 msgstr ""
-"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期"
-"限有限的搜尋引擎。%2$s 的提示和回應仍具有%3$s零提供者可見度%4$s。"
+"允許 %1$s 搜尋網頁，以調整相關提示的回應。僅將 AI 生成的查詢傳送到資料保留期限有限的搜尋引擎。%2$s "
+"的提示和回應仍具有%3$s零提供者可見度%4$s。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2111,8 +2095,7 @@ msgctxt "settings"
 msgid ""
 "Anonymously generates answers for search queries based on web content. "
 "Choose how often you want it to appear, or disable it completely."
-msgstr ""
-"根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
+msgstr "根據網頁內容匿名生成搜尋查詢的答案。你可以選擇它出現的頻率，或完全停用它。"
 
 # smartling.placeholder_format=C
 #. Instant Answer tab name
@@ -2292,9 +2275,7 @@ msgctxt "Body text for disable recent chats confirmation modal"
 msgid ""
 "Are you sure you want to disable recent chats? This will also delete any "
 "recent chats that are currently saved."
-msgstr ""
-"你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天"
-"記錄一併刪除。"
+msgstr "你是否確定要停用「最近的聊天記錄」？這麽做的話，也會將最近儲存下來的所有聊天記錄一併刪除。"
 
 # smartling.placeholder_format=C
 #. Question asking user if they want to share the URL of the page they were on when giving feedback
@@ -2331,9 +2312,7 @@ msgstr "更新時間："
 msgid ""
 "As per our privacy policy, we do not collect or share any personal "
 "information ourselves. All of this privacy protection happens on your device."
-msgstr ""
-"根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業"
-"皆於你的裝置上進行。"
+msgstr "根據我們的隱私政策規範，我們不會主動收集或分享任何個人資訊。這些隱私保護作業皆於你的裝置上進行。"
 
 # smartling.placeholder_format=C
 #. A button to ask Duck.ai a question
@@ -2475,10 +2454,9 @@ msgid ""
 "(shows more frequently on a wider range of searches). For now, AI-assisted "
 "answers are only available in the U.S. (English) region."
 msgstr ""
-"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想"
-"要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 Assist 使用介面)、隨選 (僅在"
-"點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更"
-"頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
+"Assist 可匿名根據相關網頁內容的摘要，生成某些搜尋的 AI 輔助答案。您可以選擇想要 Assist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"Assist 使用介面)、隨選 (僅在點按 Assist 按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 "
+"(在更廣泛的搜尋中更頻繁地顯示)。目前，AI 輔助答案僅在美國 (英文) 地區提供。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -2490,10 +2468,8 @@ msgid ""
 "to remember that responses are auto-generated from cited sources and based "
 "on %scrawling the web%s."
 msgstr ""
-"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI 協助的搜尋查詢答案。"
-"為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言"
-"技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並"
-"根據%1$s搜耙網路%2$s自動產生的。"
+"Assist 是我們搜尋結果中的一項選用功能，能夠匿名產生由 AI "
+"協助的搜尋查詢答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的。"
 
 # smartling.placeholder_format=C
 #. Title for the dropdown menu where users select the assistant's role. Example: 'Assistant role: Travel guide'
@@ -2518,9 +2494,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "At the café, airport, or hotel, DuckDuckGo VPN encrypts your connection and "
 "hides your IP address on Wi-Fi."
-msgstr ""
-"無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-"
-"Fi 上隱藏你的 IP 位址。"
+msgstr "無論是在咖啡廳、機場還是飯店，DuckDuckGo VPN 都能加密你的網路連線，並在 Wi-Fi 上隱藏你的 IP 位址。"
 
 # smartling.placeholder_format=C
 #. In the context of the National Hockey League (NHL), label for teams belonging to the Atlantic division
@@ -2665,9 +2639,7 @@ msgid ""
 "Automatically shows Assist for relevant searches. Assist can anonymously "
 "look up and summarize information in response to some searches. For now, "
 "Assist is only available in English regions."
-msgstr ""
-"自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜"
-"尋結果。目前，Assist 僅供英語地區使用。"
+msgstr "自動顯示相關搜尋的 Assist 功能。Assist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，Assist 僅供英語地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2676,8 +2648,8 @@ msgid ""
 "anonymously look up and summarize information in response to some searches. "
 "For now, DuckAssist is only available in English regions."
 msgstr ""
-"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應"
-"某些搜尋結果。目前，DuckAssist 僅供說英文的地區使用。"
+"對相關的搜尋自動顯示 DuckAssist。DuckAssist 能夠匿名搜尋與摘要資訊，以便回應某些搜尋結果。目前，DuckAssist "
+"僅供說英文的地區使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -2882,9 +2854,7 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "Before storing this report, DuckDuckGo will anonymize your conversation by "
 "removing PII like names, email addresses, and identifying metadata."
-msgstr ""
-"在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身"
-"份資訊，將你的對話匿名化。"
+msgstr "在儲存此報告前，DuckDuckGo 會透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Variant of DUCKCHAT_RESPONSE_FEEDBACK_ANONYMOUS_DISCLAIMER that also tells the user uploaded files and generated images are not part of the report. Shown instead of that string, never alongside it.
@@ -2896,7 +2866,7 @@ msgid ""
 "Before storing this report, DuckDuckGo will remove uploaded files and "
 "generated images, and will anonymize your conversation by removing PII like "
 "names, email addresses, and identifying metadata."
-msgstr ""
+msgstr "在儲存此報告前，DuckDuckGo 會移除已上傳的檔案與生成的圖片，並透過移除姓名、電子郵件地址及識別中繼資料等個人身份資訊，將你的對話匿名化。"
 
 # smartling.placeholder_format=C
 #. Label that's displayed next to a past start date below a web search result.
@@ -3025,8 +2995,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Block harmful sites, hide your IP address, plus get more premium protections "
 "with our subscription."
-msgstr ""
-"封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
+msgstr "封鎖有害網站、隱藏你的 IP 地址，訂閱我們的服務還能獲得更多高階保護功能。"
 
 # smartling.placeholder_format=C
 #. A disclaimer about AI-generated images in search results
@@ -3285,26 +3254,20 @@ msgstr "瀏覽檔案"
 msgid ""
 "Browse as usual while we add privacy protection. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組"
-"合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "享受隱私保護，只管放心瀏覽。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we'll take care of the rest. We bundled our search "
 "engine, tracker blocker, and encryption enforcer into one %s%s Extension%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執"
-"行程式組合為一項%1$s%2$s延伸模組%3$s。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。我們將搜尋引擎、追蹤器封鎖程式以及加密執行程式組合為一項%1$s%2$s延伸模組%3$s。"
 
 # smartling.placeholder_format=C
 msgid ""
 "Browse as usual, and we’ll take care of the rest. Get bundled private "
 "search, tracker blocking, and site encryption, all in one download, for "
 "%smajor browsers%s."
-msgstr ""
-"你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽"
-"器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
+msgstr "你盡可放心瀏覽，其餘的交給我們處理。只需下載一次，即可取得為%1$s主要瀏覽器%2$s設計的私密搜尋、追蹤器封鎖、網站加密等多合一功能。"
 
 # smartling.placeholder_format=C
 #. Header for a call to action to browse with the DuckDuckGo browser
@@ -3411,18 +3374,15 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使"
-"用匿名的 Could Save 以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別"
-"的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
+"預設情況下，所有的設定都使用非個人的 Cookie 儲存（在你的瀏覽器）。你也可以使用匿名的 Could Save "
+"以更持久的方式來將設定儲存在雲端的遠端伺服器。所有可識別的個人資訊都不會儲存在雲端，你的通關密語也不會從瀏覽器洩漏。"
 
 # smartling.placeholder_format=C
 #. Description for the consent highlight in the dictation consent modal. %s is replaced with a link to the help page.
 msgid ""
 "By enabling dictation, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始"
-"之前，請先查看我們的%1$s。"
+msgstr "啟用語音輸入功能即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Description for the 'enable voice chat' section of the voice chat consent modal. Placeholder for the voice chat help page link and text. Example: 'By enabling voice chat, you consent to your voice data being sent to OpenAI for the use of this feature. See our voice chat help page before getting started.'
@@ -3430,9 +3390,7 @@ msgctxt "voice chat"
 msgid ""
 "By enabling voice chat, you consent to your voice data being sent to OpenAI "
 "for the use of this feature. See our %s before getting started."
-msgstr ""
-"啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開"
-"始之前，請先查看我們的%1$s。"
+msgstr "啟用語音聊天功能，即表示您同意將您的語音資料傳送至 OpenAI 以使用此功能。在開始之前，請先查看我們的%1$s。"
 
 # smartling.placeholder_format=C
 #. Golf leaderboard: player missed the cut
@@ -3930,10 +3888,9 @@ msgid ""
 "DuckDuckGo Search. However, you can still access Chat when this setting is "
 "off by visiting %shttps://duck.ai%s directly."
 msgstr ""
-"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 "
-"OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo Search 上的聊天按鈕和連"
-"結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 直接使用聊天功"
-"能。"
+"聊天 (透過我們的 Duck.ai 服務) 能讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 "
+"DuckDuckGo Search 上的聊天按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s "
+"直接使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text for the switch label that enables or disables the Chat History feature, a feature that stores the user's chats.
@@ -4075,9 +4032,7 @@ msgctxt "Chat history with sync modal list item description"
 msgid ""
 "Chats are securely stored on DuckDuckGo's server with end-to-end encryption. "
 "Nobody but you can see your data, not even us."
-msgstr ""
-"聊天記錄採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人"
-"可以看到你的資料，連我們也不行。"
+msgstr "聊天記錄採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Text explaining that the Chat History feature stores the user's chats locally to their device, and not in other remote servers. Also explains that disabling chat history will delete pinned chats.
@@ -4085,9 +4040,7 @@ msgctxt "Description for Chat History feature"
 msgid ""
 "Chats are stored locally on your device instead of on DuckDuckGo servers or "
 "remote servers. Disabling chat history will delete pinned chats."
-msgstr ""
-"聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用"
-"聊天記錄將刪除置頂的聊天。"
+msgstr "聊天記錄會儲存在你的裝置本機上，而非 DuckDuckGo 伺服器或其他遠端伺服器。停用聊天記錄將刪除置頂的聊天。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the Chat History feature stores the user's chats locally to their device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection. Also explains that disabling chat history will delete pinned chats.
@@ -4099,9 +4052,8 @@ msgid ""
 "history will delete pinned chats, and disable the temporary storage of new "
 "prompts and responses."
 msgstr ""
-"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 "
-"DuckDuckGo 伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置"
-"頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
+"聊天記錄將儲存在你的裝置本地。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Title shown above the body copy in the Duck.ai recent chats IndexedDB unavailable notice.
@@ -4123,9 +4075,7 @@ msgctxt "DuckChat upload consent prompt for encrypted models"
 msgid ""
 "Chats with %s have zero provider visibility, but all files uploaded in Duck."
 "ai are anonymously reviewed by a content moderation provider for %s."
-msgstr ""
-"與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴"
-"供應商匿名審核，以用於 %2$s。"
+msgstr "與 %1$s 的聊天完全沒有供應商可見度，但在 Duck.ai 上傳的所有檔案都會由內容審柴供應商匿名審核，以用於 %2$s。"
 
 # smartling.placeholder_format=C
 #. Body text shown on the inline disclaimer above the chat input when the file-storage sync quota is full.
@@ -4484,9 +4434,7 @@ msgctxt "Information about the effect of clearing browser data on recent chats"
 msgid ""
 "Clearing browser data deletes chats. Some browsers may keep recent chats "
 "indefinitely or auto-delete them after 7+ days of no AI Chat use."
-msgstr ""
-"清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近"
-"的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
+msgstr "清除瀏覽器資料的話，也會將聊天記錄一併刪除。特定的瀏覽器可能會無限期保留最近的聊天記錄，或是在你超過 7 天未使用 AI Chat 後自動將聊天記錄刪除。"
 
 # smartling.placeholder_format=C
 #. Text explaining what happens to recent chats when browser data is cleared.
@@ -4496,8 +4444,8 @@ msgid ""
 "indefinitely or auto-deleted after 7 days without using Duck.ai, depending "
 "on your browser."
 msgstr ""
-"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期"
-"保存，或在不使用 Duck.ai 的情況下 7 天後自動刪除，視您的瀏覽器而定。"
+"清除瀏覽器資料的話，也會將最近的聊天記錄一併刪除。最近的聊天記錄可能會無限期保存，或在不使用 Duck.ai 的情況下 7 "
+"天後自動刪除，視您的瀏覽器而定。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on the Block domain success modal. Blocked sites are stored in localStorage which is cleared alongside cookies when users clear browser data. Followed by a linked 'our free browser' text.
@@ -4514,8 +4462,8 @@ msgid ""
 "%sDuck.ai%s, our private AI chat service that supports chat models from "
 "OpenAI, Anthropic, and more."
 msgstr ""
-"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私"
-"人 AI 聊天服務，支援來自 OpenAI、Anthropic 等的聊天模型。"
+"按一下「更多」深入瞭解主題，並透過 %1$sDuck.ai%2$s 提出後續問題，這是我們的私人 AI 聊天服務，支援來自 "
+"OpenAI、Anthropic 等的聊天模型。"
 
 # smartling.placeholder_format=C
 #. Tells the user where to click in their browser. Part of a list of instructions on how to change the brower's home page.
@@ -4676,9 +4624,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Search Settings%s."
-msgstr ""
-"按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏"
-"覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
+msgstr "按一下或點擊 %1$s刪除我的資料%2$s。這將從雲端移除資料，但資料仍將留存於您的瀏覽器中，等您按一下/點擊%3$s重設所有搜尋設定%4$s才會刪除。"
 
 # smartling.placeholder_format=C
 #. Tells users where to click in order to disable the cloud save feature and delete any data backed-up to the cloud.
@@ -4688,9 +4634,7 @@ msgctxt "cloudsave"
 msgid ""
 "Click or tap %sDelete My Data%s. This removes the data from the cloud, but "
 "it remains in your browser until you click/tap %sReset All Settings%s."
-msgstr ""
-"按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的"
-"瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
+msgstr "按一下或點按%1$s刪除我的資料%2$s。這即會從雲端移除資料，但資料仍會留存於你的瀏覽器中，等你按一下/點按%3$s重設所有設定%4$s才會刪除。"
 
 #  Chrome 36 on macOS, 27 on Windows
 # smartling.placeholder_format=C
@@ -4965,8 +4909,7 @@ msgctxt "cloudsave"
 msgid ""
 "Cloud Save lets you save your settings more permanently by entering a "
 "passphrase. It is entirely optional."
-msgstr ""
-"Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
+msgstr "Cloud Save將更長久地保留你的設定，只要輸入通關密語即可套用。此項純屬自願。"
 
 # smartling.placeholder_format=C
 #. Description of the daily/hourly weather condition, as returned from the (WeatherKit) API
@@ -5419,9 +5362,7 @@ msgctxt "Description for the wrong code error screen"
 msgid ""
 "Copy the code from another device. Go to %sDuck.ai Settings › Chats › Sync & "
 "Backup › Sync With Another Device%s and try again."
-msgstr ""
-"從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝"
-"置同步%2$s，然後再試一次。"
+msgstr "從其他裝置複製代碼。前往 %1$s Duck.ai 設定 › 聊天 › Sync & Backup › 與其他裝置同步%2$s，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Tooltip text for the button that copies the chat response content to the clipboard.
@@ -6154,8 +6095,7 @@ msgctxt "Description at the top of the Duck.ai shared links modal"
 msgid ""
 "Deleting a link stops it from working. People who have opened it and added "
 "the conversation to their chats will keep their own copy."
-msgstr ""
-"刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
+msgstr "刪除連結會導致連結失效。已經開啟連結並將對話加入聊天的人會保留自己的副本。"
 
 # smartling.placeholder_format=C
 #. Warning message shown on settings pages and modals to inform users that deleting browser cookies will reset their search preferences.
@@ -6268,9 +6208,7 @@ msgstr "聽寫功能暫時無法使用"
 msgid ""
 "Dictation uses an OpenAI model to convert your speech to text, so you can "
 "chat in Duck.ai without having to type."
-msgstr ""
-"語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 "
-"Duck.ai 中聊天。"
+msgstr "語音輸入功能使用 OpenAI 模型將您的語音轉換為文字，因此您不用輸入文字也能在 Duck.ai 中聊天。"
 
 # smartling.placeholder_format=C
 #. In 0-click box -- link to definition.
@@ -6403,7 +6341,7 @@ msgstr "不喜歡的來源"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Dislike visual style"
-msgstr ""
+msgstr "不喜歡視覺風格"
 
 # smartling.placeholder_format=C
 #. This appears on a button that a user clicks to close a notification.
@@ -6519,7 +6457,7 @@ msgstr "吉布地"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image.
 msgctxt "Feedback prompt"
 msgid "Doesn't follow instructions"
-msgstr ""
+msgstr "未依照指示"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing only the domain for a website URL (e.g. domain.com) -- Example image: https://i.imgur.com/KkBcFcQ.png
@@ -6606,9 +6544,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? %snoai.duckduckgo.com%s offers no AI features and AI images "
 "filtered out. %sLearn More%s"
-msgstr ""
-"不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖"
-"片。 %3$s瞭解更多%4$s"
+msgstr "不想要 AI？%1$snoai.duckduckgo.com%2$s 不提供 AI 功能，且已過濾 AI 生成的圖片。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Note shown at the bottom of the full Settings page. The first two placeholders wrap noai.duckduckgo.com in a link. The last two placeholders wrap Learn more in a link to the noai help page.
@@ -6616,9 +6552,7 @@ msgctxt "settings"
 msgid ""
 "Don’t want AI? Visit %snoai.duckduckgo.com%s to search with no AI features "
 "and AI images filtered out. %sLearn more%s"
-msgstr ""
-"不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖"
-"片的搜尋。%3$s瞭解更多%4$s"
+msgstr "不想要 AI？請造訪 %1$snoai.duckduckgo.com%2$s 以進行無 AI 功能且過濾掉 AI 圖片的搜尋。%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Tennis match stats
@@ -6900,9 +6834,7 @@ msgid ""
 "Duck.ai can now help answer questions about the page you're viewing. Page "
 "content is only included when you attach it, unless you choose to attach "
 "pages automatically in Settings."
-msgstr ""
-"Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包"
-"含，除非你在設定中選擇自動附加頁面。"
+msgstr "Duck.ai 現在可以幫助回答你正在檢視的頁面上的問題。頁面內容僅在你附加它時包含，除非你在設定中選擇自動附加頁面。"
 
 # smartling.placeholder_format=C
 #. Shown in the Duck.ai recent chats list on standalone when the browser API needed to store chats locally is missing or unavailable.
@@ -6911,9 +6843,7 @@ msgctxt ""
 msgid ""
 "Duck.ai can’t access local storage to save your chats. Please check your "
 "browser settings or disable any extensions and try again."
-msgstr ""
-"Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任"
-"何擴充套件，然後再試一次。"
+msgstr "Duck.ai 無法存取本機儲存空間來儲存你的聊天記錄。請檢查您的瀏覽器設定或停用任何擴充套件，然後再試一次。"
 
 # smartling.placeholder_format=C
 #. Displayed when the chat service has reached the maximum number of messages for one day.
@@ -6936,9 +6866,7 @@ msgid ""
 "Duck.ai is created by DuckDuckGo. We're an independent online protection "
 "company for anyone who wants to take back control of their personal "
 "information."
-msgstr ""
-"Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重"
-"新掌控個人資訊的人。"
+msgstr "Duck.ai 由 DuckDuckGo 建立。 我們是一間獨立的線上保護公司，旨在協助任何想要重新掌控個人資訊的人。"
 
 # smartling.placeholder_format=C
 #. Title shown when an update is required before proceeding.
@@ -6952,9 +6880,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Duck.ai is still a DuckDuckGo product, but will now have an easier to "
 "remember home on the web: https://duck.ai"
-msgstr ""
-"Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁："
-"https://duck.ai"
+msgstr "Duck.ai 仍然是 DuckDuckGo 產品，但現在將在網絡上有一個更容易記住的主頁：https://duck.ai"
 
 # smartling.placeholder_format=C
 #. Headline for domain change notice.
@@ -6968,8 +6894,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "Duck.ai is temporarily unavailable. If this persists, please email this "
 "anonymous code %s to %s"
-msgstr ""
-"Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
+msgstr "Duck.ai 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -6990,8 +6915,8 @@ msgid ""
 "Duck.ai lets you chat privately with popular AI models. Disabling it hides "
 "Duck.ai buttons and links, but you can still visit %sduck.ai%s directly."
 msgstr ""
-"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，"
-"但你仍然可以造訪 %1$sduck.ai%2$s 直接使用。"
+"Duck.ai 讓你與熱門的 AI 模型進行私密聊天。 停用後將隱藏 Duck.ai 按鈕和連結，但你仍然可以造訪 %1$sduck.ai%2$s "
+"直接使用。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -7002,9 +6927,9 @@ msgid ""
 "can still access Duck.ai when this setting is off by visiting %shttps://duck."
 "ai%s directly."
 msgstr ""
-"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。"
-"關閉此設定將隱藏 DuckDuckGo Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定"
-"後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 Duck.ai使用聊天功能。"
+"Duck.ai 讓你與第三方 AI 聊天模型進行匿名對話，支援 OpenAI、Anthropic 等模型。關閉此設定將隱藏 DuckDuckGo "
+"Search 上的 Duck.ai 按鈕和連結。不過，關閉此設定後，您仍可透過造訪 %1$shttps://duck.ai%2$s 來存取 "
+"Duck.ai使用聊天功能。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding Duck.ai.
@@ -7065,9 +6990,8 @@ msgid ""
 "AI chat no sign up, OpenAI, Anthropic, Llama, Mistral, open source AI "
 "models, privacy focused AI, no account AI chat"
 msgstr ""
-"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需"
-"註冊的 AI 聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點"
-"的 AI、無需帳號的 AI 聊天"
+"Duck.ai、DuckDuckGo AI、私密 AI 聊天機器人、免費 AI 聊天、匿名 AI 聊天、無需註冊的 AI "
+"聊天、OpenAI、Anthropic、Llama、Mistral、開源 AI 模型、以隱私為重點的 AI、無需帳號的 AI 聊天"
 
 # smartling.placeholder_format=C
 #. Shown directly below the Duck.ai logo on the empty chat page when the new suggestion chips are visible (new users, or users who haven't yet accepted the terms of service). Replaces the legacy 'All chats are private' header in this state.
@@ -7095,10 +7019,9 @@ msgid ""
 "relevant), or Often (shows more frequently on a wider range of searches). "
 "For now, DuckAssist is only available in the U.S. (English) region."
 msgstr ""
-"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 "
-"DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 DuckAssist UI)、隨選 (僅在"
-"點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁"
-"地顯示)。目前 DuckAssist 僅供美國 (英文) 地區使用。"
+"DuckAssist 可匿名搜尋資訊並做成摘要，以便回應某些搜尋結果。您可以選擇想要 DuckAssist 出現的頻率：從不 (從搜尋結果中完全移除 "
+"DuckAssist UI)、隨選 (僅在點按協助按鈕後顯示)、有時 (僅在高度相關時顯示) 或經常 (在更廣泛的搜尋中更頻繁地顯示)。目前 "
+"DuckAssist 僅供美國 (英文) 地區使用。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7107,8 +7030,8 @@ msgid ""
 "%sDuckDuckGo AI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI, and Anthropic, and more."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 等聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供%1$s DuckDuckGo AI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 等聊天模型。"
 
 # smartling.placeholder_format=C
 #. Second paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7117,8 +7040,8 @@ msgid ""
 "DuckDuckGo %sAI Chat%s, which is a private AI-powered chat service that "
 "supports chat models from OpenAI and Anthropic."
 msgstr ""
-"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這"
-"是一款私密 AI 驅動的聊天服務，支援 OpenAI 和 Anthropic 的聊天模型。"
+"DuckAssist 無法回答後續問題，但是，我們亦提供 DuckDuckGo %1$sAI Chat%2$s，這是一款私密 AI 驅動的聊天服務，支援 "
+"OpenAI 和 Anthropic 的聊天模型。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7130,10 +7053,8 @@ msgid ""
 "responses are currently based on Wikipedia and related content and are not "
 "checked for accuracy."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了"
-"完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 AI 驅動的自"
-"然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，"
-"尚未確認準確性。"
+"DuckAssist 是我們搜尋結果中的一項全新功能，能夠匿名產生搜尋查詢的答案。 為了完成此任務，它將掃描維基百科與相關網站以便查詢相關內容，接著使用 "
+"AI 驅動的自然語言處理技術產生該資訊的摘要。 請注意，目前的回應僅根據維基百科與相關內容，尚未確認準確性。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -7147,11 +7068,10 @@ msgid ""
 "It’s important to remember that responses are auto-generated from cited "
 "sources and based on %scrawling the web%s."
 msgstr ""
-"DuckAssist 是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完"
-"成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，"
-"根據找到的相關資訊產生簡短的答案。DuckAssist 的回應始終直接連結至一個或兩個來"
-"源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是"
-"從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
+"DuckAssist "
+""
+"是我們搜尋結果中的一項選用功能，能夠匿名產生搜尋查詢的答案。為了完成此任務，它將掃描網路以便查詢相關內容，接著使用人工智慧支援的自然語言技術，根據找到的相關資訊產生簡短的答案。DuckAssist "
+"的回應始終直接連結至一個或兩個來源，並引用答案的來源，因此您能夠輕鬆取得更詳盡的資料。重要的是要記住，回應是從引用的來源並根據%1$s搜耙網路%2$s自動產生的，"
 
 # smartling.placeholder_format=C
 #. Disclaimer for the duckassist instant answer (based on generative AI)
@@ -7174,9 +7094,7 @@ msgctxt "Modal body for information"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Subtitle displayed on the welcome screen of the onboarding. Example: 'DuckDuckGo AI Chat is a private AI-powered chat service that currently supports OpenAI’s GPT-3.5 and Anthropic’s Claude chat models.'
@@ -7184,9 +7102,7 @@ msgctxt "Onboarding welcome screen subtitle"
 msgid ""
 "DuckDuckGo AI Chat is a private AI-powered chat service that currently "
 "supports %s’s %s and %s’s %s chat models."
-msgstr ""
-"DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 "
-"%3$s 的 %4$s 聊天模型。"
+msgstr "DuckDuckGo AI Chat 是一款私密 AI 驅動的聊天服務，目前支援 %1$s 的 %2$s 與 %3$s 的 %4$s 聊天模型。"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding DuckDuckGo AI Chat.
@@ -7202,9 +7118,7 @@ msgctxt "Error message for BOTNET limit."
 msgid ""
 "DuckDuckGo AI Chat is temporarily unavailable. If this persists, please "
 "email this anonymous code %s to %s"
-msgstr ""
-"DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件"
-"傳送至%2$s"
+msgstr "DuckDuckGo AI Chat 暫時無法使用。若問題仍存在，請將此匿名代碼%1$s透過電子郵件傳送至%2$s"
 
 # smartling.placeholder_format=C
 #. Displayed when there is an error in the chat and ask the user to refresh the page and try again.
@@ -7367,17 +7281,14 @@ msgctxt "Disclaimer at the bottom of the Duck.ai response feedback form"
 msgid ""
 "DuckDuckGo anonymizes these reports by automatically removing PII like "
 "names, email addresses, phone numbers, and identifying metadata."
-msgstr ""
-"DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資"
-"訊來匿名化這些報告。"
+msgstr "DuckDuckGo 透過自動移除姓名、電子郵件地址、電話號碼及識別中繼資料等個人身份資訊來匿名化這些報告。"
 
 # smartling.placeholder_format=C
 #. The first %s is the agree button label ('Agree'). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. The leading sentence mirrors the drawer-style inline disclaimer (DUCKCHAT_TOS_INLINE_DISCLAIMER).
 msgctxt "Body copy of terms-of-service decision card on Duck.ai"
 msgid ""
 "DuckDuckGo anonymizes your chats. By clicking '%s' you agree to Duck.ai's %s."
-msgstr ""
-"DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
+msgstr "DuckDuckGo 將您的聊天匿名化。點擊「%1$s」，即表示你同意 Duck.ai 的%2$s。"
 
 # smartling.placeholder_format=C
 #. Shown below the input on the empty state when the user has not yet accepted the terms of service. The first %s is the action button label ('Ask' for chat, 'Create' for image generation). The second %s is a clickable link with the text 'Privacy Policy and Terms of Service' that opens the policy in a new tab. Clicking the action button both accepts the terms and submits the prompt.
@@ -7393,9 +7304,7 @@ msgid ""
 "DuckDuckGo blocks trackers on websites you visit, including trackers from "
 "companies like Google and Facebook, who often try to track you on other "
 "websites."
-msgstr ""
-"DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤"
-"器，它們經常試圖在你造訪其他網站時追蹤你。"
+msgstr "DuckDuckGo將封鎖你造訪網站上的追蹤器，包括來自Google和Facebook等公司的追蹤器，它們經常試圖在你造訪其他網站時追蹤你。"
 
 # smartling.placeholder_format=C
 #. Description of how DuckDuckGo keeps a user's location anonymous while the user searches on a map of their area.
@@ -7406,11 +7315,7 @@ msgid ""
 "use it to improve results for that search, and then we promptly throw it "
 "away, such that you remain anonymous. %sLearn more about how we designed "
 "this technology to protect your privacy%s."
-msgstr ""
-"DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置"
-"上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我"
-"們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保"
-"護你的隱私%2$s。"
+msgstr "DuckDuckGo的設計以隱私為主要考量。當你啟用定位功能時，只會儲存於你的本機裝置上。當你搜尋時，你的裝置會將位置傳送給我們，讓我們改善該次的搜尋結果，然後我們會立即將其丟棄，讓你繼續保持匿名。%1$s進一步瞭解我們如何設計了這項技術來保護你的隱私%2$s。"
 
 # smartling.placeholder_format=C
 msgctxt "new tab page"
@@ -7429,9 +7334,7 @@ msgctxt "settings"
 msgid ""
 "DuckDuckGo only uses your approximate location. That's all we need to "
 "deliver better results, closer to you. %sLearn more%s."
-msgstr ""
-"DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更"
-"接近你的搜尋結果。%1$s瞭解更多%2$s。"
+msgstr "DuckDuckGo只會使用你的大概位置。我們只需要這麼一點點資訊，就能呈現更好、也更接近你的搜尋結果。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 msgid "DuckDuckGo search"
@@ -7522,10 +7425,7 @@ msgid ""
 "random words from the DuckDuckGo servers. In the browser, we then select 4-5 "
 "random words from that list, ensuring that the passphrase is at least 18-20 "
 "characters long."
-msgstr ""
-"當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我"
-"們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18"
-"至20個字元。"
+msgstr "當你需要通關密語建議時，我們會從DuckDuckGo伺服器收到一長串隨機單字的清單。我們會在瀏覽器中從該清單隨機挑選出4至5個單字，確認每個通關密語的長度都至少有18至20個字元。"
 
 # smartling.placeholder_format=C
 msgctxt "Sports module"
@@ -7780,9 +7680,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Enabling anonymous location gives more accurate results but still keeps your "
 "searches and exact location private to DuckDuckGo."
-msgstr ""
-"啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保"
-"密。"
+msgstr "啟用匿名位置可提供更準確的結果，但 DuckDuckGo 仍會對你的搜尋與確切位置進行保密。"
 
 # smartling.placeholder_format=C
 msgid "Encrypt Connections"
@@ -7957,9 +7855,7 @@ msgctxt "cloudsave"
 msgid ""
 "Enter a new passphrase and click/tap %sSave Settings%s. This will save your "
 "data under your new passphrase."
-msgstr ""
-"輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關"
-"密語下。"
+msgstr "輸入新的通關密語，再按一下/點按%1$s儲存設定%2$s。這會將你的資料儲存在新的通關密語下。"
 
 # smartling.placeholder_format=C
 #. Label for the field where a user enters their passphrase.
@@ -7984,8 +7880,7 @@ msgstr "輸入文字"
 #. Instructions for how to change the default search engine.
 msgid ""
 "Enter the following details: %sName%s: DuckDuckGo%s URL%s: %s Alias%s: d%s"
-msgstr ""
-"輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
+msgstr "輸入以下細節：%1$s名稱%2$s：DuckDuckGo%3$s URL%4$s：%5$s暱稱%6$s：d%7$s"
 
 # smartling.placeholder_format=C
 #. Prompt to enter a destination for driving directions.
@@ -8328,7 +8223,7 @@ msgstr "快速"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Fast image generation"
-msgstr ""
+msgstr "圖片生成速度快"
 
 # smartling.placeholder_format=C
 #. Tagline in a promotion for a desktop web browser
@@ -8382,9 +8277,7 @@ msgctxt "feedback form"
 msgid ""
 "Feedback like yours directly influences our product updates and "
 "improvements. Hopefully we can address the issue you shared too."
-msgstr ""
-"像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的"
-"問題。"
+msgstr "像你提供的的意見回饋會直接影響我們的產品更新和改善。希望我們也能解決你分享的問題。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/search_box
@@ -8626,8 +8519,7 @@ msgstr "多霧"
 msgid ""
 "Follow the instructions for turning off the ad blocker for DuckDuckGo. You "
 "may have to select a menu option or click a button."
-msgstr ""
-"按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
+msgstr "按照指示關閉 DuckDuckGo 的廣告封鎖程式。你可能需要選取一個選項或按一下按鈕。"
 
 # smartling.placeholder_format=C
 #. Privacy reassurance and instructions intro.
@@ -8650,7 +8542,7 @@ msgstr "後續內容仍將保密。"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Followed instructions"
-msgstr ""
+msgstr "遵循指示"
 
 # smartling.placeholder_format=C
 #. Link to DuckDuckGo's Twitter profile.
@@ -8867,8 +8759,8 @@ msgid ""
 "<strong>Check for Updates...</strong>, then select <strong>Install Update</"
 "strong>."
 msgstr ""
-"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> &gt;"
-"<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
+"從 Mac 上的應用程式功能表工具列中，選取<strong>DuckDuckGo</strong> "
+"&gt;<strong>檢查更新...</strong> ，然後選取<strong>安裝更新</strong>。"
 
 # smartling.placeholder_format=C
 #. This is an option for a user setting. It refers to showing the full URL for a website, including the url path, but made to look like the breadcrumbs of a website (e.g. website.com > this > is > the > path) -- Example image: https://i.imgur.com/roiQBYz.png
@@ -9246,9 +9138,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, Personal Info Removal, "
 "and Identity Theft Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity "
-"Theft Restoration 服務。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話、個人資訊移除，以及 Identity Theft Restoration 服務。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; 'advanced AI chat' refers to Duck.ai; Identity Theft Restoration is a bundled feature.
@@ -9256,8 +9146,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get a fast, no-log VPN, optional advanced AI chat, and Identity Theft "
 "Restoration."
-msgstr ""
-"取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
+msgstr "取得快速、無紀錄的 VPN、選配的進階 AI 對話，以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription modal where users can update their subscription to DuckDuckGo.
@@ -9265,9 +9154,7 @@ msgctxt "Description of the modal to upgrade the DuckDuckGo subscription"
 msgid ""
 "Get access to advanced AI models in Duck.ai by subscribing to DuckDuckGo, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. Description for the subscription setting where users can subscribe to DuckDuckGo.
@@ -9277,9 +9164,7 @@ msgctxt ""
 msgid ""
 "Get access to advanced AI models in Duck.ai with a DuckDuckGo subscription, "
 "which also includes our VPN and other premium privacy protections."
-msgstr ""
-"訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級"
-"隱私權保護。"
+msgstr "訂閱 DuckDuckGo，即可存取 Duck.ai 的進階 AI 模型，還包括我們的 VPN 和其他頂級隱私權保護。"
 
 # smartling.placeholder_format=C
 #. A button for users to generate an AI generated answer from their query on the duckassist module
@@ -9322,9 +9207,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our fast, no-log VPN, optional access to advanced AI models with higher "
 "chat limits, and more premium protections."
-msgstr ""
-"取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以"
-"及更多高級防護。"
+msgstr "取得我們快速、不記錄活動的 VPN、可選擇存取具有更高聊天限制的進階 AI 模型，以及更多高級防護。"
 
 # smartling.placeholder_format=C
 #. US-only body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; 'Personal Information Removal' removes the user's personal information from data broker sites; Identity Theft Restoration is a bundled feature.
@@ -9333,16 +9216,15 @@ msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, Personal Information Removal, "
 "and Identity Theft Restoration."
 msgstr ""
-"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 "
-"Identity Theft Restoration。"
+"取得我們安全的無紀錄 VPN、先進的 Duck.ai，Personal Information Removal，以及 Identity Theft "
+"Restoration。"
 
 # smartling.placeholder_format=C
 #. Body text of the DuckDuckGo Subscription instant answer shown on the search results page. One of several messages rotated over time; international (non-US) version. 'No-log' means the VPN keeps no activity logs; Duck.ai is DuckDuckGo's AI chat product; Identity Theft Restoration is a bundled feature.
 msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Get our secure, no-log VPN, advanced Duck.ai, and Identity Theft Restoration."
-msgstr ""
-"取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
+msgstr "取得我們安全、無日誌的 VPN、先進的 Duck.ai 以及 Identity Theft Restoration。"
 
 # smartling.placeholder_format=C
 msgid ""
@@ -9442,8 +9324,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device › Copy Text Code%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 "
-"%3$s聊天記錄 › Sync & Backup › 與另一裝置同步 › 複製文字代碼%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或前往 DuckDuckGo 應用程式並進入 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步 › 複製文字代碼%4$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -9452,8 +9334,8 @@ msgid ""
 "Go to %sDuck.ai Settings%s in your other browser, or the DuckDuckGo App and "
 "go to %sChats › Sync & Backup › Sync With Another Device%s"
 msgstr ""
-"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s"
-"聊天記錄 › Sync & Backup › 與另一裝置同步%4$s"
+"前往其他瀏覽器中的 %1$sDuck.ai 設定%2$s，或在 DuckDuckGo 應用程式中前往 %3$s聊天記錄 › Sync & Backup "
+"› 與另一裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -9463,8 +9345,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s and scan this "
 "code:"
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊"
-"天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
+"使用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，再前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -9474,8 +9356,8 @@ msgid ""
 "go to %sChats › Sync & Backup › Sync With Another Device%s. Or scan the QR "
 "on your Recovery PDF."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s"
-"聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式前往 %1$sDuck.ai 設定%2$s，然後前往 %3$s聊天 › Sync & Backup › "
+"與其他裝置同步%4$s。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Path to the pairing code on the other device. Bold segments are UI path labels.
@@ -9483,8 +9365,7 @@ msgctxt "Detail under the first numbered step on the Enter Code tab"
 msgid ""
 "Go to %sDuck.ai Settings%s › %sChats › Sync & Backup › Sync With Another "
 "Device%s."
-msgstr ""
-"前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
+msgstr "前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells user where to find location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9498,8 +9379,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy & Security > Location Services%s, and make sure "
 "“Location Services” is turned on."
-msgstr ""
-"前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
+msgstr "前往 %1$s 設定 > 隱私權和安全性 > 位置服務 %2$s，並確定「位置服務」已開啟。"
 
 # smartling.placeholder_format=C
 #. Prompts users to turn on the location service on their phone.
@@ -9507,8 +9387,7 @@ msgctxt "precise_user_location"
 msgid ""
 "Go to %sSettings > Privacy > Permission manager > Location%s and scroll down "
 "to %sDuckDuckGo%s."
-msgstr ""
-"前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
+msgstr "前往%1$s設定>隱私權>權限管理>位置%2$s ，接著往下捲動至 %3$sDuckDuckGo%4$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings in the settings menu. Part of a list of instructions on how to enable location service.
@@ -9580,7 +9459,7 @@ msgstr "良好的隱私政策"
 #. Positive reason chip in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image.
 msgctxt "Feedback prompt"
 msgid "Good visual style"
-msgstr ""
+msgstr "良好的視覺風格"
 
 # smartling.placeholder_format=C
 #. Part of the sentence: "<b>Goodies</b> and no tracking." (used for limited browsers, mobile and co.)
@@ -10228,9 +10107,7 @@ msgstr "最近活動"
 msgid ""
 "Hit %sReturn%s on your keyboard to %ssave DuckDuckGo to the list. %sThen "
 "click %sMake Default%s"
-msgstr ""
-"在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定"
-"為預設%6$s"
+msgstr "在鍵盤上點擊%1$s返回%2$s即可將DuckDuckGo%3$s儲存至清單。%4$s接著點擊%5$s設定為預設%6$s"
 
 # smartling.placeholder_format=C
 #. The name of the Hmong Daw language
@@ -10594,9 +10471,7 @@ msgctxt "precise_user_location"
 msgid ""
 "If the browser location remains unavailable, then go to %sSettings > General "
 "> Reset > 'Reset Location & Privacy'%s."
-msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與"
-"隱私」%2$s。"
+msgstr "如果仍然沒有可用的瀏覽器位置，那麼請前往%1$s設定 > 一般 > 重設 >「重設位置與隱私」%2$s。"
 
 # smartling.placeholder_format=C
 #. Tells users where to find the location settings within the settings menu. Part of a list of instructions on how to enable location service.
@@ -10606,8 +10481,8 @@ msgid ""
 "> Menu > Settings > Site settings > Location%s, and ensure DuckDuckGo is "
 "allowed location access."
 msgstr ""
-"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > "
-"網站設定 > 位置%2$s，確認DuckDuckGo是被允許的存取位置。"
+"如果仍然沒有可用的瀏覽器位置，那麼請在你的瀏覽器中前往 %1$s⋮ > 選單 > 設定 > 網站設定 > "
+"位置%2$s，確認DuckDuckGo是被允許的存取位置。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue
@@ -10621,8 +10496,7 @@ msgstr "如果你繼續看到此錯誤，請聯絡 %1$s。"
 msgid ""
 "If you don't see %sDuckDuckGo,%s you will need to add it to the list of "
 "%sOther Search Engines%s"
-msgstr ""
-"如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
+msgstr "如果你沒看見%1$sDuckDuckGo，%2$s必須先將其新增至%3$s其他搜尋引擎%4$s的清單中"
 
 # smartling.placeholder_format=C
 #. Text displayed at the bottom of a feedback form giving a disclaimer regarding the AI model providers and links to their support pages. Example: 'If you have concerns about our chat providers or any particular chat response, you can also reach out directly to OpenAI and Anthropic support pages.'
@@ -10630,9 +10504,7 @@ msgctxt "Disclaimer text at the bottom of the feedback form."
 msgid ""
 "If you have concerns about our chat providers or any particular chat "
 "response, you can also reach out directly to %s and %s support pages."
-msgstr ""
-"若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 "
-"%2$s 支援頁面。"
+msgstr "若您對我們的聊天供應商或任何特定的聊天回覆有任何疑問，也能夠直接聯絡 %1$s 與 %2$s 支援頁面。"
 
 # smartling.placeholder_format=C
 #. Body copy explaining what the recovery code is for and how it can be saved.
@@ -10640,9 +10512,7 @@ msgctxt "Body for the Sync & Backup recovery code screen"
 msgid ""
 "If you lose access to your devices, you will need this code to recover your "
 "saved chats. You can save this code to your device as a text file."
-msgstr ""
-"如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢"
-"復碼儲存成文字檔，儲存至您的裝置。"
+msgstr "如果您無法存取裝置，需要使用此恢復碼才能恢復您儲存的聊天記錄。您可以把這個恢復碼儲存成文字檔，儲存至您的裝置。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/ReKkJtU.png
@@ -10707,7 +10577,7 @@ msgstr "圖片提示必須符合 Duck.ai %1$s。"
 #. Positive reason chip (shown first) in the Duck.ai response thumbs-up feedback form when the rated turn produced a generated image. Replaces the text-response chips on that turn. Not shown for text-only responses or when generation failed.
 msgctxt "Feedback prompt"
 msgid "Image quality"
-msgstr ""
+msgstr "圖像品質"
 
 # smartling.placeholder_format=C
 msgctxt "settingsvalue"
@@ -10810,9 +10680,7 @@ msgctxt "settings"
 msgid ""
 "In some older browsers, it's necessary to redirect your clicks through our "
 "server to prevent search leakage. %sLearn more%s."
-msgstr ""
-"若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避"
-"免搜尋記錄外洩。%1$s瞭解更多%2$s。"
+msgstr "若你使用的瀏覽器較舊，在你點擊連結時，必須透過我們的伺服器來重新導向，才能避免搜尋記錄外洩。%1$s瞭解更多%2$s。"
 
 # smartling.placeholder_format=C
 #. Instructions accompanying DUCKCHAT_SYNC_PAIRING_NATIVE_CODE_TITLE; tells the user where to use the code on a DuckDuckGo browser.
@@ -10822,9 +10690,7 @@ msgctxt ""
 msgid ""
 "In the DuckDuckGo browser, go to Settings › Sync & Backup, and then “Sync "
 "with another device”."
-msgstr ""
-"在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同"
-"步」。"
+msgstr "在 DuckDuckGo 瀏覽器中，點選設定 › Sync & Backup，然後選擇「與另一裝置同步」。"
 
 #  SeaMonkey default search engine instruction
 # smartling.placeholder_format=C
@@ -11243,9 +11109,8 @@ msgid ""
 "through Microsoft's Ad Network. Clicks lead directly to merchant landing "
 "pages and unlike ads, DuckDuckGo is not compensated for these results."
 msgstr ""
-"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad Network播送。點擊後"
-"會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收"
-"到任何報酬。"
+"物品排序是依照你的搜尋關鍵字為依據，並經由Microsoft's Ad "
+"Network播送。點擊後會立即連接到商家的登陸頁面，但與廣告不同的是，DuckDuckGo並不會因這些結果而收到任何報酬。"
 
 # smartling.placeholder_format=C
 #. Text explaining why passphrases use a series of words instead of random numbers and letters.
@@ -11253,9 +11118,7 @@ msgctxt "cloudsave"
 msgid ""
 "It’s easier to remember 4-5 words than 10 random letters and numbers, and "
 "far more secure."
-msgstr ""
-"比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安"
-"全。"
+msgstr "比起強記 10 個隨機的字母與數字，只記住 4 至 5 個單字要容易許多，而且也更加安全。"
 
 # smartling.placeholder_format=C
 msgid "Ivory Coast"
@@ -13303,9 +13166,8 @@ msgid ""
 "internet connection. Disabling chat history will delete pinned chats, and "
 "disable the temporary storage of new prompts and responses."
 msgstr ""
-"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你失去"
-"網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應"
-"的暫時儲存功能。"
+"新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo "
+"伺服器上，以便在你失去網路連線時協助恢復聊天。停用聊天紀錄會刪除置頂的聊天記錄，並停用新提示和回應的暫時儲存功能。"
 
 # smartling.placeholder_format=C
 #. Question in a feedback form.
@@ -14139,9 +14001,7 @@ msgstr "隨需"
 msgid ""
 "On Mac, %sClick Maxthon > Preferences%s, On Windows, %sClick the %s icon > "
 "Settings%s"
-msgstr ""
-"在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設"
-"定%5$s"
+msgstr "在Mac系統中，%1$s按Maxthon > 偏好設定%2$s，在Windows中，%3$s按%4$s 圖示 > 設定%5$s"
 
 # smartling.placeholder_format=C
 #. Tells the user where to find the pairing entry on their other device. Bold segments are UI path labels.
@@ -14149,9 +14009,7 @@ msgctxt "Instruction under the Scan QR tab sub-heading"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s"
-msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s"
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s"
 
 # smartling.placeholder_format=C
 #. Same path as the Scan QR instruction, plus a scan-this-code prompt. Bold segments are UI path labels.
@@ -14159,9 +14017,7 @@ msgctxt "Instruction in the mobile Scan-or-Copy-Code modal"
 msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s and scan this code:"
-msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s，然後掃描此代碼："
+msgstr "在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s，然後掃描此代碼："
 
 # smartling.placeholder_format=C
 #. Same as the Scan QR pairing instruction (DUCKCHAT_SYNC_PAIRING_SCAN_INSTRUCTION) plus the Recovery PDF option. Bold segments are UI path labels.
@@ -14170,8 +14026,8 @@ msgid ""
 "On another device go to %sDuck.ai Settings%s › %sChats › Sync & Backup › "
 "Sync With Another Device%s. Or scan the QR on your Recovery PDF."
 msgstr ""
-"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置"
-"同步%4$s。或掃描你復原 PDF 上的 QR 碼。"
+"在其他裝置上前往 %1$sDuck.ai 設定%2$s › %3$s聊天 › Sync & Backup › 與其他裝置同步%4$s。或掃描你復原 "
+"PDF 上的 QR 碼。"
 
 # smartling.placeholder_format=C
 #. https://duckduckgo.com/params under "Interface Settings" under "Page #s:"
@@ -14198,8 +14054,7 @@ msgctxt ""
 msgid ""
 "One of the files attached has more pages than we support. Please upload "
 "files with %s pages or fewer."
-msgstr ""
-"附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
+msgstr "附上的其中一個檔案頁數超過了我們的支援範圍。請上傳頁數不超過 %1$s 的檔案。"
 
 # smartling.placeholder_format=C
 #. Response a user can select in a feedback form, indicating that they heard about DuckDuckGo in an online article.
@@ -14569,8 +14424,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "Other search engines track your searches even when you’re in private "
 "browsing mode. We don’t track you &mdash; period."
-msgstr ""
-"即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
+msgstr "即使你處於隱身瀏覽模式，其他搜尋引擎也會追蹤你的搜尋。我們在這期間不追蹤你。"
 
 # smartling.placeholder_format=C
 msgctxt "SERP footer content"
@@ -14583,9 +14437,7 @@ msgctxt "DuckDuckGo Subscription instant answer"
 msgid ""
 "Our fast, no-log VPN comes with smarter AI chats with higher limits, plus "
 "more premium protections. All in one subscription."
-msgstr ""
-"我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保"
-"護。一站式訂閱。"
+msgstr "我們快速、不記錄日誌的 VPN 提供更聰明且限制更高的 AI 聊天功能，以及更多頂級保護。一站式訂閱。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -14599,9 +14451,7 @@ msgid ""
 "Our private browser for mobile comes equipped with our search engine, "
 "tracker blocker, encryption enforcer, and more. Available on %siOS & "
 "Android%s."
-msgstr ""
-"我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功"
-"能。提供%1$siOS及Android%2$s版本。"
+msgstr "我們的行動裝置私密瀏覽器配備搜尋引擎、追蹤器封鎖程式、加密執行程式等眾多功能。提供%1$siOS及Android%2$s版本。"
 
 # smartling.placeholder_format=C
 #. Negative feedback category a user can select on the Search Assist feedback form, meaning the information was out of date.
@@ -14853,9 +14703,7 @@ msgctxt "cloudsave"
 msgid ""
 "Passphrases cannot be recovered as we don't associate your IP address, "
 "browser fingerprint, or any other information with the file."
-msgstr ""
-"我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找"
-"回通關密語。"
+msgstr "我們並未將你的IP位址、瀏覽器指紋或其他相關資訊連結至通關密語檔案，因此無法找回通關密語。"
 
 # smartling.placeholder_format=C
 #. Label for the section of recent chats that were edited in the past 7 days.
@@ -15010,9 +14858,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Personal Information Removal finds your info on data broker sites that are "
 "selling it. Then we work to get it removed for you."
-msgstr ""
-"Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下"
-"來，我們會努力為你將該資訊移除。"
+msgstr "Personal Information Removal 會在販售你資訊的資料仲介網站上找出你的資訊。接下來，我們會努力為你將該資訊移除。"
 
 # smartling.placeholder_format=C
 #. Label for the option prompting the AI assistant to adopt a role of a personal trainer in its responses.
@@ -15083,8 +14929,8 @@ msgid ""
 "answers. To turn them off and hide the Assist button visit %sSearch "
 "Settings%s."
 msgstr ""
-"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常"
-"能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 %1$s搜尋設定%2$s。"
+"將您的搜尋以問句形式完整地表達出來，能提高 AI 輔助答案自動顯示的機率，且通常能得到更好的答案。欲關閉並隱藏「Assist」按鈕，請造訪 "
+"%1$s搜尋設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15093,9 +14939,8 @@ msgid ""
 "DuckAssist more likely to appear and often yields better answers. To adjust "
 "how this feature works, or to turn it off, visit %sDuckAssist Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"顯示並且通常能得出更好的答案。 欲調整此功能的運作方式或將其關閉，請造訪 "
-"%1$sDuckAssist 設定%2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能顯示並且通常能得出更好的答案。 "
+"欲調整此功能的運作方式或將其關閉，請造訪 %1$sDuckAssist 設定%2$s。"
 
 # smartling.placeholder_format=C
 #. Third paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -15105,9 +14950,8 @@ msgid ""
 "answers. To turn it off and hide the Assist button visit %sDuckAssist "
 "Settings%s."
 msgstr ""
-"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist 更可能"
-"自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s "
-"DuckAssist 設定 %2$s。"
+"將您的搜尋作為一個問題表述，並且用一個完整的句子為形式，讓 DuckAssist "
+"更可能自動顯示並且通常能得出更好的答案。欲關閉並隱藏「協助」按鈕，請造訪 %1$s DuckAssist 設定 %2$s。"
 
 # smartling.placeholder_format=C
 #. Button that allows users to manually select a location on a map.
@@ -15139,8 +14983,7 @@ msgctxt "Body copy for the chat card in the How Duck.ai Works panel"
 msgid ""
 "Pick a popular AI to chat with, like GPT-5 mini, Claude Haiku 4.5, Mistral, "
 "etc."
-msgstr ""
-"選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
+msgstr "選擇流行的 AI 進行聊天，例如 GPT-5 迷你、克勞德海庫 4.5、米斯特拉爾等。"
 
 # smartling.placeholder_format=C
 #. Describes the ability to choose from popular AI models. Pairs with a chat-bubble pictogram.
@@ -15156,8 +14999,7 @@ msgctxt "Third party map app picker"
 msgid ""
 "Pick a service to navigate to your destination. External apps won’t come "
 "with DuckDuckGo protections."
-msgstr ""
-"選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
+msgstr "選擇一項服務來導覽到你的目的地。外部應用程式不會受到 DuckDuckGo 的保護。"
 
 # smartling.placeholder_format=C
 #. Label for a list of problems on a feedback form.
@@ -15305,9 +15147,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is harmful or illegal."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非"
-"法。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容有害或非法。"
 
 # smartling.placeholder_format=C
 #. A placeholder text for an open text field prompting the user to provide feedback on the AI (Artificial Intelligence) chat bot providing harmful or illegal content
@@ -15315,9 +15155,7 @@ msgctxt "Feedback prompt"
 msgid ""
 "Please paste your prompt and the problematic output (with any personal "
 "information removed) and describe why the content is illegal or harmful."
-msgstr ""
-"請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有"
-"害。"
+msgstr "請貼上你的提示和有問題的輸出（請移除任何個人資訊），並描述為何該內容非法或有害。"
 
 # smartling.placeholder_format=C
 #. Title on a feedback form.
@@ -15531,7 +15369,7 @@ msgstr "格式不佳"
 #. Negative reason chip (shown first) in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image (success or failure). Replaces the text-response chips on that turn. Not shown for text-only responses.
 msgctxt "Feedback prompt"
 msgid "Poor image quality"
-msgstr ""
+msgstr "圖像品質不佳"
 
 # smartling.placeholder_format=C
 #. Secondary line of the one-time Duck.ai feature-discovery drawer shown to new installs under the search box.
@@ -16378,9 +16216,7 @@ msgctxt "Description for recent chats feature"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining that recent chats are stored locally on the user's device.
@@ -16388,9 +16224,7 @@ msgctxt "Description of where recent chats are stored"
 msgid ""
 "Recent chats are stored locally on your device instead of on DuckDuckGo "
 "servers or other remote servers."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器"
-"中。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上，而非在 DuckDuckGo 或其他的遠端伺服器中。"
 
 # smartling.placeholder_format=C
 #. Text explaining how recent chats are stored locally on the user's device, and temporarily stores new prompts and responses on a DuckDuckGo server after being sent, to help recover a chat if you lose your internet connection.
@@ -16399,9 +16233,7 @@ msgid ""
 "Recent chats are stored locally on your device. New prompts and responses "
 "are encrypted and temporarily stored on a DuckDuckGo server after being "
 "sent, to help recover a chat if you lose your internet connection."
-msgstr ""
-"最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲"
-"存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
+msgstr "最近的聊天記錄會儲存在你的裝置本機上。新的提示和回應在傳送後會被加密並暫時儲存在 DuckDuckGo 伺服器上，以便在你斷線時協助恢復聊天。"
 
 # smartling.placeholder_format=C
 msgctxt "region filter"
@@ -16682,8 +16514,7 @@ msgstr "重新載入 Duck.ai。"
 msgid ""
 "Reload DuckDuckGo by following the instructions, or clicking your browser's "
 "&quot;Refresh&quot; or &quot;Reload&quot; button."
-msgstr ""
-"按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
+msgstr "按照說明重新載入 DuckDuckGo，或者點擊瀏覽器的「重新整理」或「重新載入」按鈕。"
 
 # smartling.placeholder_format=C
 #. checkbox label that allows the user to save the setting
@@ -16860,18 +16691,14 @@ msgid ""
 "Reports are anonymous and sent to DuckDuckGo to help improve our search "
 "service. Your anonymous feedback is also shared with %s to help improve "
 "their services."
-msgstr ""
-"報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享"
-"給%1$s來協助改善其服務。"
+msgstr "報告會匿名傳送給DuckDuckGo，幫助我們改善搜尋服務。你的匿名回饋意見也會分享給%1$s來協助改善其服務。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
 msgid ""
 "Reports sent to DuckDuckGo are anonymous. Please do not include any personal "
 "or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別"
-"身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的檢舉採匿名制。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -16879,9 +16706,7 @@ msgid ""
 "Reports sent to DuckDuckGo include all of the text you've asked us to "
 "translate during this page load, and are anonymous. Please do not include "
 "any personal or identifying information in your feedback."
-msgstr ""
-"傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿"
-"名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
+msgstr "傳送給 DuckDuckGo 的報告包括你在此頁面載入時要求我們翻譯的所有文字，並且是匿名的。請不要在你的意見回饋中包含任何個人或可識別身分的資訊。"
 
 # smartling.placeholder_format=C
 msgid "Republic of Moldova"
@@ -16972,9 +16797,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. AI-assisted "
 "answers are subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回"
-"答受我們的 %1$s 服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。AI 輔助的回答受我們的 %1$s 服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16982,9 +16805,7 @@ msgid ""
 "Responses are for educational purposes only and are not intended as medical, "
 "legal, financial, investment, or other professional advice. DuckAssist is "
 "subject to our %sTerms of Service%s."
-msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist "
-"受我們的%1$s服務條款%2$s約束。"
+msgstr "回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。DuckAssist 受我們的%1$s服務條款%2$s約束。"
 
 # smartling.placeholder_format=C
 #. Fourth paragraph of a section inviting users to learn more about the duckassist instant answer (based on generative AI)
@@ -16994,8 +16815,8 @@ msgid ""
 "generated based on web content and may contain inaccuracies. Search Assist "
 "is subject to our %sTerms of Service%s."
 msgstr ""
-"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁"
-"內容生成，可能會有不準確之處。Search Assist 受我們的 %1$s服務條款%2$s 約束。"
+"回覆僅用於教育用途，並不構成醫療、法律、財務、投資或其他專業建議。係根據網頁內容生成，可能會有不準確之處。Search Assist 受我們的 "
+"%1$s服務條款%2$s 約束。"
 
 # smartling.placeholder_format=C
 #. Label on the button for restoring all previous website data.
@@ -17419,9 +17240,7 @@ msgctxt "Description for Chat History feature with Encrypted Storage option"
 msgid ""
 "Save up to 30 of your most recent chats locally on your device, with the "
 "option for more with Encrypted Storage."
-msgstr ""
-"你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更"
-"多內容。"
+msgstr "你最多可在裝置本機儲存多達 30 筆近期聊天記錄，並可選擇透過加密儲存功能儲存更多內容。"
 
 # smartling.placeholder_format=C
 #. Short text for native DDG browser users explaining how Chat History stores up to 30 of their most recent chats locally on their device.
@@ -17687,18 +17506,16 @@ msgid ""
 "(on a wide range of searches). For now, Search Assist is only available in a "
 "subset of English speaking regions."
 msgstr ""
-"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相"
-"關內容，然後使用 AI 生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在"
-"點按 Assist 時)、有時 (在高度相關時)，或經常 (在廣泛的搜尋中)。目前，Search "
-"Assist 功能僅供部分英語地區使用。"
+"Search Assist 會匿名生成搜尋查詢的答案。為了達成這個目的，它會掃描網路尋找相關內容，然後使用 AI "
+"生成簡短的回答。你可以選擇它出現的頻率：從不、隨需 (僅在點按 Assist 時)、有時 (在高度相關時)，或經常 "
+"(在廣泛的搜尋中)。目前，Search Assist 功能僅供部分英語地區使用。"
 
 # smartling.placeholder_format=C
 #. Error message for the duckassist instant answer (based on generative AI) when the answer is not found and the answer is unsourced or with no sources
 msgid ""
 "Search Assist couldn't find enough reliable information to generate an "
 "answer for this question. Try another search."
-msgstr ""
-"Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
+msgstr "Search Assist 找不到足夠的可靠資訊以產生這個問題的答案。嘗試另一個搜尋。"
 
 # smartling.placeholder_format=C
 #. First paragraph of a section inviting users to learn more about the Assist instant answer (based on generative AI)
@@ -17707,8 +17524,8 @@ msgid ""
 "search queries. To do this, it %sscans the web%s for relevant content and "
 "then uses AI to generate a brief answer based on information found."
 msgstr ""
-"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網"
-"路%2$s以尋找相關內容，然後使用 AI 根據找到的資訊生成簡短的答案。"
+"Search Assist 是一項選用功能，可匿名生成搜尋查詢的答案。為此，它%1$s掃描網路%2$s以尋找相關內容，然後使用 AI "
+"根據找到的資訊生成簡短的答案。"
 
 # smartling.placeholder_format=C
 #. in https://duckduckgo.com/search_box. top header
@@ -17828,9 +17645,7 @@ msgctxt "noresults"
 msgid ""
 "Search other sites with %s shortcuts: a search for ”!w ducks” will search "
 "for “ducks” directly on Wikipedia."
-msgstr ""
-"使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋"
-"「ducks」。"
+msgstr "使用 %1$s 快捷方式搜尋其他網站：搜尋「!w ducks」將直接在維基百科上搜尋「ducks」。"
 
 # smartling.placeholder_format=C
 #. Placeholder text for the search form when no text has been entered
@@ -17848,9 +17663,7 @@ msgstr "私密搜尋與封鎖追蹤器"
 msgid ""
 "Search privately with our app or extension, add private web search to your "
 "favorite browser, or search directly at %sduckduckgo.com%s."
-msgstr ""
-"使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋"
-"功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
+msgstr "使用我們的應用程式或延伸模組進行私密搜尋，為你最常用的瀏覽器新增隱身網路搜尋功能，或直接在%1$sduckduckgo.com%2$s搜尋。"
 
 # smartling.placeholder_format=C
 #. http://i.imgur.com/6LZAoqH.png
@@ -17869,9 +17682,8 @@ msgid ""
 "information will be stored in the cloud, and your passphrase will never "
 "leave your browser."
 msgstr ""
-"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 "
-"Cloud Save 將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資"
-"料，且你的通關密語永遠不會離開你的瀏覽器。"
+"搜尋設定會儲存在瀏覽器中的非個人瀏覽器 cookie 和本機儲存空間，但你也可以使用 Cloud Save "
+"將設定匿名儲存在雲端的遠端伺服器上。不會在雲端中儲存任何個人身分資料，且你的通關密語永遠不會離開你的瀏覽器。"
 
 # smartling.placeholder_format=C
 #. A feedback suggestion
@@ -17989,9 +17801,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store nearly unlimited chats on our server using end-to-end "
 "encryption, and access them from all your synced devices."
-msgstr ""
-"以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步"
-"的裝置存取。"
+msgstr "以端對端加密安全地將幾乎無限的聊天內容儲存在我們的伺服器上，並可從所有已同步的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Shown to DuckDuckGo native browser users explaining that they must finish setup inside the app.
@@ -17999,9 +17809,7 @@ msgctxt "Description explaining how native users can enable sync"
 msgid ""
 "Securely store your chats on our server using end-to-end encryption, and "
 "access them from all your devices."
-msgstr ""
-"以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存"
-"取。"
+msgstr "以端對端加密安全地將您的聊天內容儲存在我們的伺服器上，並可從您所有的裝置存取。"
 
 # smartling.placeholder_format=C
 #. Description explaining that chats are stored securely with encryption on DuckDuckGo's server.
@@ -18015,9 +17823,7 @@ msgctxt "Chat history with sync modal list item"
 msgid ""
 "Securely stored on DuckDuckGo's server with end-to-end encryption. Nobody "
 "but you can see your data, not even us."
-msgstr ""
-"採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到"
-"你的資料，連我們也不行。"
+msgstr "採用端對端加密，安全儲存在 DuckDuckGo 的伺服器上。除了你之外，沒有人可以看到你的資料，連我們也不行。"
 
 # smartling.placeholder_format=C
 #. Explains that the shared copy is stored encrypted on the server.
@@ -18423,9 +18229,7 @@ msgid ""
 "Sends a prompt to AI models with your messages with instructions on how to "
 "respond. These instructions will apply to all of your conversations going "
 "forward."
-msgstr ""
-"向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有"
-"對話。"
+msgstr "向 AI 模型發送提示，包含你的訊息和回應指示說明。這些只是將自動套用至往後所有對話。"
 
 # smartling.placeholder_format=C
 msgid "Senegal"
@@ -18547,8 +18351,7 @@ msgctxt "Chat history about modal list item"
 msgid ""
 "Set up Sync & Backup after turning on Chat History to keep your chats synced "
 "across devices."
-msgstr ""
-"開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
+msgstr "開啟聊天記錄後，請設定 Sync & Backup 以確保您的聊天記錄能在各裝置間保持同步。"
 
 # smartling.placeholder_format=C
 #. Prompt for the user to indicate their location on a map, to enable more relevant search results.
@@ -18654,9 +18457,7 @@ msgctxt "Description for Approximate Location feature"
 msgid ""
 "Share a city-level location with AI models to improve relevancy. Duck.ai "
 "never reveals your precise location to us or AI models."
-msgstr ""
-"與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透"
-"露你的精確位置。"
+msgstr "與 AI 模型分享城市等級的位置，以提升相關性。Duck.ai 絕不會向我們或 AI 模型透露你的精確位置。"
 
 # smartling.placeholder_format=C
 #. Modal header when the user opens share from the chat history options menu.
@@ -18805,9 +18606,7 @@ msgctxt "DuckDuckGo VPN instant answer"
 msgid ""
 "Shield your online activity with our no-log, fast VPN. Simple to set up and "
 "easy to turn on and off anytime."
-msgstr ""
-"使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或"
-"關閉。"
+msgstr "使用我們無記錄、快速的 VPN 來保護你的線上活動。 設定簡單，且可隨時輕鬆開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Keyboard shortcut for Duck.ai
@@ -19170,18 +18969,14 @@ msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always private. Turning "
 "this off hides the reminder and never affects search privacy."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影"
-"響私密搜尋。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都是私密的。關閉此功能會隱藏提醒，且永遠不會影響私密搜尋。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
 msgid ""
 "Shows a reminder that searches on DuckDuckGo are always protected. Turning "
 "this off hides the reminder and never affects search protection."
-msgstr ""
-"提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影"
-"響搜尋保護。"
+msgstr "提醒您，DuckDuckGo 上的所有搜尋都受到保護。關閉此功能會隱藏提醒，且永遠不會影響搜尋保護。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -20504,19 +20299,16 @@ msgid ""
 msgstr ""
 "同步恢復碼\n"
 "\n"
-"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在"
-"你無法存取某個裝置時恢復你的同步資料。\n"
+"恢復碼允許你在多個裝置之間同步您的密碼、自動填入資料和 Duck.ai 聊天記錄，並在你無法存取某個裝置時恢復你的同步資料。\n"
 "\n"
 "確保此資訊安全無虞。\n"
 "任何有權限存取此代碼的人都能存取你同步的資料。%1$s\n"
 "\n"
 "這段代碼是如何運作的？\n"
-"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & "
-"Backup」，然後選擇「恢復已同步的資料」\n"
+"1. 在瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。2. 選取「開啟 Sync & Backup」，然後選擇「恢復已同步的資料」\n"
 "3. 複製上方的恢復代碼，並貼到顯示「將你的代碼貼在這裡」的地方\n"
 "\n"
-"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將"
-"從伺服器上刪除，且無法恢復。"
+"如果你超過 18 個月未使用已啟用 Sync & Backup 的 DuckDuckGo 瀏覽器，你的資料將從伺服器上刪除，且無法恢復。"
 
 # smartling.placeholder_format=C
 #. Sets up sync on this device alone, then shows the recovery code.
@@ -20654,9 +20446,7 @@ msgctxt "Product-tour success modal body - mobile variant"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free app for quicker "
 "access, wherever you are."
-msgstr ""
-"隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存"
-"取。"
+msgstr "隨身帶著 Duck.ai。 無論身在何處，都能透過我們免費 App 的內建功能更快速地存取。"
 
 # smartling.placeholder_format=C
 #. Body of the success modal shown when the user finishes the entire onboarding checklist.
@@ -20664,9 +20454,7 @@ msgctxt "Product-tour success modal body"
 msgid ""
 "Take Duck.ai with you everywhere. Get it built into our free browser for "
 "quicker access, wherever you're browsing."
-msgstr ""
-"隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快"
-"速存取。"
+msgstr "隨時隨地帶著 Duck.ai。 使用我們免費瀏覽器的內建功能，無論你在何處瀏覽都能更快速存取。"
 
 # smartling.placeholder_format=C
 #. Primary button/link text to open the user survey (desktop only)
@@ -20909,9 +20697,7 @@ msgid ""
 "That means information sent between your device and the webpage behind this "
 "link is at increased risk of being intercepted by a third party. In rare "
 "cases this includes passwords, or payment details."
-msgstr ""
-"這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第"
-"三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
+msgstr "這代表在你的裝置與此連結通往的網頁之間傳遞的資訊處於高風險中，有可能會遭到第三方攔截。雖然極少發生，但該資訊可能包含密碼或付款詳情。"
 
 # smartling.placeholder_format=C
 #. Text explaining how the cloud save feature works.
@@ -20927,9 +20713,7 @@ msgctxt "new tab page"
 msgid ""
 "The Duck.ai toggle lets you quickly switch between private search and AI "
 "chat, anonymized by DuckDuckGo."
-msgstr ""
-"Duck.ai 切換按鈕可讓你快速在私密搜尋與 AI 聊天之間切換，並由 DuckDuckGo 提供"
-"匿名化保護。"
+msgstr "Duck.ai 切換按鈕可讓你快速在私密搜尋與 AI 聊天之間切換，並由 DuckDuckGo 提供匿名化保護。"
 
 # smartling.placeholder_format=C
 msgid "The Gambia"
@@ -21037,8 +20821,7 @@ msgctxt "Error message when there was an issue saving a chat to the browser"
 msgid ""
 "There was an error saving this chat locally. Please check your browser "
 "settings to make sure local data storage is enabled."
-msgstr ""
-"在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
+msgstr "在本機儲存此聊天時發生錯誤。請檢查你的瀏覽器設定，確保已啟用本機資料儲存。"
 
 # smartling.placeholder_format=C
 #. Error modal body line 1.
@@ -21070,9 +20853,7 @@ msgid ""
 "These browser permissions are used to add privacy protection on websites you "
 "visit by blocking hidden trackers, encrypting connections where possible, "
 "and by making DuckDuckGo your default search engine."
-msgstr ""
-"這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設"
-"搜尋引擎，藉此為你造訪的網站新增隱私保護。"
+msgstr "這些瀏覽器權限可封鎖隱藏的追蹤器，並盡可能加密資訊，並將DuckDuckGo設定為預設搜尋引擎，藉此為你造訪的網站新增隱私保護。"
 
 # smartling.placeholder_format=C
 #. Secondary line under DUCKCHAT_SYNC_PAIRING_ALREADY_SYNCED_TITLE.
@@ -21156,8 +20937,8 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using %s's %s Model. AI "
 "chats may display inaccurate or offensive information (see %s for more info)."
 msgstr ""
-"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準"
-"確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s 的 %3$s 模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %4$s "
+"取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with multiple AI models in the same chat, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with Duck.ai (https://duck.ai) using multiple chat models. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21166,9 +20947,7 @@ msgid ""
 "This conversation was generated with Duck.ai (%s) using multiple chat "
 "models. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
-msgstr ""
-"此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令"
-"人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
+msgstr "此對話是使用多個聊天模型與 Duck.ai (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 (請參閱 %2$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. When a user exports a transcript of a voice chat they had with the AI. This text goes at the very top of the downloaded file as a header. Placeholders are for links. Example: 'This conversation was generated with Duck.ai voice chat (https://duck.ai). AI may provide inaccurate or offensive information. (see https://duckduckgo.com/duckai/privacy-terms for more info).'
@@ -21176,9 +20955,7 @@ msgctxt "Export chat feature in AI Chat"
 msgid ""
 "This conversation was generated with Duck.ai voice chat (%s). AI may provide "
 "inaccurate or offensive information. (see %s for more info)."
-msgstr ""
-"這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感"
-"的資訊。（更多資訊請參見%2$s）。"
+msgstr "這段對話是透過 Duck.ai 語音聊天產生的（%1$s）。AI 可能會提供不準確或令人反感的資訊。（更多資訊請參見%2$s）。"
 
 # smartling.placeholder_format=C
 #. When a user exports a chat they had with an AI model, this text goes at the very top of the downloaded file as a header. Example: 'This conversation was generated with DuckDuckGo AI Chat (https://duck.ai) using OpenAI's GPT-4 Model. AI chats may display inaccurate or offensive information (see https://duckduckgo.com/aichat/privacy-terms for more info).'
@@ -21188,8 +20965,8 @@ msgid ""
 "Model. AI chats may display inaccurate or offensive information (see %s for "
 "more info)."
 msgstr ""
-"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能"
-"會顯示不準確或令人反感的資訊 (請參閱 %4$s 取得更多資訊)。"
+"此對話是使用 %2$s的%3$s 模型與 DuckDuckGo AI Chat (%1$s) 產生的。AI 聊天可能會顯示不準確或令人反感的資訊 "
+"(請參閱 %4$s 取得更多資訊)。"
 
 # smartling.placeholder_format=C
 #. Renders to the right of the device name for the row that matches this device's id.
@@ -21205,9 +20982,7 @@ msgctxt ""
 msgid ""
 "This device will no longer be able to access your synced data on other "
 "devices. The last %s chats will still remain available in local storage."
-msgstr ""
-"此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在"
-"本機儲存空間中。"
+msgstr "此裝置將無法再存取你在其他裝置上的同步資料。最近的 %1$s 個聊天記錄仍將保留在本機儲存空間中。"
 
 # smartling.placeholder_format=C
 #. Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Placeholder is the size limit in megabytes. E.g. This file is too large. The maximum file size is 5 MB
@@ -21312,9 +21087,7 @@ msgctxt "Sample assistant reply inside the throwaway product-tour chat"
 msgid ""
 "This is just a sample chat. Open its menu (the three dots), then choose Pin "
 "to keep it at the top of your chats!"
-msgstr ""
-"這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最"
-"上方！"
+msgstr "這只是一則範例聊天。 開啟選單（三個點），然後選擇「釘選」，將它保持在聊天的最上方！"
 
 # smartling.placeholder_format=C
 #. Placeholder assistant reply in the disposable sample chat created by the 'Delete a chat' tour step. Tells the user to delete the chat using the Fire (delete) button in the side menu. Device-agnostic: on desktop the Fire Button is on the chat row (hover-revealed), on mobile it's inside the row's 3-dot menu; the tour highlight points at the right control on each.
@@ -21342,9 +21115,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider deletes data associated with this chat within 30 days. "
 "Other model providers follow a zero data retention model."
-msgstr ""
-"此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留"
-"模式。"
+msgstr "此模型供應商會在 30 天內刪除與此聊天相關的資料。其他模型供應商遵循零資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Description explaining that the AI model provider does not store any chat data on their servers, and that other providers may retain chat data for a limited time instead.
@@ -21352,9 +21123,7 @@ msgctxt "Privacy claim description in Duck.ai chat"
 msgid ""
 "This model provider does not store any data associated with this chat. Other "
 "model providers follow a limited data retention model."
-msgstr ""
-"此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模"
-"式。"
+msgstr "此模型供應商不會儲存與此聊天相關的任何資料。其他模型供應商遵循限制資料保留模式。"
 
 # smartling.placeholder_format=C
 #. Info that page may refresh during update.
@@ -21390,9 +21159,7 @@ msgctxt "First paragraph for the Sync & Backup intro screen"
 msgid ""
 "This saves your chats with end-to-end encryption on DuckDuckGo's secure "
 "server, which later can be accessed from any browser."
-msgstr ""
-"這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從"
-"任何瀏覽器存取。"
+msgstr "這會將您的聊天內容以端對端加密方式儲存在 DuckDuckGo 的安全伺服器，之後您可從任何瀏覽器存取。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21400,9 +21167,7 @@ msgctxt "duckassist"
 msgid ""
 "This setting is stored in your browser, which means if you clear duckduckgo."
 "com browser data, then you may see AI-assisted answers again."
-msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。"
+msgstr "此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI 輔助的答案。"
 
 # smartling.placeholder_format=C
 #. A message that confirms the user has understood the message and wants to dismiss the modal. The message shown to the user would be: This setting is stored in your browser, which means if you clear duckduckgo.com browser data, then you may see AI-assisted answers again. However, we also have a start page that never shows AI-assisted answers at noai.duckduckgo.com.
@@ -21412,9 +21177,8 @@ msgid ""
 "com browser data, then you may see AI-assisted answers again. However, we "
 "also have a start page that never shows AI-assisted answers at %s."
 msgstr ""
-"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼"
-"可能會再次看到 AI 輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 "
-"AI 輔助答案。"
+"此設定儲存在你的瀏覽器中，這表示如果你清除 duckduckgo.com 的瀏覽器資料，那麼可能會再次看到 AI "
+"輔助的答案。不過，我們也有一個起始頁面，從不在 %1$s 顯示 AI 輔助答案。"
 
 # smartling.placeholder_format=C
 #. Error toast shown when a shared chat link cannot be opened because the link is incomplete or its key is incorrect.
@@ -21465,8 +21229,8 @@ msgid ""
 "Sync & Backup. You'll still be able to access your chats in other browsers "
 "connected to Sync & Backup."
 msgstr ""
-"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然"
-"可以在連接到 Sync & Backup 的其他瀏覽器中存取您的聊天記錄。"
+"這將刪除此瀏覽器中所有 Duck.ai 聊天記錄，並與 Sync & Backup 中斷連線。您仍然可以在連接到 Sync & Backup "
+"的其他瀏覽器中存取您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Text asking the user to confirm if they want to clear all recentchats, with a warning that this action cannot be undone.
@@ -21611,9 +21375,7 @@ msgctxt "directions"
 msgid ""
 "To print directions:%sGo back to the map.%sSelect the route you want to "
 "print.%sClick the print icon.%s"
-msgstr ""
-"如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖"
-"示。%4$s"
+msgstr "如要列印導航指引：%1$s返回地圖。%2$s選取你想列印的路線。%3$s按一下「列印」圖示。%4$s"
 
 # smartling.placeholder_format=C
 #. Explains where the user can find their recovery code. Figma frame 3703-44420.
@@ -21622,9 +21384,7 @@ msgid ""
 "To restore your synced data, you'll need the Recovery Code you saved when "
 "you first set up Sync. This code may have been saved as a PDF on the device "
 "you originally used to set up Sync."
-msgstr ""
-"若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲"
-"存在您最初用於設定同步的裝置上。"
+msgstr "若要恢復同步資料，請在第一次設定同步時儲存的恢復碼。此代碼可能已以 PDF 格式儲存在您最初用於設定同步的裝置上。"
 
 # smartling.placeholder_format=C
 #. Body text explaining that the user needs to update their DDG browser before migration can proceed.
@@ -21632,9 +21392,7 @@ msgctxt "duckai_migration"
 msgid ""
 "To transfer your chat history to Duck.ai, please update your DuckDuckGo "
 "browser to the latest version and try again."
-msgstr ""
-"欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再"
-"試一次。"
+msgstr "欲將你的聊天紀錄轉移至 Duck.ai，請將你的 DuckDuckGo 瀏覽器更新至最新版本並再試一次。"
 
 # smartling.placeholder_format=C
 #. Error in the duck.ai chat input when the user denies microphone access for dictation.
@@ -21735,7 +21493,7 @@ msgstr "太慢"
 #. Negative reason chip in the Duck.ai response thumbs-down feedback form when the rated turn includes a settled generated image. Distinct from FEEDBACK_TOO_SLOW, which is the text-response chip.
 msgctxt "Feedback prompt"
 msgid "Too slow to generate"
-msgstr ""
+msgstr "生成太慢"
 
 # smartling.placeholder_format=C
 #. Used as both the visible button label and its hover tooltip. The button opens a dropdown menu containing Image mode, Web Search, and Customize Responses options.
@@ -21895,8 +21653,7 @@ msgctxt "Full sentence for translating text"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成法語：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Text for a prompt suggestion for translating a sentence into another language. Translate the whole sentence and please use target language instead of 'English' and modify the sentence to translate into 'English' instead of 'French'. Example: 'Translate this {target language} sentence into English: “How do I get to the nearest movie theatre?”'
@@ -21904,8 +21661,7 @@ msgctxt "Full sentence for translating text prompt"
 msgid ""
 "Translate this English sentence into French: “How do I get to the nearest "
 "movie theatre?”"
-msgstr ""
-"將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
+msgstr "將這段英文句子翻譯成中文：“How do I get to the nearest movie theatre？”"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "Translate this page", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -22177,7 +21933,7 @@ msgstr "嘗試使用較少關鍵字。"
 #. Title-cased button label for free-tier users. Shown on the Duck.ai subscribe modal, Settings → Subscription, the image-generation limit message, and the voice-chat limit and duration-limit modals. Clicking starts the DuckDuckGo subscription free-trial / purchase flow. Distinct from sentence-cased 'Try for free' text links in the model picker and promo card.
 msgctxt "Button CTA that starts the DuckDuckGo subscription free trial"
 msgid "Try for Free"
-msgstr ""
+msgstr "免費試用"
 
 # smartling.placeholder_format=C
 #. Call-to-action button label on the DuckDuckGo Subscription instant answer shown on the search results page. Starts a free trial of the paid subscription. Default CTA, used by most rotated messages.
@@ -22388,9 +22144,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Install the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 安裝 %1$sDuckDuckGo No AI%2$s 搜尋擴充套件以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to switch to the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -22398,9 +22152,7 @@ msgctxt "settings"
 msgid ""
 "Trying to disable AI features? Switch to the %sDuckDuckGo No AI%s search "
 "extension to remember your settings. %sLearn More%s"
-msgstr ""
-"想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設"
-"定。 %3$s瞭解更多%4$s"
+msgstr "想要停用 AI 功能嗎？ 切換至 %1$sDuckDuckGo No AI%2$s 搜尋擴充功能以儲存你的設定。 %3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Placeholder text displayed while the AI assistant is generating a new response trying with a new model. Example: 'Trying with GPT-4o mini'
@@ -22600,9 +22352,7 @@ msgctxt "settings"
 msgid ""
 "Types out DuckAssist answers as they're generated. Turning this off may "
 "result in a short delay between a search and the answer being displayed."
-msgstr ""
-"在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延"
-"遲。"
+msgstr "在產生時輸入 DuckAssist 答案。關閉此功能可能會導致搜尋與顯示答案之間的短暫延遲。"
 
 # smartling.placeholder_format=C
 msgctxt "settings"
@@ -22853,9 +22603,7 @@ msgctxt "Description of the modal to upgrade to Pro"
 msgid ""
 "Unlock %s, higher AI reasoning, and 2x higher usage limits than the Plus "
 "plan by upgrading to Pro."
-msgstr ""
-"透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus "
-"方案的使用上限。"
+msgstr "透過升級至 Pro，解鎖 %1$s、比 Plus 方案更高的 AI 推理能力，以及 2 倍於 Plus 方案的使用上限。"
 
 # smartling.placeholder_format=C
 #. Title for the subscription promo shown in the SERP sidemenu.
@@ -23237,9 +22985,7 @@ msgctxt "duckai_seo"
 msgid ""
 "Use ChatGPT, Claude, and other AIs, privately. Protect chats from hackers, "
 "scammers, and companies. Keep info confidential. Free. No account required."
-msgstr ""
-"私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵"
-"害。對資訊保密。免費。不需要帳戶。"
+msgstr "私下使用 ChatGPT、Claude 及其他 AI。保護聊天內容，防止駭客、詐騙者和公司的侵害。對資訊保密。免費。不需要帳戶。"
 
 # smartling.placeholder_format=C
 #. Header above instructions on how to change a browser's default search engine to DuckDuckGo.
@@ -23423,9 +23169,7 @@ msgctxt "duckai_seo"
 msgid ""
 "View a conversation shared from Duck.ai - free, private AI chat by "
 "DuckDuckGo. Save it to your own chats and continue privately."
-msgstr ""
-"查看從 Duck.ai 分享的對話——由 DuckDuckGo 提供的免費、私密 AI 聊天功能。 儲存"
-"到你自己的聊天記錄中，並私密地繼續聊天。"
+msgstr "查看從 Duck.ai 分享的對話——由 DuckDuckGo 提供的免費、私密 AI 聊天功能。 儲存到你自己的聊天記錄中，並私密地繼續聊天。"
 
 # smartling.placeholder_format=C
 #. Heading for a dropdown that toggles more items
@@ -23459,8 +23203,7 @@ msgctxt "Ads GDPR, internal use only. Do not change"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Microsoft's ad network"
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Microsoft 的廣告網路管理"
 
 # smartling.placeholder_format=C
 #. Information about TripAdvisor ads for DuckDuckGo's users. This appears in a tooltip.
@@ -23468,9 +23211,7 @@ msgctxt "Single Place Hotel Offers Module"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "TripAdvisor's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管"
-"理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 TripAdvisor 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 #. The Yelp counterpart of AD_BADGE_TOOLTIP. Body copy of the tooltip behind the 'Ad' badge on Yelp-sourced local results, followed by an AD_BADGE_TOOLTIP_MORE_INFO link to the DuckDuckGo help page about ads by Yelp.
@@ -23478,8 +23219,7 @@ msgctxt "Ads GDPR"
 msgid ""
 "Viewing ads is privacy protected by DuckDuckGo. Ad clicks are managed by "
 "Yelp's ad network."
-msgstr ""
-"DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Yelp 的廣告網路管理。"
+msgstr "DuckDuckGo 會保護你在觀看廣告時的隱私。點擊廣告則由 Yelp 的廣告網路管理。"
 
 # smartling.placeholder_format=C
 msgid "Virgin Islands"
@@ -23521,8 +23261,8 @@ msgid ""
 "Visit Duck.ai in your other browser and go to %sDuck.ai Settings%s > %sSync "
 "& Backup%s > %sManage%s then select %sSync With Another Device%s."
 msgstr ""
-"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
-"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & Backup%4$s > "
+"%5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23532,8 +23272,8 @@ msgid ""
 "On” under Sync & Backup and select “Sync With Another Device”. Or scan the "
 "QR on your Recovery PDF."
 msgstr ""
-"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & Backup」下選取"
-"「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
+"在您的其他瀏覽器中造訪 Duck.ai 並開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Shared body copy for every screen in the Sync Another Device flow (QR display, camera scan, camera-unavailable fallback, manual entry). Bold tags wrap navigation breadcrumbs. Render with <Translate /> so the HTML is interpreted; plain `translate()` will trip the html-string warning.
@@ -23543,8 +23283,8 @@ msgid ""
 "ai Settings%s > %sSync & Backup%s > %sManage%s then select %sSync With "
 "Another Device%s."
 msgstr ""
-"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設"
-"定%2$s > %3$sSync & Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
+"請用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，並前往 %1$sDuck.ai 設定%2$s > %3$sSync & "
+"Backup%4$s > %5$s管理%6$s，再選取%7$s與其他裝置同步%8$s。"
 
 # smartling.placeholder_format=C
 #. Instructions for where to find the QR or recovery code. Figma frame 3705-32811.
@@ -23554,9 +23294,8 @@ msgid ""
 "Settings. Select “Turn On” under Sync & Backup and select “Sync With Another "
 "Device”. Or scan the QR on your Recovery PDF."
 msgstr ""
-"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在"
-"「Sync & Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 "
-"PDF 上的二維碼。"
+"使用其他瀏覽器或 DuckDuckGo 應用程式造訪 Duck.ai，然後開啟 Duck.ai 設定。在「Sync & "
+"Backup」下選取「開啟」，然後選取「與另一裝置同步」。或掃描您的恢復 PDF 上的二維碼。"
 
 # smartling.placeholder_format=C
 #. Step 2 label for export screens.
@@ -23757,9 +23496,7 @@ msgstr "在 Duck Player 中觀看"
 msgid ""
 "Watch in Duck Player to block personalized ads on YouTube and prevent your "
 "viewing activity from influencing YouTube recommendations."
-msgstr ""
-"在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推"
-"播干擾。"
+msgstr "在 Duck Player 中觀看，阻擋 YouTube 上的個人化廣告，避免觀看體驗受 YouTube 推播干擾。"
 
 # smartling.placeholder_format=C
 #. A button that takes a user to another site in order to watch a video. The placeholder is the name of the video site. For example: 'Watch on Vimeo'
@@ -23779,8 +23516,8 @@ msgid ""
 "independent company and has no relationship with YouTube, where most videos "
 "are hosted."
 msgstr ""
-"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內"
-"容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube 沒有任何關係。"
+"在此處觀看影片即代表託管影片的網站能夠追蹤您，因為我們必須從那邊串流傳輸內容。DuckDuckGo 是一間獨立公司，與託管大多數影片的 YouTube "
+"沒有任何關係。"
 
 # smartling.placeholder_format=C
 #. Heading for the highlight card explaining anonymized prompt delivery.
@@ -23803,9 +23540,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share this conversation with DuckDuckGo so we can investigate and "
 "address the issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo "
-"分享此對話，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與 DuckDuckGo 分享此對話，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Tooltip message prompting the user to share their prompt and response before they can submit a Harmful or Illegal feedback report.
@@ -23816,9 +23551,7 @@ msgid ""
 "We can only fix what we can see. To report a harmful or illegal response, "
 "please share your prompt and response so we can investigate and address the "
 "issue."
-msgstr ""
-"我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的"
-"提示詞與回覆內容，以便我們調查並處理該問題。"
+msgstr "我們必須先察覺問題，才能修正問題。若要檢舉有害或非法的回覆，請與我們分享您的提示詞與回覆內容，以便我們調查並處理該問題。"
 
 # smartling.placeholder_format=C
 #. Explains how location service is used to show users search results near their current location.
@@ -23858,8 +23591,7 @@ msgstr "我們不會儲存你的個人資訊。"
 msgid ""
 "We don't store your personal info. We don't follow you around with ads. We "
 "don't track you. Ever."
-msgstr ""
-"我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
+msgstr "我們不會儲存你的個人資訊。我們不會用廣告到處煩你。我們不會追蹤你。絕對不會。"
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23880,8 +23612,7 @@ msgctxt "new user poll"
 msgid ""
 "We don't track you, so we could use your help telling us what convinced you "
 "to try us out today:"
-msgstr ""
-"本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
+msgstr "本站不追蹤任何用戶，請告訴我們為何你願意試用我們的服務，以讓我們不斷完善："
 
 # smartling.placeholder_format=C
 msgctxt "reasons-to-use-duckduckgo"
@@ -23920,9 +23651,7 @@ msgctxt "homepage onboarding"
 msgid ""
 "We don’t store your search history. We therefore have nothing to sell to "
 "advertisers that track you across the Internet."
-msgstr ""
-"我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告"
-"商。"
+msgstr "我們不會儲存你的搜尋紀錄。因此，我們沒有東西能夠賣給網路上那些追蹤你的廣告商。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage onboarding"
@@ -23947,8 +23676,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We find and remove your personal info from data broker sites. Plus get a VPN "
 "and more."
-msgstr ""
-"我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
+msgstr "我們會從資料仲介網站中尋找並移除你的個人資訊。另外還能取得 VPN 等功能。"
 
 # smartling.placeholder_format=C
 #. Explains that agreements with AI providers prevent chats from being used for model training. Pairs with a flame pictogram.
@@ -23956,9 +23684,7 @@ msgctxt "Body copy for the no-AI-training card in the How Duck.ai Works panel"
 msgid ""
 "We have agreements with all AI providers to ensure your chats aren't used to "
 "train AIs."
-msgstr ""
-"我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智"
-"慧。"
+msgstr "我們與所有人工智慧提供者都簽訂了協議，以確保你的聊天記錄不會用於訓練人工智慧。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -23990,9 +23716,7 @@ msgctxt "precise_user_location"
 msgid ""
 "We only use your anonymous location to deliver better results, closer to "
 "you. You can always change your mind later."
-msgstr ""
-"我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主"
-"意。"
+msgstr "我們僅會將你的匿名位置用於提供更優質、離你更近的結果。你之後可以隨時改變主意。"
 
 # smartling.placeholder_format=C
 #. Body text of the Personal Information Removal instant answer shown on the search results page (US only). One of several messages rotated over time. 'Data broker sites' are companies that collect and sell personal information; the dashboard shows removal progress.
@@ -24000,9 +23724,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We regularly scan data broker sites for your personal info, and we share our "
 "progress with you in an easy-to-use dashboard."
-msgstr ""
-"我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我"
-"們的進度。"
+msgstr "我們會定期在資料仲介網站上掃描你的個人資訊，並在易於使用的儀表板中與你分享我們的進度。"
 
 # smartling.placeholder_format=C
 msgctxt "Feedback prompt"
@@ -24028,9 +23750,7 @@ msgid ""
 "We use feedback like this to improve DuckDuckGo. Suggestions will be "
 "incorporated at the discretion of %s. Corrections may not show up in results "
 "right away."
-msgstr ""
-"我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立"
-"刻出現。"
+msgstr "我們運用這樣的回饋來完善DuckDuckGo。%1$s將視情況採納建議。修改內容可能不會立刻出現。"
 
 # smartling.placeholder_format=C
 msgctxt "homepage ATB modal"
@@ -24043,9 +23763,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "We'll scan data broker sites for your email, name, address, and more, and "
 "work to get anything we find about you removed."
-msgstr ""
-"我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任"
-"何相關資訊移除。"
+msgstr "我們會針對你的電子郵件、姓名、地址等資訊掃描資料仲介網站，並努力將找到的你任何相關資訊移除。"
 
 # smartling.placeholder_format=C
 #. Inform the user we're still having errors and that we will investigate the issue. Placeholder is an email for folks to reach out to. For example 'If you continue to see this error, please reach out to ops@duckduckgo.com'
@@ -24204,9 +23922,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to Duck.ai! All of your chats here are private, anonymized by us and "
 "not used to train AI models."
-msgstr ""
-"歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會"
-"用來訓練人工智慧模型。"
+msgstr "歡迎來到 Duck.ai！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened.
@@ -24214,9 +23930,7 @@ msgctxt "Welcome message in chat"
 msgid ""
 "Welcome to DuckDuckGo AI Chat! All of your chats here are private, "
 "anonymized by us and not used to train AI models."
-msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名"
-"化，且不會用來訓練人工智慧模型。"
+msgstr "歡迎來到 DuckDuckGo AI Chat！您在這裡的所有聊天內容都是私密的，我們會將其匿名化，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Welcome message displayed when the chat is opened. Example: 'Welcome to DuckDuckGo AI Chat! This chat session is powered by OpenAI’s GPT-3. All of your chats here are private, and are never stored by DuckDuckGo or used to train AI models.'
@@ -24226,8 +23940,8 @@ msgid ""
 "of your chats here are private, and are never stored by DuckDuckGo or used "
 "to train AI models."
 msgstr ""
-"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這"
-"裡的所有聊天內容都是私密的，且永遠不會被 DuckDuckGo 儲存或用來訓練 AI 模型。"
+"歡迎來到 DuckDuckGo AI Chat！此聊天會話由 %1$s 的 %2$s 提供技術支援。 您在這裡的所有聊天內容都是私密的，且永遠不會被 "
+"DuckDuckGo 儲存或用來訓練 AI 模型。"
 
 # smartling.placeholder_format=C
 #. Intro message on import screen.
@@ -24359,9 +24073,8 @@ msgid ""
 "easy to understand for people with or without much AI, or technical, "
 "experience."
 msgstr ""
-"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 "
-"DuckDuckGo 來源。將回應分成清晰的部分，並以 Duck.ai 整合和隱私保護為重點。對"
-"於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
+"下載 DuckDuckGo 瀏覽器對於有興趣使用 Duck.ai 的人有哪些好處？僅參考官方 DuckDuckGo 來源。將回應分成清晰的部分，並以 "
+"Duck.ai 整合和隱私保護為重點。對於具有或沒有太多 AI 或技術經驗的人來說，保持內容相當簡短、簡單且易於理解。"
 
 # smartling.placeholder_format=C
 #. Page-suggestion chip label "What are the counterarguments?", shown on the current web page in the duck.ai sidebar. Tapping the chip sends a related prompt to the AI.
@@ -24896,9 +24609,7 @@ msgctxt "new tab page"
 msgid ""
 "With Duck.ai, your chats are anonymized and never used to train AI. Turn it "
 "on or off anytime in the '%s' menu."
-msgstr ""
-"使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時"
-"在「%1$s」選單中將其開啟或關閉。"
+msgstr "使用 Duck.ai，你的聊天內容都會經過匿名處理，且絕不會用於訓練 AI。 你可以隨時在「%1$s」選單中將其開啟或關閉。"
 
 # smartling.placeholder_format=C
 #. Supporting copy under the save-on-device headline when Sync & Backup is unavailable. %s is replaced with the chat limit. Example: 'With chat history on, up to 100 of your most recent chats will be saved on this device.'
@@ -24927,8 +24638,7 @@ msgctxt "DuckDuckGo Personal Information Removal instant answer"
 msgid ""
 "Works right from your device to remove your email, name, address, and more "
 "from data broker sites."
-msgstr ""
-"直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
+msgstr "直接在你的裝置上運作，從資料仲介網站中移除你的電子郵件、姓名、地址等資訊。"
 
 # smartling.placeholder_format=C
 #. Label for the global number of confirmed Covid 19 cases
@@ -25247,8 +24957,7 @@ msgstr "你最多可以附加 %1$s 個文字選擇。"
 msgid ""
 "You can change how frequently you see Search Assist, or turn it off "
 "entirely, in %sSearch Settings%s."
-msgstr ""
-"你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
+msgstr "你可以在 %1$s搜尋設定%2$s 中變更 Search Assist 的顯示頻率，或將其完全關閉。"
 
 # smartling.placeholder_format=C
 #. A label shown after the user enables the remember setting toggle that lets them know they change change it, and links to the appropriate setting
@@ -25268,8 +24977,7 @@ msgctxt "cloudsave"
 msgid ""
 "You can do this by saving your settings under a different passphrase, "
 "optionally deleting the first set."
-msgstr ""
-"你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
+msgstr "你可以將你的設定以另一通關密語儲存，你亦可同時刪除以舊通關密語儲存的設定。"
 
 # smartling.placeholder_format=C
 #. Prefix for filename location sentence.
@@ -25424,9 +25132,7 @@ msgctxt "Description of the post-upgrade success modal"
 msgid ""
 "You now have access to %s, higher AI reasoning, and 2x higher usage limits "
 "than Plus."
-msgstr ""
-"您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高"
-"出 2 倍的使用上限。"
+msgstr "您現在已獲得 %1$s 的存取權限，具備更高階的 AI 推理能力，並享有比 Plus 方案高出 2 倍的使用上限。"
 
 # smartling.placeholder_format=C
 #. Description text for the welcome modal displayed after the user subscribes to DuckDuckGo.
@@ -25434,9 +25140,7 @@ msgctxt "Description text for the subscription welcome modal"
 msgid ""
 "You now have access to advanced AI models. You can access the VPN and other "
 "DuckDuckGo subscription protections in the DuckDuckGo browser."
-msgstr ""
-"你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 "
-"DuckDuckGo 訂閱保護功能。"
+msgstr "你現在可以使用進階的 AI 模型。你可以在 DuckDuckGo 瀏覽器中存取 VPN 和其他 DuckDuckGo 訂閱保護功能。"
 
 # smartling.placeholder_format=C
 #. Welcome message that appears after the DuckDuckGo extension is installed.
@@ -25457,9 +25161,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Explains that turning off disconnects this browser only; the last 30 chats stay in local storage and the encrypted server backup is not deleted.
@@ -25468,9 +25170,7 @@ msgid ""
 "You will no longer be able to access your saved chats from this browser. The "
 "last 30 chats will still remain available in local storage. This will not "
 "delete your chats from the encrypted server."
-msgstr ""
-"您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地"
-"儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
+msgstr "您將無法再從此瀏覽器存取已儲存的聊天記錄。最近的 30 個聊天記錄仍將保留在本地儲存空間中。這不會刪除您在加密伺服器上的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Informational message letting the user know they won't see the message unless they clear their cookies or other browsing data
@@ -25497,9 +25197,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You're now searching privately in Chrome. Use our app instead of Chrome to "
 "browse privately too. It’s already installed and can:"
-msgstr ""
-"你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏"
-"覽。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在Chrome進行私密搜尋。不用Chrome，在我們的應用程式中也可以進行隱身瀏覽。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Confirmation message that appears after the DuckDuckGo browser extension is installed.
@@ -25586,9 +25284,7 @@ msgctxt "Sync file storage limit modal description"
 msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats with attachments. "
 "Delete the %s oldest chats to resume Sync. Pinned chats will not be deleted."
-msgstr ""
-"您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您 Duck.ai 聊天 (含附件) 的 Sync & Backup 儲存空間已用完。刪除 %1$s 則最舊的聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Description explaining that Sync & Backup storage for chats with attachments is full and deleting the oldest such chats will resume syncing. %s is replaced with the batch-size cap (currently 10). The dispatch deletes AT MOST this many unpinned chats with files; the placeholder value is the upper bound, not the exact count.
@@ -25597,9 +25293,7 @@ msgid ""
 "You've run out of Sync & Backup storage for Duck.ai chats. Delete the %s "
 "oldest chats with attachments to resume Sync. Pinned chats will not be "
 "deleted."
-msgstr ""
-"您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件"
-"聊天記錄以恢復同步。置頂聊天不會刪除。"
+msgstr "您已用完 Duck.ai 聊天記錄的 Sync & Backup 儲存空間。刪除 %1$s 則最舊的含附件聊天記錄以恢復同步。置頂聊天不會刪除。"
 
 # smartling.placeholder_format=C
 #. Title shown when user has reached the sync storage limit.
@@ -25612,9 +25306,7 @@ msgstr "你的儲存空間已用完"
 msgid ""
 "YouTube (owned by Google) does not let you watch videos anonymously. As "
 "such, watching YouTube videos here will be tracked by YouTube/Google."
-msgstr ""
-"YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/"
-"Google追蹤。"
+msgstr "YouTube(Google所擁有的公司)不允許匿名看影片。觀看YouTube影片還是會被Youtube/Google追蹤。"
 
 # smartling.placeholder_format=C
 #. Label for a privacy disclaimer related to YouTube videos
@@ -25682,9 +25374,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your %s most recent chats will be available in local "
 "storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 %1$s 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. Explains the consequence of deleting all server data; followed by the device list.
@@ -25693,9 +25383,7 @@ msgid ""
 "Your backup will be deleted from DuckDuckGo's server. All devices will be "
 "disconnected from sync. Your 100 most recent chats will be available in "
 "local storage on these browsers:"
-msgstr ""
-"您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器"
-"中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
+msgstr "您的備份將從 DuckDuckGo 的伺服器中刪除。所有裝置都將中斷同步。在以下瀏覽器中，您最近的 100 筆聊天記錄將保存在本機儲存空間中："
 
 # smartling.placeholder_format=C
 #. List item indicating that a site exclusion filter is currently active for the search
@@ -25759,16 +25447,14 @@ msgstr "您的聊天內容是私密的，且絕不會用於訓練 AI 模型"
 msgctxt "Active Privacy protection description"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text explaining that user chats are private and not used for AI (Artificial Intelligence) training.
 msgctxt "Body text for privacy protection modal"
 msgid ""
 "Your chats are private, anonymized by us, and not used to train AI models."
-msgstr ""
-"您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
+msgstr "您的聊天內容是私密的，我們會對其進行匿名處理，且不會用來訓練人工智慧模型。"
 
 # smartling.placeholder_format=C
 #. Text for a menu item that describes the privacy protection feature.
@@ -25796,9 +25482,7 @@ msgctxt "duckai_migration"
 msgid ""
 "Your chats are still private, anonymized by us, and not used to train AI "
 "models. Follow these steps to keep your chat history."
-msgstr ""
-"您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些"
-"步驟保留您的聊天記錄。"
+msgstr "您的聊天內容是私密的，我們會進行匿名處理，且不會用來訓練 AI 模型。請依照這些步驟保留您的聊天記錄。"
 
 # smartling.placeholder_format=C
 #. Body shown after import completes.
@@ -25837,8 +25521,7 @@ msgctxt "newsletter email collection"
 msgid ""
 "Your email address will not be shared, %sor associated with anonymous "
 "searches. [%sExample message%s]"
-msgstr ""
-"你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
+msgstr "你的電子信箱將不會被公開分享，%1$s或與匿名搜尋有任何關聯。[%2$s範例訊息%3$s]"
 
 # smartling.placeholder_format=C
 #. A prompt for the user to provide feedback on the third party map app directions experience
@@ -25880,10 +25563,7 @@ msgid ""
 "known as %sSHA-2%s. Only the key and associated settings file leave your "
 "browser. We save the settings file using the key as the name. DuckDuckGo "
 "never knows your passphrase."
-msgstr ""
-"我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。"
-"只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔"
-"案。DuckDuckGo不會知道你的通關密語。"
+msgstr "我們將使用%1$sSHA-2%2$s安全雜湊演算法，根據你的通關密語產生一組512位的金鑰。只有金鑰及其相關設定檔案會傳至你的瀏覽器之外。我們將以該金鑰為檔名儲存設定檔案。DuckDuckGo不會知道你的通關密語。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25897,9 +25577,7 @@ msgid ""
 "Your prompts are relayed through DuckDuckGo servers and stripped of "
 "personally identifiable metadata, so model providers can't tie your "
 "conversations back to you."
-msgstr ""
-"你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者"
-"無法將你的對話與你連結起來。"
+msgstr "你的提示會透過 DuckDuckGo 伺服器轉發，並移除個人識別的元資料，因此模型提供者無法將你的對話與你連結起來。"
 
 # smartling.placeholder_format=C
 #. Tagline for DuckDuckGo's values, emphasizing we protect users privacy as our top priority
@@ -25943,9 +25621,7 @@ msgctxt "settings"
 msgid ""
 "Your settings are saved, but clearing cookies will reset them. Enable the "
 "%sDuckDuckGo No AI%s extension to make it permanent."
-msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。"
+msgstr "你的設定已儲存，但清除 Cookie 將會重設這些設定。啟用 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。"
 
 # smartling.placeholder_format=C
 #. Message shown in a modal after users who already have the standard DuckDuckGo extension disable AI features in Settings, inviting them to install the No AI extension. The first two placeholders bold DuckDuckGo No AI. The last two placeholders wrap Learn More in a link to the noai help page.
@@ -25954,8 +25630,8 @@ msgid ""
 "Your settings are saved, but clearing cookies will reset them. Install the "
 "%sDuckDuckGo No AI%s extension to make it permanent. %sLearn More%s"
 msgstr ""
-"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No "
-"AI%2$s 擴充套件以使其永久生效。 %3$s瞭解更多%4$s"
+"你的設定已儲存，但清除 Cookie 將會重設這些設定。 安裝 %1$sDuckDuckGo No AI%2$s 擴充套件以使其永久生效。 "
+"%3$s瞭解更多%4$s"
 
 # smartling.placeholder_format=C
 #. Shown once the share link has been created. %s is a link that opens Duck.ai Settings, labeled Settings.
@@ -25982,9 +25658,7 @@ msgctxt "welcome message eu search preference android"
 msgid ""
 "You’re now searching privately in Chrome. Use our browser instead of Chrome "
 "for more protection. It’s already installed and can:"
-msgstr ""
-"你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得"
-"更全面的保護。應用程式已經安裝完畢，而且可以："
+msgstr "你目前正在 Chrome 使用隱私搜尋。使用我們的瀏覽器而非 Chrome，如此一來即可取得更全面的保護。應用程式已經安裝完畢，而且可以："
 
 # smartling.placeholder_format=C
 #. Displayed when the user has exceeded the maximum message size.
@@ -26000,8 +25674,7 @@ msgctxt "Error message for conversation limit"
 msgid ""
 "You’ve reached the maximum chat length in this conversation. Clear this "
 "conversation with the Fire Button to continue."
-msgstr ""
-"您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
+msgstr "您已達到此對話的最長聊天長度。 使用「Fire Button」按鈕清除此對話以繼續。"
 
 # smartling.placeholder_format=C
 #. Displayed when the user has reached the maximum chat length in a conversation.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to gettext template and locale files with no application logic or secrets in the diff.
> 
> **Overview**
> Syncs the translation catalog with newly imported tokens for **Duck.ai image-generation feedback** and related UI copy.
> 
> The POT and locale `.po` files gain strings for **image-turn thumbs up/down reason chips** (e.g. image quality, visual style, instruction-following, generation speed) that replace the text-response chips when a rated turn has a settled generated image. A **variant of the anonymous feedback disclaimer** explains that uploaded files and generated images are removed before the report is stored, used instead of the text-only disclaimer on image turns.
> 
> Locales also get a separate **“Try for Free”** entry with its own `msgctxt` for the subscription free-trial button (Duck.ai subscribe/limit modals, Settings → Subscription), distinct from other “Try for Free” CTAs. Fully translated locales (e.g. `af_ZA`, `be_BY`, `bg_BG`, `cs_CZ`) include `msgstr` values; many others add empty placeholders for translators. `af_ZA` includes minor fixes unrelated to the new tokens (`Complete`, `Shots`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b281fd4244078477d478943233af64f11da2f125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->